### PR TITLE
Update Top 100 hero to center Pulse intelligence

### DIFF
--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -81,7 +81,7 @@ The gap is where the real story lives. Explore all 36 products and their Pulse s
 
 **Ladder mapping:** Our AI — trained on 20 years of experience evaluation at Drawbackwards — analyzes sentiment, identifies friction patterns, and maps the quality of the described experience to Ladder's 1.0-5.0 scale. Not just positive or negative. Five distinct levels of experience quality.
 
-**Continuous scoring:** Pulse scores update as new signal flows in. Both scores in this study will be updated quarterly. The Top 100 is a living dataset.
+**Continuous scoring:** Pulse scores update as new signal flows in. Both scores in this study will be updated monthly. The Top 100 is a living dataset.
 
 Want to see what Pulse reveals about your product or organization? Request a Pulse demo and see your real score from the people who use what you build.`,
   },

--- a/src/app/top-100/page.tsx
+++ b/src/app/top-100/page.tsx
@@ -65,7 +65,7 @@ export default function Top100Page() {
             system can. No sponsorships. No paid placements. Just the truth.
           </p>
           <p className="text-xs text-muted mt-4">
-            {PRODUCTS.length} products scored &middot; Updated quarterly
+            {PRODUCTS.length} products scored &middot; Updated monthly
           </p>
         </div>
 
@@ -213,7 +213,7 @@ export default function Top100Page() {
         {/* ── "More coming" ── */}
         <div className="text-center py-12 border-b border-border">
           <p className="text-sm text-muted">
-            {PRODUCTS.length} of 100 scored by Pulse &middot; New products added quarterly
+            {PRODUCTS.length} of 100 scored by Pulse &middot; New products added monthly
           </p>
         </div>
 
@@ -281,7 +281,7 @@ export default function Top100Page() {
             },
             {
               title: "Updated quarterly",
-              body: "Pulse re-scores every product each quarter as new data flows in. Scores go up and down. The delta column shows real movement.",
+              body: "Pulse re-scores every product each month as new data flows in. Scores go up and down. The delta column shows real movement.",
             },
             {
               title: "The gap is the story",


### PR DESCRIPTION
## Summary
- **Hero rewritten**: "The definitive ranking of digital experience quality" — describes Pulse scanning thousands of sources to produce scores no other system can
- **Removed outdated disclaimer** about "editorial estimates" and "scoring pipeline coming Q2 2026"
- **Methodology section** reframed: "Pulse Intelligence" is now the lead card, describing data ingestion and AI mapping
- **All copy** updated to reference Pulse by name: "Rankings determined by Pulse," "Pulse re-scores every quarter," "Pulse finds both"
- **"More coming" footer** updated from "Full list coming Q2" to "New products added quarterly"

## Test plan
- [ ] Visit /top-100 — hero copy reflects Pulse intelligence, no outdated disclaimers
- [ ] Methodology section reads Pulse-first
- [ ] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)