### PR TITLE
Remove Ladder API as a product, reorder footer

### DIFF
--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -349,7 +349,7 @@ export default function OrganizationsPage() {
               {[
                 { surface: "runladder.com", desc: "Upload a screenshot and get a score in seconds. No installs, no configuration." },
                 { surface: "Ladder for Figma", desc: "Score screens without leaving your design tool. Built into the workflow designers already use." },
-                { surface: "Ladder API", desc: "Bake quality scoring into CI/CD. Every deploy, every PR, automatically scored before it reaches users." },
+                { surface: "Ladder for Claude", desc: "Get a quality check mid-conversation. Know if what you generated is a 2.1 or a 3.8 before anyone else sees it." },
                 { surface: "Ladder Pulse", desc: "Turn customer feedback, support logs, and field reports into a quality score that tracks real experience." },
               ].map((s) => (
                 <div

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,12 +65,6 @@ const PRODUCTS = [
     cta: "Coming soon",
   },
   {
-    name: "Ladder API",
-    desc: "Bake quality scoring into your pipeline. Every deploy, every PR, every AI-generated screen, automatically scored before it reaches users.",
-    href: "/api",
-    cta: "View the docs",
-  },
-  {
     name: "Drawbackwards Consulting",
     desc: "The team behind Ladder embeds with yours, sprint by sprint. Ideation workshops, design thinking studios, UI/UX execution, team mentoring, skill evaluation, and custom Pulse deployments. 20 years of doing the work, not just scoring it.",
     href: "https://drawbackwards.com",

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -160,13 +160,12 @@ export default function PricingPage() {
           <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-8">
             <div>
               <h3 className="font-mono text-sm font-semibold text-foreground mb-3">
-                Ladder API &amp; Enterprise
+                Enterprise
               </h3>
               <p className="text-sm text-body max-w-lg leading-relaxed">
-                Need programmatic access or organization-wide deployment? API
-                access, SSO, custom Ladder calibration, cross-team dashboards,
-                executive reporting, and dedicated support. Priced for your
-                scale.
+                Organization-wide deployment with SSO, custom Ladder
+                calibration, cross-team dashboards, executive reporting, and
+                dedicated support. Priced for your scale.
               </p>
             </div>
             <Link

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Products | Ladder",
   description:
-    "One quality score across every surface. Score in your browser, in Figma, from customer feedback, through Claude, or via API.",
+    "One quality score across every surface. Score in your browser, in Figma, from customer feedback, or through Claude.",
 };
 
 const SURFACES = [
@@ -76,23 +76,6 @@ const SURFACES = [
     available: false,
   },
   {
-    name: "Ladder API",
-    badge: "Infrastructure",
-    tagline: "Bake quality into your pipeline.",
-    description:
-      "Every deploy, every PR, every AI-generated screen, automatically scored before it reaches users. The API is the backbone that powers every Ladder surface and is available for you to integrate into your own tools, CI/CD pipelines, and AI workflows.",
-    features: [
-      "REST API with per-rung scoring",
-      "MCP server for AI agent integration",
-      "Batch scoring for portfolios and audits",
-      "Webhook support for CI/CD pipelines",
-      "Per-call pricing with generous free tier",
-    ],
-    cta: "View the docs",
-    href: "/api",
-    available: true,
-  },
-  {
     name: "Drawbackwards Consulting",
     badge: "Expert Services",
     tagline: "The team behind Ladder, embedded with yours.",
@@ -125,9 +108,9 @@ export default function ProductsPage() {
             <span className="text-ladder-green">Every surface.</span>
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto leading-relaxed">
-            Score in your browser, in Figma, from customer feedback, through
-            Claude, or via API. Every score feeds the same account, the same
-            history, the same truth.
+            Score in your browser, in Figma, from customer feedback, or through
+            Claude. Every score feeds the same account, the same history, the
+            same truth.
           </p>
         </div>
       </section>
@@ -163,12 +146,6 @@ export default function ProductsPage() {
                 <span className="text-muted">Ladder for Claude</span>
                 <span className="flex-1 border-b border-dashed border-border" />
                 <span className="text-muted text-xs">coming soon</span>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
-                <span>Ladder API</span>
-                <span className="flex-1 border-b border-dashed border-border" />
-                <span className="text-muted text-xs">infrastructure</span>
               </div>
             </div>
             <div className="mt-8 pt-6 border-t border-border text-center">
@@ -251,9 +228,9 @@ export default function ProductsPage() {
             <span className="text-body">Everywhere.</span>
           </h2>
           <p className="text-body leading-relaxed max-w-xl mx-auto mb-10">
-            Score a screen on the web, check it in Figma, reference it in
-            Claude, pull it from the API. It&apos;s the same score, the same
-            history, the same account. One subscription unlocks every surface.
+            Score a screen on the web, check it in Figma, or reference it in
+            Claude. It&apos;s the same score, the same history, the same
+            account. One subscription unlocks every surface.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -13,7 +13,6 @@ export function Footer() {
               <li><Link href="/score" className="hover:text-foreground transition-colors">Score a screen</Link></li>
               <li><Link href="/framework" className="hover:text-foreground transition-colors">Framework</Link></li>
               <li><Link href="/pricing" className="hover:text-foreground transition-colors">Pricing</Link></li>
-              <li><Link href="/api" className="hover:text-foreground transition-colors">API</Link></li>
             </ul>
           </div>
           <div>
@@ -22,9 +21,8 @@ export function Footer() {
             </h4>
             <ul className="space-y-3 text-sm text-body">
               <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Figma</Link></li>
-              <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder Pulse</Link></li>
               <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Claude</Link></li>
-              <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder API</Link></li>
+              <li><Link href="/pulse" className="hover:text-foreground transition-colors">Ladder Pulse</Link></li>
             </ul>
           </div>
           <div>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -26,9 +26,6 @@ export function Nav() {
           <Link href="/pricing" className="hover:text-foreground transition-colors">
             Pricing
           </Link>
-          <Link href="/api" className="hover:text-foreground transition-colors">
-            API
-          </Link>
         </div>
 
         <div className="flex items-center gap-6">


### PR DESCRIPTION
## Summary
- Removes **Ladder API** as a publicly listed product across the entire site
- Footer surfaces reordered to: **Ladder for Figma, Ladder for Claude, Ladder Pulse**
- API link removed from top navigation
- Pricing section renamed from "Ladder API & Enterprise" to "Enterprise"
- Organizations page replaces API surface with Ladder for Claude

**Files changed:** Footer.tsx, Nav.tsx, products/page.tsx, page.tsx, organizations/page.tsx, pricing/page.tsx

## Test plan
- [x] `npx next build` passes
- [ ] Footer shows three surfaces in correct order
- [ ] Nav no longer has API link
- [ ] Products page has no Ladder API card or architecture line
- [ ] Pricing enterprise section no longer mentions API


🤖 Generated with [Claude Code](https://claude.com/claude-code)