### PR TITLE
Differentiate Screen Score vs. Pulse Score site-wide

### DIFF
--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -71,9 +71,9 @@ The Screen-to-Pulse delta isn't a quality score. It's a trust score. Products wi
 
 This is exactly what Pulse was designed to reveal. Traditional metrics like NPS or CSAT give you a single sentiment number. Pulse maps customer voice data against the five levels of the Ladder framework and tells you not just *how* people feel, but *why*, and what to fix first.
 
-A beautiful interface with a low Pulse score is a warning: this team invests in appearance over substance. An unremarkable interface with a high Pulse score is an opportunity: this team builds things that work, and hasn't yet invested in making them look as good as they feel.
+A beautiful interface with a low Pulse Score is a warning: this team invests in appearance over substance. An unremarkable interface with a high Pulse Score is an opportunity: this team builds things that work, and hasn't yet invested in making them look as good as they feel.
 
-The gap is where the real story lives. [Explore all 36 products and their Pulse scores on the Ladder Top 100.](/top-100)
+The gap is where the real story lives. [Explore all 36 products and their Pulse Scores on the Ladder Top 100.](/top-100)
 
 ## How Pulse works
 
@@ -81,7 +81,7 @@ The gap is where the real story lives. [Explore all 36 products and their Pulse 
 
 **Ladder mapping:** Our AI, trained on 20 years of experience evaluation at Drawbackwards, analyzes sentiment, identifies friction patterns, and maps the quality of the described experience to Ladder's 1.0-5.0 scale. Not just positive or negative. Five distinct levels of experience quality.
 
-**Continuous scoring:** Pulse scores update as new signal flows in. Both scores in this study will be updated monthly. The [Top 100](/top-100) is a living dataset.
+**Continuous scoring:** Pulse Scores update as new signal flows in. Both scores in this study will be updated monthly. The [Top 100](/top-100) is a living dataset.
 
 Want to see what Pulse reveals about your product or organization? [Request a Pulse demo](/contact) and see your real score from the people who use what you build.`,
   },
@@ -94,7 +94,7 @@ Want to see what Pulse reveals about your product or organization? [Request a Pu
     category: "Pulse Teardown",
     featured: true,
     excerpt:
-      "Pulse scored Linear's lived experience at 4.2, within 0.1 of its screen score. That's the smallest gap in our dataset. Here's what Pulse found inside 3,200+ reviews, forum posts, and community discussions.",
+      "Pulse scored Linear's lived experience at 4.2, within 0.1 of its Screen Score. That's the smallest gap in our dataset. Here's what Pulse found inside 3,200+ reviews, forum posts, and community discussions.",
     products: ["linear", "jira", "notion"],
     content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when [Pulse](/pulse) analyzed 3,200+ data points from G2, Reddit, developer forums, and community discussions, it found something rare: the experience matches the interface almost exactly.
 
@@ -122,7 +122,7 @@ The mobile experience trails the desktop product significantly. Pulse found that
 
 ## The Jira comparison: what Pulse reveals
 
-[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, Hacker News, and developer sentiment platforms, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse score on the Top 100.](/top-100/jira)
+[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, Hacker News, and developer sentiment platforms, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse Score on the Top 100.](/top-100/jira)
 
 The comparison is instructive: Jira was built to serve methodologies (Scrum, Kanban, SAFe). Linear was built to serve humans. Pulse can measure the difference. Products designed for process consistently score lower on lived experience because humans aren't processes.
 
@@ -152,7 +152,7 @@ Then we pointed [Pulse](/pulse) at it.
 
 Pulse ingested reviews from G2, threads from Reddit and Hacker News, App Store ratings, and community forum discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
-The result: a Pulse Score of 2.8. Upper Usable. A -1.3 gap from the screen score.
+The result: a Pulse Score of 2.8. Upper Usable. A -1.3 gap from the Screen Score.
 
 Here's what Pulse surfaced as the dominant themes:
 
@@ -166,7 +166,7 @@ Here's what Pulse surfaced as the dominant themes:
 
 Pulse identified something deeper than individual complaints: a structural pattern. The more flexible the product, the more the experience depends on how you configure it. A well-structured Notion workspace is genuinely powerful. A poorly structured one is a maze.
 
-This means Notion's quality varies by user in a way most products don't. Your Notion and my Notion are different products. The 4.1 screen score reflects the best Notion can be. The 2.8 Pulse score reflects what Notion actually is for most people, as measured by thousands of real voices.
+This means Notion's quality varies by user in a way most products don't. Your Notion and my Notion are different products. The 4.1 Screen Score reflects the best Notion can be. The 2.8 Pulse Score reflects what Notion actually is for most people, as measured by thousands of real voices.
 
 ## What Pulse would tell Notion's product team
 
@@ -240,7 +240,7 @@ This is exactly the problem Pulse was built to solve. Traditional review platfor
 
 The enterprise UX crisis isn't about technology. It's about incentives. When the buyer isn't the user, the user's experience becomes secondary. Pulse makes that gap visible. And measurable. And impossible to ignore.
 
-But the pressure is building. Pulse scores prove that tools like [Linear](/top-100/linear) (4.2), [Mercury](/top-100/mercury) (3.2), and [Figma](/top-100/figma) (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
+But the pressure is building. Pulse Scores prove that tools like [Linear](/top-100/linear) (4.2), [Mercury](/top-100/mercury) (3.2), and [Figma](/top-100/figma) (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
 
 The scores won't lie. Pulse will make sure of it. [Explore the full Ladder Top 100](/top-100) and see where every product stands.
 
@@ -256,7 +256,7 @@ If your organization relies on enterprise tools and wants to measure the real ex
     excerpt:
       "Airbnb's interface scores 3.7: emotional design, beautiful photography, discovery that feels like exploring. Pulse analyzed 42,000+ real user signals and scored the lived experience at 2.3. The gap is about trust.",
     products: ["airbnb", "shopify"],
-    content: `[Airbnb](/top-100/airbnb) wrote the playbook on emotional design. The listing photography, the map integration, the category browsing (OMG!, Icons, Treehouses). Every pixel is engineered to make you feel something. It works. The screen score is 3.7.
+    content: `[Airbnb](/top-100/airbnb) wrote the playbook on emotional design. The listing photography, the map integration, the category browsing (OMG!, Icons, Treehouses). Every pixel is engineered to make you feel something. It works. The Screen Score is 3.7.
 
 Then we ran it through [Pulse](/pulse).
 
@@ -264,7 +264,7 @@ Then we ran it through [Pulse](/pulse).
 
 Pulse ingested data from Trustpilot, the App Store, Google Play, Reddit, and travel community forums, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
-The Pulse Score: 2.3. Usable. A -1.4 gap from the screen, one of the largest in the entire Top 100.
+The Pulse Score: 2.3. Usable. A -1.4 gap from the Screen Score, one of the largest in the entire Top 100.
 
 Here's what Pulse surfaced as the three dominant signals:
 

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -305,6 +305,71 @@ export default function FrameworkPage() {
           </div>
         </div>
 
+        {/* ── Two score types ── */}
+        <div className="mb-24">
+          <div className="flex items-center gap-4 mb-12">
+            <div className="h-px flex-1 bg-border" />
+            <span className="text-[10px] font-semibold text-muted uppercase tracking-[0.2em]">
+              Two ways to measure
+            </span>
+            <div className="h-px flex-1 bg-border" />
+          </div>
+
+          <p className="text-sm text-body text-center max-w-lg mx-auto mb-10 leading-relaxed">
+            The Ladder framework powers two distinct types of analysis.
+            Each produces a score on the same 1.0 to 5.0 scale.
+            Together, they tell the full story.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="border border-border bg-card/30 p-8">
+              <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-3">
+                Screen Score
+              </p>
+              <p className="text-sm font-bold text-foreground mb-2">
+                What the interface shows
+              </p>
+              <p className="text-xs text-body leading-relaxed mb-4">
+                AI evaluates a screenshot of your product against the five
+                levels. Design, hierarchy, layout, patterns, accessibility.
+                The score reflects what a user sees the moment they land.
+              </p>
+              <a
+                href="/score"
+                className="text-[11px] text-ladder-green hover:text-ladder-green/80 transition-colors"
+              >
+                Try the free scorer &rarr;
+              </a>
+            </div>
+
+            <div className="border border-border bg-card/30 p-8">
+              <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-3">
+                Pulse Score
+              </p>
+              <p className="text-sm font-bold text-foreground mb-2">
+                What real users feel
+              </p>
+              <p className="text-xs text-body leading-relaxed mb-4">
+                Ladder Pulse ingests thousands of real customer signals:
+                reviews, forums, support tickets, social sentiment. It
+                scores the lived experience, not the interface.
+              </p>
+              <a
+                href="/pulse"
+                className="text-[11px] text-ladder-green hover:text-ladder-green/80 transition-colors"
+              >
+                Learn about Pulse &rarr;
+              </a>
+            </div>
+          </div>
+
+          <p className="text-xs text-muted text-center mt-6 max-w-md mx-auto leading-relaxed">
+            The gap between Screen Score and Pulse Score is where the
+            real insight lives. A high Screen Score with a low Pulse Score
+            means the product looks better than it feels.
+          </p>
+        </div>
+
         {/* ── CTA ── */}
         <div className="text-center pt-8 border-t border-border">
           <p className="text-lg font-bold text-foreground mb-3">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -234,21 +234,30 @@ export default function Home() {
                 Get the truth.
               </h2>
               <p className="text-body leading-relaxed mb-6">
-                Ladder evaluates every screen against the same five-level
-                framework that Drawbackwards has used on thousands of real
-                projects. The AI has been trained on two decades of design
-                judgment. Not generic best practices, but the specific patterns
+                Upload a screenshot and get a <strong className="text-foreground">Screen Score</strong>: an
+                AI evaluation of the interface against the same five-level
+                framework Drawbackwards has used on thousands of real projects.
+                Not generic best practices, but the specific patterns
                 that separate products people tolerate from products people love.
               </p>
-              <p className="text-body leading-relaxed">
+              <p className="text-body leading-relaxed mb-6">
                 You get an honest score, the specific issues holding you back,
                 and exactly how much each fix would improve your score.
                 No flattery. No vague advice. Just the truth.
               </p>
+              <p className="text-body leading-relaxed">
+                Want to measure the lived experience, not just the interface?{" "}
+                <a href="/pulse" className="text-ladder-green hover:text-ladder-green/80 transition-colors">
+                  Ladder Pulse
+                </a>{" "}
+                ingests real customer signals from across the internet and scores
+                what people actually feel. The gap between Screen Score and
+                Pulse Score is where the real insight lives.
+              </p>
             </div>
             <div className="bg-card border border-border rounded-2xl p-12 text-center">
               <p className="font-mono text-xs text-muted uppercase tracking-wider mb-6">
-                Ladder Score
+                Screen Score
               </p>
               <LadderScore score={2.4} size="xl" />
               <p className="text-sm text-body mt-8 leading-relaxed">

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -47,11 +47,11 @@ const SURFACES = [
     badge: "Feedback Intelligence",
     tagline: "Score the lived experience, not just the screen.",
     description:
-      "Screens only tell half the story. Pulse ingests what real people say: customer reviews, support logs, survey responses, field reports, NPS comments. It scores the actual lived experience against the Ladder framework. The gap between your screen score and your Pulse score is where the real work lives.",
+      "Screens only tell half the story. Pulse ingests what real people say: customer reviews, support logs, survey responses, field reports, NPS comments. It scores the actual lived experience against the Ladder framework. The gap between your Screen Score and your Pulse Score is where the real work lives.",
     features: [
       "Ingest reviews, surveys, support tickets, field reports",
       "Per-rung scoring from real human language",
-      "AI-to-screen gap analysis (screen score vs lived experience)",
+      "Gap analysis (Screen Score vs. Pulse Score)",
       "Domain-specific rubrics (B2B, B2C, Process, Service)",
       "Trend tracking across feedback windows",
     ],

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -85,7 +85,7 @@ function AnimatedScore({ target }: { target: number }) {
 
 /* ── Social share helpers ── */
 function ShareButtons({ score, label, summary }: { score: number; label: string; summary: string }) {
-  const text = `My Ladder Score: ${score.toFixed(1)} (${label}). ${summary}`;
+  const text = `My Screen Score: ${score.toFixed(1)} (${label}). ${summary}`;
   const url = "https://runladder.com/score";
 
   return (
@@ -652,7 +652,7 @@ export default function ScorePage() {
 
               {/* Right: score panel */}
               <div className="border border-[#333] bg-[#1e1e1e] p-8 flex flex-col">
-                <span className="text-[10px] text-muted uppercase tracking-widest mb-6">Ladder Score</span>
+                <span className="text-[10px] text-muted uppercase tracking-widest mb-6">Screen Score</span>
                 <div className="flex-1 flex flex-col items-start justify-center">
                   <AnimatedScore target={result.score} />
                   <span className="text-sm font-bold uppercase tracking-widest mt-1" style={{ color: getScoreColor(result.score) }}>
@@ -682,6 +682,10 @@ export default function ScorePage() {
 
                 <p className="text-xs text-body leading-relaxed mt-6 border-t border-[#333] pt-4">
                   {result.summary}
+                </p>
+                <p className="text-[10px] text-muted mt-3">
+                  This is a Screen Score: what the interface shows. Want to know how it actually feels?{" "}
+                  <a href="/pulse" className="text-ladder-green hover:text-ladder-green/80 transition-colors">That takes Pulse.</a>
                 </p>
               </div>
             </div>

--- a/src/app/top-100/[slug]/page.tsx
+++ b/src/app/top-100/[slug]/page.tsx
@@ -140,6 +140,23 @@ export default async function ProductPage({ params }: Props) {
             </div>
 
             <div className="mt-6 pt-4 border-t border-border w-full">
+              <div className="flex justify-center gap-6 mb-4">
+                <div className="text-center">
+                  <span className="text-[9px] text-muted uppercase tracking-widest">Screen</span>
+                  <div className="text-sm font-bold mt-0.5" style={{ color: product.screenScore ? getScoreColor(product.screenScore.score) : undefined }}>
+                    {product.screenScore ? product.screenScore.score.toFixed(1) : "—"}
+                  </div>
+                </div>
+                <div className="text-center">
+                  <span className="text-[9px] text-muted uppercase tracking-widest">Pulse</span>
+                  <div className="text-sm font-bold mt-0.5" style={{ color: product.pulseScore ? getScoreColor(product.pulseScore.score) : undefined }}>
+                    {product.pulseScore ? product.pulseScore.score.toFixed(1) : <span className="text-muted text-xs">Pending</span>}
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="pt-4 border-t border-border w-full">
               <span className="text-[10px] text-muted uppercase tracking-widest">
                 Gap to {nextLevel}
               </span>
@@ -164,9 +181,10 @@ export default async function ProductPage({ params }: Props) {
         {/* ── Score layers ── */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-16">
           <div className="border border-border p-5">
-            <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-2">
+            <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-1">
               Screen Score
             </p>
+            <p className="text-[9px] text-muted/60 mb-2">AI analysis of public interface screenshots</p>
             {product.screenScore ? (
               <>
                 <span className="text-2xl font-bold" style={{ color: getScoreColor(product.screenScore.score) }}>
@@ -180,9 +198,10 @@ export default async function ProductPage({ params }: Props) {
           </div>
 
           <div className="border border-border p-5">
-            <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-2">
+            <p className="text-[10px] font-semibold text-muted uppercase tracking-widest mb-1">
               Pulse Score
             </p>
+            <p className="text-[9px] text-muted/60 mb-2">Lived experience scored from real user signals</p>
             {product.pulseScore ? (
               <>
                 <span className="text-2xl font-bold" style={{ color: getScoreColor(product.pulseScore.score) }}>

--- a/src/app/top-100/page.tsx
+++ b/src/app/top-100/page.tsx
@@ -256,8 +256,8 @@ export default function Top100Page() {
               body: "Pulse ingests thousands of data points per product from G2, Capterra, Trustpilot, App Store, Reddit, Hacker News, Product Hunt, and community forums. Our AI maps every signal to the Ladder framework's five levels of experience quality. This is the lived experience score.",
             },
             {
-              title: "Screen Analysis",
-              body: "Public screenshots from marketing sites, review platforms, and product tours, analyzed by AI against the Ladder framework. This measures what the product looks like. The gap between Screen and Pulse scores is where the real insight lives.",
+              title: "Screen Score",
+              body: "Public screenshots from marketing sites, review platforms, and product tours, analyzed by AI against the Ladder framework. This measures what the product looks like. The gap between Screen Score and Pulse Score is where the real insight lives.",
             },
             {
               title: "Company Verified",
@@ -280,7 +280,7 @@ export default function Top100Page() {
               body: "Rankings are determined entirely by Pulse. No company can pay for placement, boost their ranking, or suppress a low score. The intelligence is what it is.",
             },
             {
-              title: "Updated quarterly",
+              title: "Updated monthly",
               body: "Pulse re-scores every product each month as new data flows in. Scores go up and down. The delta column shows real movement.",
             },
             {


### PR DESCRIPTION
## Summary
- **Screen Score**: AI visual analysis of a screenshot (what the interface shows)
- **Pulse Score**: sentiment intelligence from real user data (what the experience feels like)
- **Ladder Score**: umbrella brand term covering both

### Key changes
- `/score` result panel: "Ladder Score" → "Screen Score" + Pulse cross-reference
- `/top-100/[slug]` hero card: keeps "Ladder Score" with Screen + Pulse sub-scores shown beneath
- `/top-100/[slug]` layer cards: added one-line descriptors for Screen Score and Pulse Score
- `/top-100` methodology: "Screen Analysis" → "Screen Score"
- Homepage demo: "Ladder Score" → "Screen Score" + new Pulse paragraph
- `/framework`: new "Two ways to measure" section explaining both score types
- `/products`: consistent capitalization
- Blog posts: all score type references capitalized consistently

## Test plan
- [x] `npx next build` passes
- [ ] Visual check: score page result panel shows "Screen Score"
- [ ] Visual check: Top 100 product page hero card shows sub-scores
- [ ] Visual check: framework page shows two-score explainer section

🤖 Generated with [Claude Code](https://claude.com/claude-code)