### PR TITLE
Add Teams sales page

### DIFF
--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -69,14 +69,11 @@ const TIER = {
   period: "/ year",
   features: [
     "Team leader dashboard on runladder.com",
-    "Add and manage designers",
+    "Add and manage up to ten designers",
     "Team knowledge base (brand standards + leadership lens)",
-    "Design system spec ingestion",
-    "Custom rubric weights",
     "Per-designer scores, trends, and leaderboard",
     "Design system compliance scoring",
     "Unlimited scores on all surfaces (web, Figma, Claude)",
-    "Shareable score cards and reports",
     "Priority support",
   ],
 };
@@ -316,8 +313,6 @@ export default function TeamsPage() {
                   "Ladder score with coaching cards",
                   "Per-dimension scoring breakdown",
                   "Full score history + trend line",
-                  "Design system compliance scoring",
-                  "Shareable score cards and reports",
                   "Web, Figma, and Claude access",
                 ].map((f: string) => (
                   <li


### PR DESCRIPTION
## Summary
- New `/teams` route — sales page for design team leaders
- Capabilities: dashboard, brand standards, leadership lens, DS compliance, custom weights, designer management
- Before/after comparison showing what changes on day one
- Pricing: Teams ($8K/yr, 10 designers), Teams Pro ($18K/yr, 25 designers), Enterprise (custom)
- Follows existing site patterns (Inter font, dark theme, section rhythm)

## Purpose
Shareable URL for Ward to float at design leaders during sales conversations.

## Test plan
- [ ] Visit /teams and verify dark theme renders correctly
- [ ] Check all links point to /contact and /framework correctly
- [ ] Verify responsive layout on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)