### PR TITLE
Genericize Pulse data sources: 3,000+ online sources

### DIFF
--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -25,7 +25,7 @@ export const BLOG_POSTS: BlogPost[] = [
     products: ["notion", "airbnb", "arc", "apple-music", "raycast", "linear"],
     content: `We built [Ladder Pulse](/pulse) to answer a question most product teams avoid: does your product actually feel as good as it looks?
 
-Pulse is Ladder's proprietary experience intelligence engine. It ingests real customer sentiment from across the internet (G2, Reddit, the App Store, Hacker News, Trustpilot, Product Hunt, Capterra, and community forums) and runs it through the [Ladder framework](/framework) to produce a single, honest score: the Pulse Score.
+Pulse is Ladder's proprietary experience intelligence engine. It ingests real customer sentiment from 3,000+ online sources and runs it through the [Ladder framework](/framework) to produce a single, honest score: the Pulse Score.
 
 To put Pulse to the test, we pointed it at 36 of the most-used digital products in the world. We scored each one twice. Once on the interface: the screens, the visual design, the information architecture. And once through Pulse, analyzing what thousands of real users actually say about the lived experience.
 
@@ -35,11 +35,11 @@ The gap between those two numbers is the most honest thing we've ever measured.
 
 **[Airbnb](/top-100/airbnb): Screen 3.7, Pulse 2.3 (gap: -1.4)**
 
-Pulse ingested 42,000+ data points from Trustpilot, the App Store, Reddit, and travel forums. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." Pulse says "surprise costs." [See how Airbnb's full score breaks down on the Top 100.](/top-100/airbnb)
+Pulse ingested 42,000+ data points across 3,000+ online sources. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." Pulse says "surprise costs." [See how Airbnb's full score breaks down on the Top 100.](/top-100/airbnb)
 
 **[Notion](/top-100/notion): Screen 4.1, Pulse 2.8 (gap: -1.3)**
 
-Pulse analyzed 4,100+ reviews from G2, Reddit, and Hacker News. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. [See Notion's full Pulse breakdown.](/top-100/notion)
+Pulse analyzed 4,100+ data points across 3,000+ online sources. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. [See Notion's full Pulse breakdown.](/top-100/notion)
 
 **[Arc Browser](/top-100/arc): Screen 3.8, Pulse 2.6 (gap: -1.2)**
 
@@ -47,7 +47,7 @@ Pulse processed 1,800+ data points and surfaced a consistent theme: innovative s
 
 **[Apple Music](/top-100/apple-music): Screen 3.6, Pulse 2.4 (gap: -1.2)**
 
-Pulse analyzed 8,500+ reviews, primarily from the App Store where users average 2.4 out of 5 stars. Users consistently describe library management issues, inconsistent navigation, and discovery algorithms that trail Spotify by miles. Beautiful surfaces don't compensate for friction in daily tasks.
+Pulse analyzed 8,500+ data points across 3,000+ online sources, where app store ratings average 2.4 out of 5. Users consistently describe library management issues, inconsistent navigation, and discovery algorithms that trail Spotify by miles. Beautiful surfaces don't compensate for friction in daily tasks.
 
 ## What Pulse found: products where reality exceeds appearance
 
@@ -77,7 +77,7 @@ The gap is where the real story lives. [Explore all 36 products and their Pulse 
 
 ## How Pulse works
 
-**Data ingestion:** Pulse scans G2 reviews, Reddit threads, Hacker News discussions, App Store ratings, Trustpilot scores, Product Hunt reviews, Capterra data, and community forums, aggregating thousands of data points per product.
+**Data ingestion:** Pulse scans 3,000+ online sources, aggregating thousands of data points per product. Ladder Pulse subscribers can also feed internal signals: support tickets, NPS responses, field reports, employee surveys, customer interviews, CSAT data, in-app feedback, and churn interviews.
 
 **Ladder mapping:** Our AI, trained on 20 years of experience evaluation at Drawbackwards, analyzes sentiment, identifies friction patterns, and maps the quality of the described experience to Ladder's 1.0-5.0 scale. Not just positive or negative. Five distinct levels of experience quality.
 
@@ -96,7 +96,7 @@ Want to see what Pulse reveals about your product or organization? [Request a Pu
     excerpt:
       "Pulse scored Linear's lived experience at 4.2, within 0.1 of its Screen Score. That's the smallest gap in our dataset. Here's what Pulse found inside 3,200+ reviews, forum posts, and community discussions.",
     products: ["linear", "jira", "notion"],
-    content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when [Pulse](/pulse) analyzed 3,200+ data points from G2, Reddit, developer forums, and community discussions, it found something rare: the experience matches the interface almost exactly.
+    content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when [Pulse](/pulse) analyzed 3,200+ data points across 3,000+ online sources, it found something rare: the experience matches the interface almost exactly.
 
 ## What Pulse found
 
@@ -108,7 +108,7 @@ A near-zero gap means the product is honest. Pulse couldn't find a meaningful di
 
 ## What Pulse identified as strengths
 
-**Speed as a design constraint.** Across G2 reviews and developer forums, Pulse consistently surfaced speed as the defining sentiment. Not "it's fast for a project management tool," just "it's fast." Users describe every interaction completing in under 100ms. Pulse categorized this as a core experience differentiator, not just a feature.
+**Speed as a design constraint.** Across professional reviews and developer forums, Pulse consistently surfaced speed as the defining sentiment. Not "it's fast for a project management tool," just "it's fast." Users describe every interaction completing in under 100ms. Pulse categorized this as a core experience differentiator, not just a feature.
 
 **Keyboard-first interaction.** Pulse detected a pattern: users who mention keyboard shortcuts consistently rate the product higher than those who don't. The shortcuts follow a grammar (C for create, V for views, G for go-to) that users internalize within days. Pulse flagged this as a signal of "Delightful" level design: the product anticipates how expert users want to work.
 
@@ -122,7 +122,7 @@ The mobile experience trails the desktop product significantly. Pulse found that
 
 ## The Jira comparison: what Pulse reveals
 
-[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, Hacker News, and developer sentiment platforms, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse Score on the Top 100.](/top-100/jira)
+[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse Score on the Top 100.](/top-100/jira)
 
 The comparison is instructive: Jira was built to serve methodologies (Scrum, Kanban, SAFe). Linear was built to serve humans. Pulse can measure the difference. Products designed for process consistently score lower on lived experience because humans aren't processes.
 
@@ -142,7 +142,7 @@ Linear's lesson: make fewer promises and keep all of them. Pulse will know the d
     readTime: "6 min read",
     category: "Pulse Teardown",
     excerpt:
-      "Notion's interface scores 4.1. When Pulse ingested 4,100+ real user signals from G2, Reddit, and Hacker News, it scored the lived experience at 2.8. The gap reveals a product that's better at promising than delivering.",
+      "Notion's interface scores 4.1. When Pulse ingested 4,100+ real user signals across 3,000+ online sources, it scored the lived experience at 2.8. The gap reveals a product that's better at promising than delivering.",
     products: ["notion", "linear", "airtable"],
     content: `[Notion's](/top-100/notion) interface is genuinely impressive. The block-based editor is flexible, the database views are powerful, and the visual design is clean and confident. It scores 4.1 on screen quality, putting it in Delightful territory.
 
@@ -150,7 +150,7 @@ Then we pointed [Pulse](/pulse) at it.
 
 ## What 4,100+ data points told Pulse
 
-Pulse ingested reviews from G2, threads from Reddit and Hacker News, App Store ratings, and community forum discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
+Pulse ingested public reviews, forums, and community discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
 The result: a Pulse Score of 2.8. Upper Usable. A -1.3 gap from the Screen Score.
 
@@ -192,9 +192,9 @@ This is what Pulse does. It takes the noise of thousands of reviews and turns it
     readTime: "5 min read",
     category: "Pulse Intelligence",
     excerpt:
-      "Pulse scored the three most-used enterprise products in the world: Jira (2.1), Salesforce (2.2), Workday (1.4). Over 114,000 data points from G2, Reddit, Trustpilot, and employee forums reveal an experience crisis hiding in plain sight.",
+      "Pulse scored the three most-used enterprise products in the world: Jira (2.1), Salesforce (2.2), Workday (1.4). Over 114,000 data points across 3,000+ online sources reveal an experience crisis hiding in plain sight.",
     products: ["jira", "salesforce", "workday"],
-    content: `We pointed [Pulse](/pulse) at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Pulse ingested over 114,000 data points from G2, Capterra, Reddit, Hacker News, Trustpilot, Atlassian community forums, Quora, Glassdoor, and employee sentiment platforms.
+    content: `We pointed [Pulse](/pulse) at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Pulse ingested over 114,000 data points across 3,000+ online sources, including public reviews, forums, and community discussions.
 
 The results:
 
@@ -214,7 +214,7 @@ Pulse can measure the cost of that disconnect. Here's what it found.
 
 ## Jira: Pulse Score 2.1
 
-Pulse analyzed 15,000+ data points from G2, Capterra, Atlassian's own community forums, Reddit, and Hacker News. The intelligence was clear: Jira's G2 score of 4.3/5 reflects buyer satisfaction. Pulse's 2.1 reflects user experience.
+Pulse analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions. The intelligence was clear: Jira's 4.3/5 on traditional review platforms reflects buyer satisfaction. Pulse's 2.1 reflects user experience.
 
 The dominant signal: every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Pulse detected overwhelming negative sentiment around the 2025 navigation redesign, which users described as making an already complex product worse. [See Jira's full Pulse analysis on the Top 100.](/top-100/jira)
 
@@ -222,7 +222,7 @@ For context: [Linear](/top-100/linear) does much less and Pulse scores it at 4.2
 
 ## Salesforce: Pulse Score 2.2
 
-Pulse processed 94,000+ data points, the largest dataset of any product in the Top 100. G2 reviews, Capterra, Quora threads, Reddit, and independent analysis all fed into the Pulse engine.
+Pulse processed 94,000+ data points, the largest dataset of any product in the Top 100. Public reviews, professional platforms, community forums, and independent analysis all fed into the Pulse engine.
 
 What Pulse found: a massive gap between capability and experience. Salesforce can do almost anything. But Pulse identified that end users (the sales reps and support agents who click through it 8 hours a day) generate overwhelmingly negative experience signals. The Lightning redesign improved surface aesthetics but didn't address the labyrinthine navigation and inconsistent patterns across modules that Pulse flagged as structural issues.
 
@@ -230,13 +230,13 @@ The most common sentiment Pulse extracted: "It's the industry standard, so we us
 
 ## Workday: Pulse Score 1.4
 
-Pulse scored Workday the lowest of any product in the entire Top 100. Across 5,000+ data points from G2, Trustpilot, Reddit, Glassdoor, and employee forums, Pulse identified a product in the Functional tier, meaning users fight it to complete basic tasks.
+Pulse scored Workday the lowest of any product in the entire Top 100. Across 5,000+ data points from public reviews, forums, and employee sentiment platforms, Pulse identified a product in the Functional tier, meaning users fight it to complete basic tasks.
 
 The most striking signal: Pulse found that even simple actions like submitting time off, checking a pay stub, or updating personal information generate measurably negative sentiment. The interface feels dated. Navigation requires memorizing paths rather than following intuition. And the job applicant experience, which touches millions of people, is what Pulse classifies as a UX crisis. [See Workday's full score.](/top-100/workday)
 
 ## What Pulse proves about enterprise software
 
-This is exactly the problem Pulse was built to solve. Traditional review platforms like G2 aggregate buyer satisfaction, which is why Jira, Salesforce, and Workday all score 4.0+ on G2. Pulse measures something different: the quality of the lived experience, from the perspective of the person who has to use the product every day.
+This is exactly the problem Pulse was built to solve. Traditional review platforms aggregate buyer satisfaction, which is why Jira, Salesforce, and Workday all score 4.0+ on professional review platforms. Pulse measures something different: the quality of the lived experience, from the perspective of the person who has to use the product every day.
 
 The enterprise UX crisis isn't about technology. It's about incentives. When the buyer isn't the user, the user's experience becomes secondary. Pulse makes that gap visible. And measurable. And impossible to ignore.
 
@@ -262,7 +262,7 @@ Then we ran it through [Pulse](/pulse).
 
 ## What Pulse found across 42,000+ signals
 
-Pulse ingested data from Trustpilot, the App Store, Google Play, Reddit, and travel community forums, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
+Pulse ingested data across 3,000+ online sources, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
 The Pulse Score: 2.3. Usable. A -1.4 gap from the Screen Score, one of the largest in the entire Top 100.
 
@@ -319,7 +319,7 @@ This sounds basic. It is basic. That's the point. A 3.0 doesn't mean a product i
 
 ## Pulse data: most products don't clear it
 
-When we pointed Pulse at 36 of the most prominent digital products in the world, ingesting millions of data points from G2, Reddit, Trustpilot, App Store, Hacker News, Product Hunt, Capterra, and community forums, only 15 scored 3.0 or above.
+When we pointed Pulse at 36 of the most prominent digital products in the world, ingesting millions of data points across 3,000+ online sources, only 15 scored 3.0 or above.
 
 That means 21 of the most-used digital products in the world still make their users think more than they should.
 
@@ -382,7 +382,7 @@ A Screen Score answers: *does this interface look and function like it respects 
 
 ## Pulse Score: what real users feel
 
-A [Pulse Score](/pulse) is different. Ladder Pulse ingests real customer signals from across the internet: G2 reviews, Reddit threads, App Store ratings, Trustpilot, Hacker News, forums, support communities. Thousands of data points per product, run through the same Ladder framework.
+A [Pulse Score](/pulse) is different. Ladder Pulse ingests real customer signals from 3,000+ online sources: public reviews, forums, and community discussions. Thousands of data points per product, run through the same Ladder framework.
 
 A Pulse Score doesn't care what the interface looks like. It cares what people say when they talk about using it. The frustrations they describe. The moments they celebrate. The features they beg for. The ones they curse.
 
@@ -500,7 +500,7 @@ If your Pulse Score is higher than your Screen Score, you've already built somet
       "Pinterest still owns visual discovery. But 25,000+ real user signals reveal an experience eroding under ad pressure, declining content quality, and a platform that's stopped serving the people who made it valuable.",
     content: `[Pinterest](/top-100/pinterest) invented the modern visual discovery feed. The grid layout, the infinite scroll, the pin-and-board model that a dozen other platforms copied. On screen, it still works. The interface is clean, the visual density is appropriate, and the browsing experience is fluid. Screen Score: 3.2.
 
-Then we pointed [Pulse](/pulse) at 25,000+ real data points: App Store reviews, Reddit threads, Trustpilot, creator forums, and social sentiment. Pulse Score: 1.8.
+Then we pointed [Pulse](/pulse) at 25,000+ real data points across 3,000+ online sources. Pulse Score: 1.8.
 
 That -1.4 gap ties [Airbnb](/top-100/airbnb) for the largest negative delta in the entire [Top 100](/top-100).
 
@@ -558,7 +558,7 @@ A Screen Score tells you the interface works. A Pulse Score tells you whether th
       "Monzo's interface is competent but unremarkable. Its Pulse Score is +0.6 higher than its Screen Score, the largest positive gap in the Top 100. 325,000 data points explain why.",
     content: `[Monzo](/top-100/monzo) doesn't look special. Open the app and you'll find standard card layouts, mid-range typography, and a color scheme (hot coral on white) that's distinctive but not sophisticated. A design blog wouldn't feature it. The Screen Score reflects this: 3.3, solidly Comfortable but not pushing toward Delightful.
 
-Then [Pulse](/pulse) ingested 325,000+ data points: App Store reviews, Trustpilot, Reddit, finance forums, and social sentiment. Pulse Score: 3.9.
+Then [Pulse](/pulse) ingested 325,000+ data points across 3,000+ online sources. Pulse Score: 3.9.
 
 That +0.6 gap is the largest positive delta in the entire [Top 100](/top-100). Monzo's users love it significantly more than its interface would predict.
 
@@ -614,7 +614,7 @@ If your Screen Score is higher than your Pulse Score, you're investing in the wr
       "Pulse analyzed 120,000+ Netflix reviews and found a 1.0-point gap between interface and reality. Content discovery peaked. The interface hasn't kept up. And users are noticing.",
     content: `[Netflix](/top-100/netflix) defined streaming. The autoplay preview, the percentage match, the horizontal category rows, the "Because you watched..." recommendations. Every streaming service copied the playbook. Screen Score: 3.4, Comfortable. The interface still works.
 
-But [Pulse](/pulse) tells a different story. 120,000+ data points from the App Store, Reddit, Trustpilot, social media, and entertainment forums. Pulse Score: 2.4. Usable. A full point below the interface.
+But [Pulse](/pulse) tells a different story. 120,000+ data points across 3,000+ online sources. Pulse Score: 2.4. Usable. A full point below the interface.
 
 ## What 120,000 data points reveal
 
@@ -662,7 +662,7 @@ The Screen Score says the interface is fine. The Pulse Score says the relationsh
     products: ["discord", "spotify", "robinhood", "twitch", "canva"],
     content: `Most product analytics work with thousands of data points. User interviews might cover dozens. Surveys might reach hundreds. [Pulse](/pulse) works with millions.
 
-Five products in the [Ladder Top 100](/top-100) have datasets exceeding one million real user signals each. Combined, they represent over 25 million data points: App Store reviews, Google Play ratings, Reddit threads, forum posts, Trustpilot scores, and social sentiment.
+Five products in the [Ladder Top 100](/top-100) have datasets exceeding one million real user signals each. Combined, they represent over 25 million data points across 3,000+ online sources.
 
 At this scale, Pulse doesn't just measure whether users are happy. It maps the terrain of how millions of people actually experience software.
 

--- a/src/app/pulse/page.tsx
+++ b/src/app/pulse/page.tsx
@@ -308,12 +308,12 @@ export default function PulsePage() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {[
-              { source: "Customer reviews", detail: "App Store, Google Play, G2, Trustpilot, Yelp. Wherever your users talk about you." },
-              { source: "Support transcripts", detail: "Zendesk, Intercom, Freshdesk, call center logs. The raw voice of frustration or delight." },
-              { source: "NPS and surveys", detail: "Qualtrics, SurveyMonkey, Typeform, Alchemer, in-app surveys. Structured sentiment at scale." },
-              { source: "Field reports", detail: "Technicians, officers, nurses, inspectors. People in the field telling HQ what\u2019s really happening." },
-              { source: "Internal operations", detail: "Manufacturing lines, logistics teams, satellite feeds, warehouse ops. The experience of the people who keep the machine running." },
-              { source: "Employee feedback", detail: "Slack channels, retros, engagement surveys, exit interviews. The internal experience is an experience too." },
+              { source: "3,000+ online sources", detail: "Public reviews, forums, communities, social media, ratings platforms, and discussion boards. Wherever humans talk about products, Pulse is listening." },
+              { source: "Support transcripts", detail: "Zendesk, Intercom, Freshdesk, call center logs. The raw voice of frustration or delight. Available to Pulse subscribers." },
+              { source: "NPS and surveys", detail: "CSAT, NPS responses, in-app feedback, onboarding surveys, churn interviews. Structured sentiment at scale. Available to Pulse subscribers." },
+              { source: "Field reports", detail: "Technicians, officers, nurses, inspectors. People in the field telling HQ what\u2019s really happening. Available to Pulse subscribers." },
+              { source: "Internal operations", detail: "Manufacturing lines, logistics teams, warehouse ops, sales call transcripts. The experience of the people who keep the machine running. Available to Pulse subscribers." },
+              { source: "Employee feedback", detail: "Engagement surveys, retros, exit interviews, internal forums. The internal experience is an experience too. Available to Pulse subscribers." },
             ].map((s) => (
               <div
                 key={s.source}

--- a/src/app/top-100/[slug]/page.tsx
+++ b/src/app/top-100/[slug]/page.tsx
@@ -213,7 +213,7 @@ export default async function ProductPage({ params }: Props) {
                 </p>
               </>
             ) : (
-              <p className="text-xs text-muted">Pending: will aggregate G2, Reddit, App Store, and more</p>
+              <p className="text-xs text-muted">Pending: will aggregate data from 3,000+ online sources</p>
             )}
           </div>
 

--- a/src/app/top-100/data.ts
+++ b/src/app/top-100/data.ts
@@ -1,6 +1,6 @@
 export type ScoreLayer = {
   score: number;
-  source: string;       // e.g. "Marketing site screenshots", "2,400 G2 reviews"
+  source: string;       // e.g. "Marketing site screenshots", "3,200+ data points across public reviews and forums"
   sourceCount?: number; // number of data points
 };
 
@@ -53,7 +53,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "The standard for modern SaaS interaction design",
     delta: 0.2,
     screenScore: { score: 4.3, source: "Marketing site and product screenshots" },
-    pulseScore: { score: 4.2, source: "G2 4.6/5 (2.1K reviews), Reddit sentiment very positive, Product Hunt highly rated", sourceCount: 3200 },
+    pulseScore: { score: 4.2, source: "Professional review platforms rate 4.6/5 (2.1K reviews), community sentiment very positive, product launch platforms highly rated", sourceCount: 3200 },
     scoreDisclaimer: "Pulse score from 3,200+ data points",
     description: "Linear has become the benchmark that other developer tools measure themselves against. The interface is fast. Not marketing-fast, but perceptibly instant. Every interaction feels like it was designed by someone who uses the product daily. The keyboard-first philosophy isn't a gimmick; it's woven into every workflow. Where most project management tools add features by adding screens, Linear adds features by making existing screens smarter.",
     strengths: [
@@ -78,7 +78,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Flexible power with a learning curve that still rewards",
     delta: 0.1,
     screenScore: { score: 4.1, source: "Marketing site and product screenshots" },
-    pulseScore: { score: 2.8, source: "G2 4.5/5 (2.5K reviews), Reddit mixed (performance complaints), App Store 3.2/5", sourceCount: 4100 },
+    pulseScore: { score: 2.8, source: "Professional review platforms rate 4.5/5 (2.5K reviews), community mixed (performance complaints), app store ratings 3.2/5", sourceCount: 4100 },
     scoreDisclaimer: "Pulse score from 4,100+ data points",
     description: "Notion took the radical bet that one tool could replace many, and largely won. The block-based editor is genuinely flexible, and the database system enables workflows that would require three other tools. The learning curve is real, but the payoff is a workspace that shapes itself around how you think. The gap between 'getting started' and 'getting productive' is where Notion still loses people.",
     strengths: [
@@ -102,7 +102,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 4.0,
     verdict: "Complexity made legible: developer-grade clarity for finance",
     screenScore: { score: 4.0, source: "Dashboard screenshots and product tours" },
-    pulseScore: { score: 3.1, source: "G2 4.3/5 (1.1K reviews), Reddit developer sentiment positive, Trustpilot 1.6/5 (merchant complaints)", sourceCount: 2800 },
+    pulseScore: { score: 3.1, source: "Professional review platforms rate 4.3/5 (1.1K reviews), developer community sentiment positive, consumer review platforms rate 1.6/5 (merchant complaints)", sourceCount: 2800 },
     scoreDisclaimer: "Pulse score from 2,800+ data points",
     description: "Stripe's dashboard handles an extraordinary amount of complexity (payments, subscriptions, invoicing, fraud detection, tax compliance) and makes most of it navigable. The information architecture is remarkably clear for the density of data presented. Where it falls short of a higher score is in progressive disclosure; some workflows still require too many clicks to reach critical information.",
     strengths: [
@@ -126,7 +126,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Deploy-to-delight pipeline built into every interaction",
     delta: 0.3,
     screenScore: { score: 3.9, source: "Dashboard screenshots and deploy UI" },
-    pulseScore: { score: 3.4, source: "G2 4.5/5 (400+ reviews), Reddit developer sentiment positive, HN mixed on pricing", sourceCount: 1200 },
+    pulseScore: { score: 3.4, source: "Professional review platforms rate 4.5/5 (400+ reviews), developer community sentiment positive, developer forums mixed on pricing", sourceCount: 1200 },
     scoreDisclaimer: "Pulse score from 1,200+ data points",
     description: "Vercel has turned deployment into a design problem and solved it with taste. The dashboard communicates complex infrastructure states (builds, domains, environments, logs) through a visual language that feels calm even when things go wrong. The biggest delta this quarter reflects their investment in making the analytics and monitoring surfaces match the quality of the deploy experience.",
     strengths: [
@@ -148,7 +148,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.9,
     verdict: "Collaboration as a first-class design primitive",
     screenScore: { score: 3.9, source: "Product screenshots and design workflows" },
-    pulseScore: { score: 3.8, source: "G2 4.7/5 (1.1K reviews), Reddit very positive, Product Hunt top-rated", sourceCount: 2600 },
+    pulseScore: { score: 3.8, source: "Professional review platforms rate 4.7/5 (1.1K reviews), community very positive, product launch platforms top-rated", sourceCount: 2600 },
     scoreDisclaimer: "Pulse score from 2,600+ data points",
     description: "Figma proved that design tools could be multiplayer. The real-time collaboration isn't a feature. It's the foundation everything else is built on. The plugin ecosystem, component system, and prototyping tools are all strong. Where Figma loses points is in the growing complexity of its own interface; features added since the Adobe acquisition attempt have started to create navigation overhead.",
     strengths: [
@@ -172,7 +172,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Rethinks the browser chrome with taste and restraint",
     delta: -0.1,
     screenScore: { score: 3.8, source: "Product screenshots and browser UI" },
-    pulseScore: { score: 2.6, source: "Reddit polarized (love/hate), Product Hunt 4.2/5, App Store 3.1/5, stability complaints", sourceCount: 1800 },
+    pulseScore: { score: 2.6, source: "Community polarized (love/hate), product launch platforms 4.2/5, app store ratings 3.1/5, stability complaints", sourceCount: 1800 },
     scoreDisclaimer: "Pulse score from 1,800+ data points",
     description: "Arc made the bold bet that the browser's frame, the chrome around the web, deserved a complete rethink. Spaces, Boosts, and the sidebar model genuinely improve how you organize browsing. The slight downward movement reflects stability issues in recent updates and the tension between innovation and reliability in a tool people depend on every minute of the day.",
     strengths: [
@@ -195,7 +195,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.8,
     verdict: "Speed is the feature: every interaction under 200ms",
     screenScore: { score: 3.8, source: "Product screenshots and extension UI" },
-    pulseScore: { score: 4.2, source: "Product Hunt 4.8/5, Reddit overwhelmingly positive, HN enthusiastic adoption", sourceCount: 1500 },
+    pulseScore: { score: 4.2, source: "Product launch platforms 4.8/5, community overwhelmingly positive, developer forums enthusiastic adoption", sourceCount: 1500 },
     scoreDisclaimer: "Pulse score from 1,500+ data points",
     description: "Raycast treats speed as its core design principle, and it shows. Every interaction (launching, searching, executing) feels instantaneous. The extension ecosystem turns it from a launcher into a command center. Where it excels is making complex workflows feel like one step. Where it struggles is in discoverability; the power is there, but finding it requires exploration.",
     strengths: [
@@ -218,7 +218,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.7,
     verdict: "Emotional design that makes browsing feel like discovery",
     screenScore: { score: 3.7, source: "Marketing site and booking flow screenshots" },
-    pulseScore: { score: 2.3, source: "Trustpilot 1.4/5 (25K+ reviews), App Store 4.7/5, Reddit mixed, fee complaints dominate", sourceCount: 42000 },
+    pulseScore: { score: 2.3, source: "Consumer review platforms rate 1.4/5 (25K+ reviews), app store ratings 4.7/5, community mixed, fee complaints dominate", sourceCount: 42000 },
     scoreDisclaimer: "Pulse score from 42,000+ data points",
     description: "Airbnb remains one of the strongest examples of emotional design in production. Browsing listings feels like exploring, not shopping. The map integration, photo presentation, and pricing transparency create a flow that's genuinely enjoyable. The booking flow is solid. Where points are lost: the host-side experience and the growing number of fees that erode trust at checkout.",
     strengths: [
@@ -241,7 +241,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.8,
     verdict: "Speed and keyboard-first design justify the premium",
     screenScore: { score: 3.8, source: "Product screenshots and email UI" },
-    pulseScore: { score: 3.8, source: "G2 4.6/5 (400+ reviews), Reddit positive, price complaints balanced by speed praise", sourceCount: 900 },
+    pulseScore: { score: 3.8, source: "Professional review platforms rate 4.6/5 (400+ reviews), community positive, price complaints balanced by speed praise", sourceCount: 900 },
     scoreDisclaimer: "Pulse score from 900+ data points",
     description: "Superhuman proved that email, the most commoditized software category, could be reimagined through speed and intentional design constraints. The keyboard-first model, combined with AI features that actually save time, creates an experience that makes free alternatives feel sluggish. The premium pricing is justified by the time saved.",
     strengths: [
@@ -264,7 +264,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.6,
     verdict: "Beautiful surfaces but navigation still costs effort",
     screenScore: { score: 3.6, source: "App screenshots and product UI" },
-    pulseScore: { score: 2.4, source: "App Store 2.4/5 (iOS), Reddit mixed, discovery complaints vs Spotify", sourceCount: 8500 },
+    pulseScore: { score: 2.4, source: "App store ratings 2.4/5 (iOS), community mixed, discovery complaints vs Spotify", sourceCount: 8500 },
     scoreDisclaimer: "Pulse score from 8,500+ data points",
     description: "Apple Music is visually polished. Every screen feels considered and premium. The typography, album art presentation, and spatial audio features are best-in-class. But navigation remains the weak point. Finding your library, managing playlists, and discovering new music all require more taps and more memory than they should. Beauty without friction reduction caps the score.",
     strengths: [
@@ -286,7 +286,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.6,
     verdict: "Enterprise complexity compressed into merchant-friendly flows",
     screenScore: { score: 3.6, source: "Admin dashboard screenshots" },
-    pulseScore: { score: 2.9, source: "G2 4.4/5 (4.5K reviews), Trustpilot 1.7/5 (6K+ reviews), App Store 4.3/5, merchant frustrations", sourceCount: 15000 },
+    pulseScore: { score: 2.9, source: "Professional review platforms rate 4.4/5 (4.5K reviews), consumer review platforms rate 1.7/5 (6K+ reviews), app store ratings 4.3/5, merchant frustrations", sourceCount: 15000 },
     scoreDisclaimer: "Pulse score from 15,000+ data points",
     description: "Shopify's admin panel manages an absurd amount of functionality (inventory, orders, shipping, analytics, marketing, apps) and keeps it navigable for merchants who aren't technical. The progressive disclosure model works: simple stores see simple tools, complex stores unlock complexity. The Polaris design system ensures consistency across a massive surface area.",
     strengths: [
@@ -309,7 +309,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.6,
     verdict: "Gamification done right: habit loops that actually teach",
     screenScore: { score: 3.6, source: "App screenshots and lesson UI" },
-    pulseScore: { score: 3.2, source: "App Store 4.7/5 (2.5M+ ratings), Reddit mixed on monetization, G2 4.5/5", sourceCount: 35000 },
+    pulseScore: { score: 3.2, source: "App store ratings 4.7/5 (2.5M+ ratings), community mixed on monetization, professional review platforms rate 4.5/5", sourceCount: 35000 },
     scoreDisclaimer: "Pulse score from 35,000+ data points",
     description: "Duolingo cracked the code on making daily practice feel like play rather than homework. The streak system, hearts model, and progression mechanics create genuine engagement. The visual design is playful without being childish. Where it falls short of a higher score: the actual language learning effectiveness plateaus for intermediate learners, and the monetization pressure has increased.",
     strengths: [
@@ -332,7 +332,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.5,
     verdict: "Dense but navigable: information architecture does the heavy lifting",
     screenScore: { score: 3.5, source: "Product UI and workflow screenshots" },
-    pulseScore: { score: 3.4, source: "G2 4.7/5 (12K reviews), Trustpilot 2.4/5 polarized, 2025 reliability crisis eroding trust", sourceCount: 50000 },
+    pulseScore: { score: 3.4, source: "Professional review platforms rate 4.7/5 (12K reviews), consumer review platforms rate 2.4/5 polarized, 2025 reliability crisis eroding trust", sourceCount: 50000 },
     scoreDisclaimer: "Pulse score from 50,000+ data points",
     description: "GitHub manages an enormous information space (code, issues, pull requests, actions, packages, discussions) and keeps it usable through strong information architecture rather than visual simplicity. It's dense by necessity. The score reflects that density is well-managed but rarely delightful; most workflows are functional and efficient without ever feeling effortless.",
     strengths: [
@@ -356,7 +356,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Discovery is strong but settings and library management lag behind",
     delta: -0.2,
     screenScore: { score: 3.5, source: "App screenshots and listening UI" },
-    pulseScore: { score: 2.8, source: "Trustpilot 1.6/5 (5K reviews), App Store 4.8/5, Reddit frustrated, ConsumerAffairs mixed", sourceCount: 5000000 },
+    pulseScore: { score: 2.8, source: "Consumer review platforms rate 1.6/5 (5K reviews), app store ratings 4.8/5, community frustrated, consumer complaint platforms mixed", sourceCount: 5000000 },
     scoreDisclaimer: "Pulse score from 5M+ data points",
     description: "Spotify's recommendation engine remains its strongest UX feature. Discover Weekly, Daily Mixes, and algorithmic playlists genuinely surface music people love. The listening experience itself is solid. The downward delta reflects increasing frustration with library management, settings buried behind too many taps, and podcast integration that clutters the music experience.",
     strengths: [
@@ -378,7 +378,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.4,
     verdict: "Feature bloat is winning the war against early simplicity",
     screenScore: { score: 3.4, source: "Product screenshots and workspace UI" },
-    pulseScore: { score: 3.6, source: "G2 4.5/5 (33K reviews, 96% positive), intuitive but notification fatigue caps it", sourceCount: 45000 },
+    pulseScore: { score: 3.6, source: "Professional review platforms rate 4.5/5 (33K reviews, 96% positive), intuitive but notification fatigue caps it", sourceCount: 45000 },
     scoreDisclaimer: "Pulse score from 45,000+ data points",
     description: "Slack's early genius was making work communication feel casual and fast. That simplicity is eroding. Huddles, Canvas, Clips, Workflow Builder, and the growing app ecosystem have added capability at the cost of focus. The core messaging experience is still good, but finding anything in a busy workspace now requires learned navigation patterns that new users struggle with.",
     strengths: [
@@ -401,7 +401,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.4,
     verdict: "Content discovery peaked years ago. The UI hasn't kept up",
     screenScore: { score: 3.4, source: "App screenshots and browsing UI" },
-    pulseScore: { score: 2.4, source: "Trustpilot 1.3/5 (25K+ reviews), App Store 3.8/5, Reddit frustrated with discovery/ads", sourceCount: 120000 },
+    pulseScore: { score: 2.4, source: "Consumer review platforms rate 1.3/5 (25K+ reviews), app store ratings 3.8/5, community frustrated with discovery/ads", sourceCount: 120000 },
     scoreDisclaimer: "Pulse score from 120,000+ data points",
     description: "Netflix defined streaming UX but hasn't meaningfully evolved in years. The row-based browsing model still works, autoplay previews are polarizing, and the 'Continue Watching' row remains both the most useful and most neglected feature. The viewing experience is solid. The content discovery experience is coasting.",
     strengths: [
@@ -423,7 +423,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.4,
     verdict: "Record-to-share in seconds: the core loop is pristine",
     screenScore: { score: 3.4, source: "Product screenshots and recording UI" },
-    pulseScore: { score: 3.2, source: "G2 4.7/5 (2.3K reviews), Trustpilot 2.5/5, core record-share loop earns Comfortable but Atlassian migration eroding trust", sourceCount: 3000 },
+    pulseScore: { score: 3.2, source: "Professional review platforms rate 4.7/5 (2.3K reviews), consumer review platforms rate 2.5/5, core record-share loop earns Comfortable but Atlassian migration eroding trust", sourceCount: 3000 },
     scoreDisclaimer: "Pulse score from 3,000+ data points",
     description: "Loom's core interaction (record screen, get shareable link) is one of the tightest product loops in SaaS. Three clicks from thought to shared video. Where the score is held back: the viewing experience, organization of recorded content, and workspace management all feel like they were designed after the core recording feature shipped.",
     strengths: [
@@ -445,7 +445,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.3,
     verdict: "Template-first approach democratizes design at scale",
     screenScore: { score: 3.3, source: "Product screenshots and editor UI" },
-    pulseScore: { score: 3.7, source: "G2 4.7/5 (6.9K reviews), App Store 4.9/5 (2.1M ratings), Trustpilot 2.3/5 (billing trap complaints)", sourceCount: 2100000 },
+    pulseScore: { score: 3.7, source: "Professional review platforms rate 4.7/5 (6.9K reviews), app store ratings 4.9/5 (2.1M ratings), consumer review platforms rate 2.3/5 (billing trap complaints)", sourceCount: 2100000 },
     scoreDisclaimer: "Pulse score from 18,000+ data points",
     description: "Canva solved a real problem: most people need to create visual content but can't use professional design tools. The template system, drag-and-drop editor, and brand kit features make that possible. The experience is friendly and approachable. What holds it back from a higher score is that power users quickly hit walls, and the editor can feel sluggish with complex designs.",
     strengths: [
@@ -467,7 +467,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.3,
     verdict: "Creative power with a steep on-ramp for non-designers",
     screenScore: { score: 3.3, source: "Product screenshots and website builder UI" },
-    pulseScore: { score: 3.4, source: "G2 4.5/5 (200+ reviews), designer-native workflow earns Comfortable, CMS gaps and pricing cap it", sourceCount: 1200 },
+    pulseScore: { score: 3.4, source: "Professional review platforms rate 4.5/5 (200+ reviews), designer-native workflow earns Comfortable, CMS gaps and pricing cap it", sourceCount: 1200 },
     scoreDisclaimer: "Pulse score from 1,200+ data points",
     description: "Framer has evolved from a prototyping tool into a genuine website builder that produces production-quality output. The visual editor is powerful, animations are impressive, and the published sites perform well. The gap: the learning curve is steep for anyone who isn't already a designer, and some common tasks require non-obvious interaction patterns.",
     strengths: [
@@ -489,7 +489,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.3,
     verdict: "Banking clarity that legacy institutions still can't match",
     screenScore: { score: 3.3, source: "App screenshots and banking UI" },
-    pulseScore: { score: 3.9, source: "Trustpilot 4.6/5 (59K reviews), App Store 4.9/5 (266K ratings), approaching Delightful", sourceCount: 325000 },
+    pulseScore: { score: 3.9, source: "Consumer review platforms rate 4.6/5 (59K reviews), app store ratings 4.9/5 (266K ratings), approaching Delightful", sourceCount: 325000 },
     scoreDisclaimer: "Pulse score from 8,000+ data points",
     description: "Monzo proved that banking apps don't have to feel like banking apps. Transaction categorization, instant notifications, and spending insights are presented with a clarity that makes legacy bank apps feel hostile by comparison. The experience falls short of higher levels because premium features are increasingly gated and the investment/savings products feel like different apps.",
     strengths: [
@@ -511,7 +511,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.2,
     verdict: "Business banking that feels consumer-grade in the best way",
     screenScore: { score: 3.2, source: "Dashboard screenshots and banking UI" },
-    pulseScore: { score: 3.2, source: "G2 4.5/5 (119 reviews), Trustpilot 3.7/5, account closure complaints", sourceCount: 1750 },
+    pulseScore: { score: 3.2, source: "Professional review platforms rate 4.5/5 (119 reviews), consumer review platforms rate 3.7/5, account closure complaints", sourceCount: 1750 },
     scoreDisclaimer: "Pulse score from 1,750+ data points",
     description: "Mercury brought consumer-grade design to business banking, a category that historically looked like it was designed in 2005. Account management, transactions, and treasury features are clean and navigable. The score reflects that while the core banking experience is strong, some workflows (multi-entity management, complex permissions) still require too many steps.",
     strengths: [
@@ -533,7 +533,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.2,
     verdict: "The booking flow is flawless. Everything around it is furniture",
     screenScore: { score: 3.2, source: "Booking flow and dashboard screenshots" },
-    pulseScore: { score: 3.2, source: "G2 4.7/5 (2.6K reviews), Trustpilot 3.0/5, core loop is Comfortable but broken defaults and support cap it", sourceCount: 3500 },
+    pulseScore: { score: 3.2, source: "Professional review platforms rate 4.7/5 (2.6K reviews), consumer review platforms rate 3.0/5, core loop is Comfortable but broken defaults and support cap it", sourceCount: 3500 },
     scoreDisclaimer: "Pulse score from 3,500+ data points",
     description: "Calendly's booker-facing experience is one of the best single-purpose flows in SaaS: see availability, pick a time, done. It's the gold standard for reducing a multi-step process to its minimum. The scheduler-facing dashboard, however, doesn't match that quality. Event type management, team settings, and analytics all feel like they were designed with less care.",
     strengths: [
@@ -555,7 +555,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.2,
     verdict: "Visual discovery remains best-in-class despite ad pressure",
     screenScore: { score: 3.2, source: "App screenshots and discovery UI" },
-    pulseScore: { score: 1.8, source: "Trustpilot 1.3/5, App Store mixed, Reddit frustrated with ad saturation and app-install walls", sourceCount: 25000 },
+    pulseScore: { score: 1.8, source: "Consumer review platforms rate 1.3/5, app store ratings mixed, community frustrated with ad saturation and app-install walls", sourceCount: 25000 },
     scoreDisclaimer: "Pulse score from 25,000+ data points",
     description: "Pinterest's masonry grid and visual search remain the best implementation of discovery-by-browsing on the web. The 'save to board' mental model is intuitive and sticky. What's pulling the score down: advertising is increasingly indistinguishable from organic content, and the balance between discovery and monetization is tilting toward the latter.",
     strengths: [
@@ -577,7 +577,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.1,
     verdict: "Conversational simplicity hides growing feature sprawl",
     screenScore: { score: 3.1, source: "Product screenshots and chat UI" },
-    pulseScore: { score: 2.8, source: "App Store 4.8/5, Reddit mixed on quality decline, Trustpilot 2.1/5, reliability complaints", sourceCount: 85000 },
+    pulseScore: { score: 2.8, source: "App store ratings 4.8/5, community mixed on quality decline, consumer review platforms rate 2.1/5, reliability complaints", sourceCount: 85000 },
     scoreDisclaimer: "Pulse score from 85,000+ data points",
     description: "ChatGPT's core interaction (type a question, get an answer) is one of the most intuitive product experiences in recent memory. The blank input box is inviting. The problem is everything that's been added around it: GPTs, plugins, memory settings, model selection, file uploads, image generation. Each feature individually makes sense; together they're creating navigation complexity that undermines the original simplicity.",
     strengths: [
@@ -599,7 +599,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.1,
     verdict: "Simplified investing with guardrails that sometimes patronize",
     screenScore: { score: 3.1, source: "App screenshots and trading UI" },
-    pulseScore: { score: 2.4, source: "App Store 4.3/5 (4.7M), Trustpilot 1.3/5 (4.2K), PissedConsumer 1.7/5, FINRA fines", sourceCount: 5300000 },
+    pulseScore: { score: 2.4, source: "App store ratings 4.3/5 (4.7M), consumer review platforms rate 1.3/5 (4.2K), consumer complaint platforms rate 1.7/5, regulatory actions", sourceCount: 5300000 },
     scoreDisclaimer: "Pulse score from 5.3M+ data points",
     description: "Robinhood succeeded at making investing feel approachable. The clean interface, confetti celebrations, and simplified flows brought millions of new investors into the market. The design challenge now is that those same simplifications can feel patronizing as users become more sophisticated, and the addition of crypto, options, and cash management has added complexity without proportional design investment.",
     strengths: [
@@ -621,7 +621,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 3.0,
     verdict: "Immense power behind a UI that asks too much of newcomers",
     screenScore: { score: 3.0, source: "Product screenshots and designer UI" },
-    pulseScore: { score: 2.8, source: "G2 4.4/5 (946 reviews), Trustpilot 1.5/5, community open letter on stability crisis", sourceCount: 3300 },
+    pulseScore: { score: 2.8, source: "Professional review platforms rate 4.4/5 (946 reviews), consumer review platforms rate 1.5/5, community open letter on stability crisis", sourceCount: 3300 },
     scoreDisclaimer: "Pulse score from 3,300+ data points",
     description: "Webflow is probably the most powerful no-code website builder available. It can produce genuinely professional websites with complex interactions, CMS-driven content, and e-commerce. The score reflects a tension: experts love it, beginners bounce. The learning curve is the product's biggest liability and its biggest moat.",
     strengths: [
@@ -644,7 +644,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Onboarding is solid but the product grows confusing fast",
     delta: -0.3,
     screenScore: { score: 2.9, source: "Product screenshots and trading UI" },
-    pulseScore: { score: 2.7, source: "App Store 4.7/5, Trustpilot 1.5/5 (11K reviews), BBB 1.1/5, fee and support complaints", sourceCount: 50000 },
+    pulseScore: { score: 2.7, source: "App store ratings 4.7/5, consumer review platforms rate 1.5/5 (11K reviews), consumer advocacy platforms rate 1.1/5, fee and support complaints", sourceCount: 50000 },
     scoreDisclaimer: "Pulse score from 50,000+ data points",
     description: "Coinbase's onboarding and initial purchase flow are clean. Buying your first crypto is straightforward. The experience degrades from there. The addition of DeFi features, NFTs, staking, and Coinbase Wallet has created a product that serves too many audiences without a coherent experience for any of them. The downward delta reflects recent UI changes that added complexity without solving existing navigation problems.",
     strengths: [
@@ -666,7 +666,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.9,
     verdict: "Spreadsheet flexibility with enterprise-grade confusion",
     screenScore: { score: 2.9, source: "Product screenshots and database UI" },
-    pulseScore: { score: 2.7, source: "G2 4.5/5 (2.3K reviews), Trustpilot 2.4/5, Reddit mixed on performance", sourceCount: 5000 },
+    pulseScore: { score: 2.7, source: "Professional review platforms rate 4.5/5 (2.3K reviews), consumer review platforms rate 2.4/5, community mixed on performance", sourceCount: 5000 },
     scoreDisclaimer: "Pulse score from 5,000+ data points",
     description: "Airtable's pitch (a database that feels like a spreadsheet) is genuinely compelling when it works. Views, automations, and the interface designer enable powerful workflows. The problem: the gap between 'this is a nice spreadsheet' and 'this is a powerful app platform' creates confusion about what Airtable even is. Enterprise features have added layers that the core interaction model wasn't designed to support.",
     strengths: [
@@ -688,7 +688,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.8,
     verdict: "Output quality masks an interface that's barely held together",
     screenScore: { score: 2.8, source: "Web app screenshots and generation UI" },
-    pulseScore: { score: 3.2, source: "G2 4.4/5 (94 reviews), Trustpilot 2.0/5, Reddit/Discord 65% positive on output quality", sourceCount: 550 },
+    pulseScore: { score: 3.2, source: "Professional review platforms rate 4.4/5 (94 reviews), consumer review platforms rate 2.0/5, community forums 65% positive on output quality", sourceCount: 550 },
     scoreDisclaimer: "Pulse score from 550+ data points",
     description: "Midjourney produces the best AI-generated images available. The output is stunning. The interface (originally Discord-only, now a web app) is not. The web experience is functional but feels like it was designed by engineers solving technical problems rather than designers solving human ones. The score reflects that output quality and interface quality are two different things.",
     strengths: [
@@ -710,7 +710,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.8,
     verdict: "Community power undermined by settings complexity",
     screenScore: { score: 2.8, source: "Product screenshots and server UI" },
-    pulseScore: { score: 3.4, source: "Capterra 4.7/5, App Store 4.8/5 (232K), Trustpilot 1.2/5 (2K), Google Play 4.3/5 (6.3M)", sourceCount: 6600000 },
+    pulseScore: { score: 3.4, source: "Enterprise review platforms rate 4.7/5, app store ratings 4.8/5 (232K), consumer review platforms rate 1.2/5 (2K), app store ratings 4.3/5 (6.3M)", sourceCount: 6600000 },
     scoreDisclaimer: "Pulse score from 6.6M+ data points",
     description: "Discord's core value, real-time community communication, is strong. Voice channels, text channels, and the server model create genuine community infrastructure. But the settings are bewildering: server settings, channel settings, notification settings, privacy settings, each with dozens of options. For a product used by millions of non-technical users, the configuration complexity is a serious accessibility issue.",
     strengths: [
@@ -732,7 +732,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.7,
     verdict: "The core meeting is reliable. Everything else feels bolted on",
     screenScore: { score: 2.7, source: "Product screenshots and meeting UI" },
-    pulseScore: { score: 3.2, source: "G2 4.5/5 (55.7K reviews), Trustpilot 1.4/5 (78% one-star), Workplace redesign friction", sourceCount: 56000 },
+    pulseScore: { score: 3.2, source: "Professional review platforms rate 4.5/5 (55.7K reviews), consumer review platforms rate 1.4/5 (78% one-star), Workplace redesign friction", sourceCount: 56000 },
     scoreDisclaimer: "Pulse score from 56,000+ data points",
     description: "Zoom's core meeting experience is reliable and familiar. That's its strength and its ceiling. Joining a meeting is easy. Being in a meeting works. Everything Zoom has added since (Zoom Phone, Zoom Whiteboard, Zoom Chat, Zoom Mail) feels like it belongs to a different product with a different design team. The experience is fragmented.",
     strengths: [
@@ -754,7 +754,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.6,
     verdict: "Viewer experience is strong but creator tools are a maze",
     screenScore: { score: 2.6, source: "Product screenshots and streaming UI" },
-    pulseScore: { score: 2.1, source: "Trustpilot 1.3/5 (1.1K reviews), Google Play 3.95/5 (5.3M), broken mobile/TV apps, hostile ads", sourceCount: 5300000 },
+    pulseScore: { score: 2.1, source: "Consumer review platforms rate 1.3/5 (1.1K reviews), app store ratings 3.95/5 (5.3M), broken mobile/TV apps, hostile ads", sourceCount: 5300000 },
     scoreDisclaimer: "Pulse score from 15,000+ data points",
     description: "Watching a stream on Twitch is a good experience. The player is solid, chat is engaging, and discovery has improved. Creating on Twitch is a different story. The creator dashboard, monetization settings, moderation tools, and analytics are spread across interfaces that feel like they were designed by different teams in different years. The viewer/creator gap is the defining UX problem.",
     strengths: [
@@ -776,7 +776,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.5,
     verdict: "The product that defined cloud storage now struggles to justify itself",
     screenScore: { score: 2.5, source: "Product screenshots and file management UI" },
-    pulseScore: { score: 2.6, source: "G2 4.4/5 (38.4K reviews), Trustpilot 1.3/5 (1.5K), billing complaints, forced upgrades", sourceCount: 40000 },
+    pulseScore: { score: 2.6, source: "Professional review platforms rate 4.4/5 (38.4K reviews), consumer review platforms rate 1.3/5 (1.5K), billing complaints, forced upgrades", sourceCount: 40000 },
     scoreDisclaimer: "Pulse score from 40,000+ data points",
     description: "Dropbox invented a category and then watched the category commoditize around it. The core sync experience is still reliable, but the product has been unable to articulate why you'd choose it over Google Drive, iCloud, or OneDrive, which come free with products you already use. Recent additions (Paper, Capture, Sign) feel disconnected. The interface works; the product story doesn't.",
     strengths: [
@@ -798,7 +798,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 2.1,
     verdict: "More process than product: the UI serves the methodology, not the human",
     screenScore: { score: 2.1, source: "Product screenshots and project management UI" },
-    pulseScore: { score: 2.1, source: "G2 4.3/5 (7.5K reviews), Reddit/HN overwhelmingly negative UX, 86% market lock-in", sourceCount: 15000 },
+    pulseScore: { score: 2.1, source: "Professional review platforms rate 4.3/5 (7.5K reviews), community and developer forums overwhelmingly negative UX, 86% market lock-in", sourceCount: 15000 },
     scoreDisclaimer: "Pulse score from 15,000+ data points",
     description: "Jira is powerful. Jira is also the canonical example of enterprise software that prioritizes process configuration over user experience. The interface serves Scrum and Kanban methodologies before it serves the humans using it. Every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Power at the cost of usability.",
     strengths: [
@@ -821,7 +821,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     verdict: "Power under layers of UI debt that would take a decade to repay",
     delta: -0.1,
     screenScore: { score: 1.8, source: "Product screenshots and CRM UI" },
-    pulseScore: { score: 2.2, source: "G2 4.4/5 (25.5K reviews), 200-field forms, 'How has Salesforce gotten away with such terrible UX?' (Quora)", sourceCount: 94000 },
+    pulseScore: { score: 2.2, source: "Professional review platforms rate 4.4/5 (25.5K reviews), 200-field forms, 'How has Salesforce gotten away with such terrible UX?' (Q&A forums)", sourceCount: 94000 },
     scoreDisclaimer: "Pulse score from 25,000+ data points",
     description: "Salesforce is the most powerful CRM platform in the world and one of the worst user experiences in enterprise software. The Lightning redesign improved surface-level aesthetics but didn't address the fundamental information architecture problems. Navigation is labyrinthine, customization creates inconsistency, and the simplest tasks require too many clicks. Users don't choose Salesforce for its UX; they tolerate its UX for its capability.",
     strengths: [
@@ -843,7 +843,7 @@ const RAW_PRODUCTS: Omit<Product, "rank">[] = [
     score: 1.6,
     verdict: "Enterprise software that treats its users as an afterthought",
     screenScore: { score: 1.6, source: "Product screenshots and HR/finance UI" },
-    pulseScore: { score: 1.4, source: "G2 4.2/5 (2.8K reviews), Yahoo News 'most hated workplace software', Team Blind/Reddit universal hatred", sourceCount: 5000 },
+    pulseScore: { score: 1.4, source: "Professional review platforms rate 4.2/5 (2.8K reviews), media coverage 'most hated workplace software', employee platforms and community universal hatred", sourceCount: 5000 },
     scoreDisclaimer: "Pulse score from 5,000+ data points",
     description: "Workday is the product most people point to when they talk about why enterprise software has a bad reputation. The interface is functional in the strictest sense. You can complete tasks, but every interaction requires more effort than it should. Finding information requires memorizing navigation paths. Basic tasks like submitting time off or finding a pay stub involve more clicks than they do on any consumer app. The score reflects that users endure Workday; they don't use it.",
     strengths: [

--- a/src/app/top-100/page.tsx
+++ b/src/app/top-100/page.tsx
@@ -59,8 +59,7 @@ export default function Top100Page() {
             digital experience quality.
           </h1>
           <p className="text-base text-body max-w-xl mx-auto leading-relaxed">
-            Ladder Pulse scans thousands of sources, including G2, Reddit, Trustpilot,
-            App Store, Hacker News, and Product Hunt, then combines that
+            Ladder Pulse scans 3,000+ online sources, then combines that
             intelligence with interface analysis to produce one score no other
             system can. No sponsorships. No paid placements. Just the truth.
           </p>
@@ -253,7 +252,7 @@ export default function Top100Page() {
           {[
             {
               title: "Pulse Intelligence",
-              body: "Pulse ingests thousands of data points per product from G2, Capterra, Trustpilot, App Store, Reddit, Hacker News, Product Hunt, and community forums. Our AI maps every signal to the Ladder framework's five levels of experience quality. This is the lived experience score.",
+              body: "Pulse ingests thousands of data points per product from 3,000+ online sources. Our AI maps every signal to the Ladder framework's five levels of experience quality. This is the lived experience score. Ladder Pulse subscribers can also feed internal data: support tickets, NPS responses, field reports, employee surveys, and more.",
             },
             {
               title: "Screen Score",


### PR DESCRIPTION
## Summary
Removes all specific platform names (G2, Reddit, Trustpilot, App Store, Hacker News, Product Hunt, Capterra, etc.) from Pulse data source descriptions across the entire site.

**New language:**
- Public: "3,000+ online sources" / "professional review platforms" / "community forums" / "app store ratings"
- Subscriber internal: support tickets, NPS responses, field reports, employee surveys, customer interviews, CSAT data, in-app feedback, churn interviews

**Files changed:**
- `data.ts` — 36 product pulseScore.source fields genericized
- `posts.ts` — 22 edits across 13 blog posts
- `top-100/page.tsx` — hero text + methodology card
- `top-100/[slug]/page.tsx` — pending Pulse text
- `pulse/page.tsx` — signal sources grid (now leads with "3,000+ online sources", internal sources marked as subscriber-only)

## Test plan
- [x] `npx next build` passes
- [ ] Grep for "G2" / "Reddit" / "Trustpilot" in tsx/ts files returns zero hits
- [ ] Product detail pages display genericized source text
- [ ] Blog posts read naturally without specific platform names


🤖 Generated with [Claude Code](https://claude.com/claude-code)