### PR TITLE
Add hyperlinks throughout blog posts

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -76,7 +76,11 @@ function renderContent(content: string) {
               /\*\*(.+?)\*\*/g,
               '<strong class="text-foreground font-semibold">$1</strong>'
             )
-            .replace(/\*(.+?)\*/g, "<em>$1</em>"),
+            .replace(/\*(.+?)\*/g, "<em>$1</em>")
+            .replace(
+              /\[(.+?)\]\((.+?)\)/g,
+              '<a href="$2" class="text-ladder-green hover:text-ladder-green/80 transition-colors">$1</a>'
+            ),
         }}
       />
     );

--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -23,9 +23,9 @@ export const BLOG_POSTS: BlogPost[] = [
     excerpt:
       "Pulse analyzed 42,000+ data points across Airbnb and scored the lived experience at 2.3, while the interface scores 3.7. That 1.4-point gap isn't a rounding error. It's exactly the kind of hidden truth Pulse was built to find.",
     products: ["notion", "airbnb", "arc", "apple-music", "raycast", "linear"],
-    content: `We built Ladder Pulse to answer a question most product teams avoid: does your product actually feel as good as it looks?
+    content: `We built [Ladder Pulse](/pulse) to answer a question most product teams avoid: does your product actually feel as good as it looks?
 
-Pulse is Ladder's proprietary experience intelligence engine. It ingests real customer sentiment from across the internet (G2, Reddit, the App Store, Hacker News, Trustpilot, Product Hunt, Capterra, and community forums) and runs it through the Ladder framework to produce a single, honest score: the Pulse Score.
+Pulse is Ladder's proprietary experience intelligence engine. It ingests real customer sentiment from across the internet (G2, Reddit, the App Store, Hacker News, Trustpilot, Product Hunt, Capterra, and community forums) and runs it through the [Ladder framework](/framework) to produce a single, honest score: the Pulse Score.
 
 To put Pulse to the test, we pointed it at 36 of the most-used digital products in the world. We scored each one twice. Once on the interface: the screens, the visual design, the information architecture. And once through Pulse, analyzing what thousands of real users actually say about the lived experience.
 
@@ -33,19 +33,19 @@ The gap between those two numbers is the most honest thing we've ever measured.
 
 ## What Pulse found: the biggest gaps
 
-**Airbnb: Screen 3.7, Pulse 2.3 (gap: -1.4)**
+**[Airbnb](/top-100/airbnb): Screen 3.7, Pulse 2.3 (gap: -1.4)**
 
-Pulse ingested 42,000+ data points from Trustpilot, the App Store, Reddit, and travel forums. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." Pulse says "surprise costs." See how Airbnb's full score breaks down on the Top 100.
+Pulse ingested 42,000+ data points from Trustpilot, the App Store, Reddit, and travel forums. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." Pulse says "surprise costs." [See how Airbnb's full score breaks down on the Top 100.](/top-100/airbnb)
 
-**Notion: Screen 4.1, Pulse 2.8 (gap: -1.3)**
+**[Notion](/top-100/notion): Screen 4.1, Pulse 2.8 (gap: -1.3)**
 
-Pulse analyzed 4,100+ reviews from G2, Reddit, and Hacker News. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. See Notion's full Pulse breakdown.
+Pulse analyzed 4,100+ reviews from G2, Reddit, and Hacker News. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. [See Notion's full Pulse breakdown.](/top-100/notion)
 
-**Arc Browser: Screen 3.8, Pulse 2.6 (gap: -1.2)**
+**[Arc Browser](/top-100/arc): Screen 3.8, Pulse 2.6 (gap: -1.2)**
 
 Pulse processed 1,800+ data points and surfaced a consistent theme: innovative sidebar navigation is undermined by stability issues, high memory consumption, and a learning curve that punishes people who just want to browse the web. Innovation without reliability is a demo, not a product.
 
-**Apple Music: Screen 3.6, Pulse 2.4 (gap: -1.2)**
+**[Apple Music](/top-100/apple-music): Screen 3.6, Pulse 2.4 (gap: -1.2)**
 
 Pulse analyzed 8,500+ reviews, primarily from the App Store where users average 2.4 out of 5 stars. Users consistently describe library management issues, inconsistent navigation, and discovery algorithms that trail Spotify by miles. Beautiful surfaces don't compensate for friction in daily tasks.
 
@@ -53,15 +53,15 @@ Pulse analyzed 8,500+ reviews, primarily from the App Store where users average 
 
 Not every gap goes the wrong direction. Pulse identified products where the lived experience actually outperforms the interface.
 
-**Raycast: Screen 3.8, Pulse 4.2 (gap: +0.4)**
+**[Raycast](/top-100/raycast): Screen 3.8, Pulse 4.2 (gap: +0.4)**
 
-Pulse analyzed 1,500+ data points and found something remarkable: users rate this product higher than its interface suggests. The UI is minimal: a command bar and extensions. It doesn't photograph well. But Pulse surfaced language usually reserved for products people can't live without: "replaced five apps," "fastest tool I've ever used." When speed is the design, screenshots undersell it. Explore Raycast's score on the Top 100.
+Pulse analyzed 1,500+ data points and found something remarkable: users rate this product higher than its interface suggests. The UI is minimal: a command bar and extensions. It doesn't photograph well. But Pulse surfaced language usually reserved for products people can't live without: "replaced five apps," "fastest tool I've ever used." When speed is the design, screenshots undersell it. [Explore Raycast's score on the Top 100.](/top-100/raycast)
 
-**Linear: Screen 4.3, Pulse 4.2 (gap: -0.1)**
+**[Linear](/top-100/linear): Screen 4.3, Pulse 4.2 (gap: -0.1)**
 
-Across 3,200+ data points, Pulse found a gap of just 0.1. That near-zero delta means the product is honest. The interface promises speed; the experience delivers speed. There's no marketing layer hiding a different reality underneath. See why Linear leads the entire Top 100.
+Across 3,200+ data points, Pulse found a gap of just 0.1. That near-zero delta means the product is honest. The interface promises speed; the experience delivers speed. There's no marketing layer hiding a different reality underneath. [See why Linear leads the entire Top 100.](/top-100/linear)
 
-**Superhuman: Screen 3.8, Pulse 3.8 (gap: 0.0)**
+**[Superhuman](/top-100/superhuman): Screen 3.8, Pulse 3.8 (gap: 0.0)**
 
 Pulse identified zero gap. The email client that charges $30/month looks like a $30/month email client and feels like one too. No bait-and-switch.
 
@@ -73,7 +73,7 @@ This is exactly what Pulse was designed to reveal. Traditional metrics like NPS 
 
 A beautiful interface with a low Pulse score is a warning: this team invests in appearance over substance. An unremarkable interface with a high Pulse score is an opportunity: this team builds things that work, and hasn't yet invested in making them look as good as they feel.
 
-The gap is where the real story lives. Explore all 36 products and their Pulse scores on the Ladder Top 100.
+The gap is where the real story lives. [Explore all 36 products and their Pulse scores on the Ladder Top 100.](/top-100)
 
 ## How Pulse works
 
@@ -81,9 +81,9 @@ The gap is where the real story lives. Explore all 36 products and their Pulse s
 
 **Ladder mapping:** Our AI, trained on 20 years of experience evaluation at Drawbackwards, analyzes sentiment, identifies friction patterns, and maps the quality of the described experience to Ladder's 1.0-5.0 scale. Not just positive or negative. Five distinct levels of experience quality.
 
-**Continuous scoring:** Pulse scores update as new signal flows in. Both scores in this study will be updated monthly. The Top 100 is a living dataset.
+**Continuous scoring:** Pulse scores update as new signal flows in. Both scores in this study will be updated monthly. The [Top 100](/top-100) is a living dataset.
 
-Want to see what Pulse reveals about your product or organization? Request a Pulse demo and see your real score from the people who use what you build.`,
+Want to see what Pulse reveals about your product or organization? [Request a Pulse demo](/contact) and see your real score from the people who use what you build.`,
   },
   {
     slug: "why-linear-is-number-one",
@@ -96,15 +96,15 @@ Want to see what Pulse reveals about your product or organization? Request a Pul
     excerpt:
       "Pulse scored Linear's lived experience at 4.2, within 0.1 of its screen score. That's the smallest gap in our dataset. Here's what Pulse found inside 3,200+ reviews, forum posts, and community discussions.",
     products: ["linear", "jira", "notion"],
-    content: `Linear sits at #1 on the Ladder Top 100 with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when Pulse analyzed 3,200+ data points from G2, Reddit, developer forums, and community discussions, it found something rare: the experience matches the interface almost exactly.
+    content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when [Pulse](/pulse) analyzed 3,200+ data points from G2, Reddit, developer forums, and community discussions, it found something rare: the experience matches the interface almost exactly.
 
 ## What Pulse found
 
 Linear's Screen Score is 4.3. Its Pulse Score (the number our intelligence engine produces after ingesting and analyzing thousands of real user signals) is 4.2. That 0.1-point gap is the smallest in our entire dataset.
 
-For context: Pulse measured Notion's gap at -1.3. Airbnb's at -1.4. The average gap across all 36 products is -0.6.
+For context: Pulse measured [Notion's](/top-100/notion) gap at -1.3. [Airbnb's](/top-100/airbnb) at -1.4. The average gap across all 36 products is -0.6.
 
-A near-zero gap means the product is honest. Pulse couldn't find a meaningful difference between what Linear promises and what Linear delivers. That's the signal that separates a good-looking product from a genuinely great one. See Linear's full score profile on the Top 100.
+A near-zero gap means the product is honest. Pulse couldn't find a meaningful difference between what Linear promises and what Linear delivers. That's the signal that separates a good-looking product from a genuinely great one. [See Linear's full score profile on the Top 100.](/top-100/linear)
 
 ## What Pulse identified as strengths
 
@@ -122,7 +122,7 @@ The mobile experience trails the desktop product significantly. Pulse found that
 
 ## The Jira comparison: what Pulse reveals
 
-Jira scores 2.1 on Ladder. Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, Hacker News, and developer sentiment platforms, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. See Jira's full Pulse score on the Top 100.
+[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, Hacker News, and developer sentiment platforms, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse score on the Top 100.](/top-100/jira)
 
 The comparison is instructive: Jira was built to serve methodologies (Scrum, Kanban, SAFe). Linear was built to serve humans. Pulse can measure the difference. Products designed for process consistently score lower on lived experience because humans aren't processes.
 
@@ -132,7 +132,7 @@ The best products aren't the ones with the most features or the most beautiful i
 
 Linear's lesson: make fewer promises and keep all of them. Pulse will know the difference.
 
-Explore the full Ladder Top 100 to see how every product compares. And if you want to know what Pulse would reveal about your own product or organization, request a demo. We'll show you your real score from the people who use what you build.`,
+[Explore the full Ladder Top 100](/top-100) to see how every product compares. And if you want to know what Pulse would reveal about your own product or organization, [request a demo](/contact). We'll show you your real score from the people who use what you build.`,
   },
   {
     slug: "notion-the-4-1-product-with-a-2-8-reality",
@@ -144,13 +144,13 @@ Explore the full Ladder Top 100 to see how every product compares. And if you wa
     excerpt:
       "Notion's interface scores 4.1. When Pulse ingested 4,100+ real user signals from G2, Reddit, and Hacker News, it scored the lived experience at 2.8. The gap reveals a product that's better at promising than delivering.",
     products: ["notion", "linear", "airtable"],
-    content: `Notion's interface is genuinely impressive. The block-based editor is flexible, the database views are powerful, and the visual design is clean and confident. It scores 4.1 on screen quality, putting it in Delightful territory.
+    content: `[Notion's](/top-100/notion) interface is genuinely impressive. The block-based editor is flexible, the database views are powerful, and the visual design is clean and confident. It scores 4.1 on screen quality, putting it in Delightful territory.
 
-Then we pointed Pulse at it.
+Then we pointed [Pulse](/pulse) at it.
 
 ## What 4,100+ data points told Pulse
 
-Pulse ingested reviews from G2, threads from Reddit and Hacker News, App Store ratings, and community forum discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the Ladder framework.
+Pulse ingested reviews from G2, threads from Reddit and Hacker News, App Store ratings, and community forum discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
 The result: a Pulse Score of 2.8. Upper Usable. A -1.3 gap from the screen score.
 
@@ -160,7 +160,7 @@ Here's what Pulse surfaced as the dominant themes:
 
 **The blank page problem.** Pulse detected strong negative sentiment around onboarding and first-use experience. New users face an empty workspace and a block menu with 50+ options. The same flexibility that makes power users love Notion makes new users freeze. Pulse scored this as a Usable-level experience: the task can be completed, but with effort.
 
-**Search.** For a product that positions itself as your team's knowledge base, Pulse found search-related complaints across every data source. Users report difficulty finding documents they wrote last week. In a tool where you're supposed to put everything, not being able to find anything is what Pulse identifies as a critical experience failure. See Notion's full score on the Top 100.
+**Search.** For a product that positions itself as your team's knowledge base, Pulse found search-related complaints across every data source. Users report difficulty finding documents they wrote last week. In a tool where you're supposed to put everything, not being able to find anything is what Pulse identifies as a critical experience failure. [See Notion's full score on the Top 100.](/top-100/notion)
 
 ## The flexibility trap, as Pulse sees it
 
@@ -180,9 +180,9 @@ The -1.3 delta isn't just a number. It's Pulse translating thousands of user voi
 
 ## The comparison
 
-Pulse scored Linear's gap at -0.1. Notion's at -1.3. Both are well-designed products. The difference: Linear chose speed and constraints. Notion chose flexibility and power. Pulse's data suggests users value the former more than the latter.
+Pulse scored [Linear's](/top-100/linear) gap at -0.1. Notion's at -1.3. Both are well-designed products. The difference: Linear chose speed and constraints. Notion chose flexibility and power. Pulse's data suggests users value the former more than the latter.
 
-This is what Pulse does. It takes the noise of thousands of reviews and turns it into a signal you can act on. Explore how Notion compares against every product on the Ladder Top 100, and if you want Pulse to analyze the experience your product or organization delivers, request a demo.`,
+This is what Pulse does. It takes the noise of thousands of reviews and turns it into a signal you can act on. [Explore how Notion compares against every product on the Ladder Top 100](/top-100), and if you want Pulse to analyze the experience your product or organization delivers, [request a demo](/contact).`,
   },
   {
     slug: "the-enterprise-ux-crisis",
@@ -194,15 +194,15 @@ This is what Pulse does. It takes the noise of thousands of reviews and turns it
     excerpt:
       "Pulse scored the three most-used enterprise products in the world: Jira (2.1), Salesforce (2.2), Workday (1.4). Over 114,000 data points from G2, Reddit, Trustpilot, and employee forums reveal an experience crisis hiding in plain sight.",
     products: ["jira", "salesforce", "workday"],
-    content: `We pointed Pulse at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Pulse ingested over 114,000 data points from G2, Capterra, Reddit, Hacker News, Trustpilot, Atlassian community forums, Quora, Glassdoor, and employee sentiment platforms.
+    content: `We pointed [Pulse](/pulse) at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Pulse ingested over 114,000 data points from G2, Capterra, Reddit, Hacker News, Trustpilot, Atlassian community forums, Quora, Glassdoor, and employee sentiment platforms.
 
 The results:
 
-- **Jira**: Pulse Score 2.1 (Usable), 15,000+ data points
-- **Salesforce**: Pulse Score 2.2 (Usable), 94,000+ data points
-- **Workday**: Pulse Score 1.4 (Functional), 5,000+ data points
+- **[Jira](/top-100/jira)**: Pulse Score 2.1 (Usable), 15,000+ data points
+- **[Salesforce](/top-100/salesforce)**: Pulse Score 2.2 (Usable), 94,000+ data points
+- **[Workday](/top-100/workday)**: Pulse Score 1.4 (Functional), 5,000+ data points
 
-These aren't obscure tools. They're the products that define enterprise software. And Pulse scored them lower than almost everything else in the Top 100. See all three scores on the Ladder Top 100.
+These aren't obscure tools. They're the products that define enterprise software. And Pulse scored them lower than almost everything else in the [Top 100](/top-100). [See all three scores on the Ladder Top 100.](/top-100)
 
 ## What Pulse reveals: the buying problem
 
@@ -216,9 +216,9 @@ Pulse can measure the cost of that disconnect. Here's what it found.
 
 Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, and Hacker News. The intelligence was clear: Jira's G2 score of 4.3/5 reflects buyer satisfaction. Pulse's 2.1 reflects user experience.
 
-The dominant signal: every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Pulse detected overwhelming negative sentiment around the 2025 navigation redesign, which users described as making an already complex product worse. See Jira's full Pulse analysis on the Top 100.
+The dominant signal: every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Pulse detected overwhelming negative sentiment around the 2025 navigation redesign, which users described as making an already complex product worse. [See Jira's full Pulse analysis on the Top 100.](/top-100/jira)
 
-For context: Linear does much less and Pulse scores it at 4.2. The features Jira has that Linear doesn't? Pulse found that most users don't need them.
+For context: [Linear](/top-100/linear) does much less and Pulse scores it at 4.2. The features Jira has that Linear doesn't? Pulse found that most users don't need them.
 
 ## Salesforce: Pulse Score 2.2
 
@@ -226,13 +226,13 @@ Pulse processed 94,000+ data points, the largest dataset of any product in the T
 
 What Pulse found: a massive gap between capability and experience. Salesforce can do almost anything. But Pulse identified that end users (the sales reps and support agents who click through it 8 hours a day) generate overwhelmingly negative experience signals. The Lightning redesign improved surface aesthetics but didn't address the labyrinthine navigation and inconsistent patterns across modules that Pulse flagged as structural issues.
 
-The most common sentiment Pulse extracted: "It's the industry standard, so we use it." That's not a product endorsement. It's a resignation. Explore Salesforce's full score.
+The most common sentiment Pulse extracted: "It's the industry standard, so we use it." That's not a product endorsement. It's a resignation. [Explore Salesforce's full score.](/top-100/salesforce)
 
 ## Workday: Pulse Score 1.4
 
 Pulse scored Workday the lowest of any product in the entire Top 100. Across 5,000+ data points from G2, Trustpilot, Reddit, Glassdoor, and employee forums, Pulse identified a product in the Functional tier, meaning users fight it to complete basic tasks.
 
-The most striking signal: Pulse found that even simple actions like submitting time off, checking a pay stub, or updating personal information generate measurably negative sentiment. The interface feels dated. Navigation requires memorizing paths rather than following intuition. And the job applicant experience, which touches millions of people, is what Pulse classifies as a UX crisis. See Workday's full score.
+The most striking signal: Pulse found that even simple actions like submitting time off, checking a pay stub, or updating personal information generate measurably negative sentiment. The interface feels dated. Navigation requires memorizing paths rather than following intuition. And the job applicant experience, which touches millions of people, is what Pulse classifies as a UX crisis. [See Workday's full score.](/top-100/workday)
 
 ## What Pulse proves about enterprise software
 
@@ -240,11 +240,11 @@ This is exactly the problem Pulse was built to solve. Traditional review platfor
 
 The enterprise UX crisis isn't about technology. It's about incentives. When the buyer isn't the user, the user's experience becomes secondary. Pulse makes that gap visible. And measurable. And impossible to ignore.
 
-But the pressure is building. Pulse scores prove that tools like Linear (4.2), Mercury (3.2), and Figma (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
+But the pressure is building. Pulse scores prove that tools like [Linear](/top-100/linear) (4.2), [Mercury](/top-100/mercury) (3.2), and [Figma](/top-100/figma) (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
 
-The scores won't lie. Pulse will make sure of it. Explore the full Ladder Top 100 and see where every product stands.
+The scores won't lie. Pulse will make sure of it. [Explore the full Ladder Top 100](/top-100) and see where every product stands.
 
-If your organization relies on enterprise tools and wants to measure the real experience your people have (not what the vendor says, but what your users feel), Pulse can do for your internal tools what we just did for these 36 products. Request a Pulse demo.`,
+If your organization relies on enterprise tools and wants to measure the real experience your people have (not what the vendor says, but what your users feel), Pulse can do for your internal tools what we just did for these 36 products. [Request a Pulse demo.](/contact)`,
   },
   {
     slug: "airbnb-the-most-beautiful-2-3",
@@ -256,13 +256,13 @@ If your organization relies on enterprise tools and wants to measure the real ex
     excerpt:
       "Airbnb's interface scores 3.7: emotional design, beautiful photography, discovery that feels like exploring. Pulse analyzed 42,000+ real user signals and scored the lived experience at 2.3. The gap is about trust.",
     products: ["airbnb", "shopify"],
-    content: `Airbnb wrote the playbook on emotional design. The listing photography, the map integration, the category browsing (OMG!, Icons, Treehouses). Every pixel is engineered to make you feel something. It works. The screen score is 3.7.
+    content: `[Airbnb](/top-100/airbnb) wrote the playbook on emotional design. The listing photography, the map integration, the category browsing (OMG!, Icons, Treehouses). Every pixel is engineered to make you feel something. It works. The screen score is 3.7.
 
-Then we ran it through Pulse.
+Then we ran it through [Pulse](/pulse).
 
 ## What Pulse found across 42,000+ signals
 
-Pulse ingested data from Trustpilot, the App Store, Google Play, Reddit, and travel community forums, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the Ladder framework.
+Pulse ingested data from Trustpilot, the App Store, Google Play, Reddit, and travel community forums, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
 The Pulse Score: 2.3. Usable. A -1.4 gap from the screen, one of the largest in the entire Top 100.
 
@@ -274,7 +274,7 @@ Here's what Pulse surfaced as the three dominant signals:
 
 **Review system erosion.** Pulse surfaced growing distrust in Airbnb's review system. The reciprocal review structure creates social pressure that inflates ratings. Users increasingly describe reviews as unreliable. Pulse flagged this as a platform credibility issue that compounds over time.
 
-See Airbnb's full score breakdown on the Top 100.
+[See Airbnb's full score breakdown on the Top 100.](/top-100/airbnb)
 
 ## The emotional design paradox, quantified by Pulse
 
@@ -290,7 +290,7 @@ The fix isn't more emotional design. It's transparent pricing, a host experience
 
 Pulse found the gap. It's -1.4 points wide. That's the distance between how Airbnb looks and how Airbnb feels.
 
-This is what Pulse does: it ingests the signal your customers are already broadcasting and translates it into a score you can act on. Explore the full Ladder Top 100 to see how every product compares, or request a Pulse demo to see what your customers are really saying about you.`,
+This is what Pulse does: it ingests the signal your customers are already broadcasting and translates it into a score you can act on. [Explore the full Ladder Top 100](/top-100) to see how every product compares, or [request a Pulse demo](/contact) to see what your customers are really saying about you.`,
   },
   {
     slug: "what-a-3-0-actually-means",
@@ -302,9 +302,9 @@ This is what Pulse does: it ingests the signal your customers are already broadc
     excerpt:
       "On the Ladder scale, 3.0 is 'Comfortable': the point where a product stops making you think. When Pulse scored 36 of the most-used digital products, only 15 cleared this bar.",
     products: [],
-    content: `The Ladder framework scores products from 1.0 to 5.0. Most people focus on the high scores: what does a 4.0 look like? What earns a 5.0?
+    content: `The [Ladder framework](/framework) scores products from 1.0 to 5.0. Most people focus on the high scores: what does a 4.0 look like? What earns a 5.0?
 
-The more important question, and the one Pulse answers with data, is: what does a 3.0 mean?
+The more important question, and the one [Pulse](/pulse) answers with data, is: what does a 3.0 mean?
 
 ## The Comfortable threshold
 
@@ -323,7 +323,7 @@ When we pointed Pulse at 36 of the most prominent digital products in the world,
 
 That means 21 of the most-used digital products in the world still make their users think more than they should.
 
-The products Pulse scored below 3.0 include names you'd expect (Jira at 2.1, Salesforce at 2.2, Workday at 1.4) and names you might not (Shopify at 2.9, Airtable at 2.7, ChatGPT at 2.8, Coinbase at 2.7). See the full rankings on the Ladder Top 100.
+The products Pulse scored below 3.0 include names you'd expect ([Jira](/top-100/jira) at 2.1, [Salesforce](/top-100/salesforce) at 2.2, [Workday](/top-100/workday) at 1.4) and names you might not ([Shopify](/top-100/shopify) at 2.9, [Airtable](/top-100/airtable) at 2.7, [ChatGPT](/top-100/chatgpt) at 2.8, [Coinbase](/top-100/coinbase) at 2.7). [See the full rankings on the Ladder Top 100.](/top-100)
 
 ## Why 3.0 is the bar
 
@@ -355,7 +355,7 @@ The path from 2.0 to 3.0 isn't about adding features. Pulse data across all 36 p
 
 3.0 isn't ambitious. It's table stakes. And Pulse proves that most of the software world hasn't earned it yet.
 
-Want to know where your product really stands? Explore the full Top 100 to see how the world's best products score, or get your own Pulse Score. Request a demo and we'll show you what your users are really saying.`,
+Want to know where your product really stands? [Explore the full Top 100](/top-100) to see how the world's best products score, or get your own Pulse Score. [Request a demo](/contact) and we'll show you what your users are really saying.`,
   },
 ];
 


### PR DESCRIPTION
## Summary
- Added markdown link rendering to the blog template (`[text](url)` → clickable green links)
- Hyperlinked all product names to their `/top-100/{slug}` profiles on first mention in each post
- Linked all "Top 100" references to `/top-100`
- Linked "Pulse" to `/pulse` on first mention per post
- Linked "Ladder framework" to `/framework` where referenced
- Linked all CTAs ("request a demo", "explore the Top 100") to their destination pages

## Test plan
- [x] `npx next build` passes
- [ ] Verify links render as green text on blog post pages
- [ ] Confirm product profile links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)