### PR TITLE
Polish pricing: green rings, seat info, Pulse cleanup

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -42,14 +42,15 @@ const SCREEN_SCORE_TIERS = [
     name: "Team",
     price: "$500",
     period: "/ mo",
-    periodNote: "Up to 5 team members \u00b7 $100 / additional seat",
     highlight: false,
     limit: "Unlimited everything",
     features: [
       "Everything in Professional",
+      "Up to 5 team members, $100 / additional seat",
       "Team leaderboard + portfolio score",
       "Design system compliance scoring",
       "Manager dashboard + performance tracking",
+      "Access to Pulse data if subscribed",
     ],
     cta: "Subscribe",
     href: "/score",
@@ -96,7 +97,7 @@ export default function PricingPage() {
               className={`rounded-2xl p-8 flex flex-col ${
                 tier.highlight
                   ? "border-2 border-ladder-green bg-ladder-green/5"
-                  : "border border-border bg-card"
+                  : "border-2 border-ladder-green/30 bg-card"
               }`}
             >
               {/* Name */}
@@ -111,11 +112,7 @@ export default function PricingPage() {
                 </span>
                 <span className="text-sm text-muted">{tier.period}</span>
               </div>
-              {tier.periodNote ? (
-                <p className="text-xs text-muted mb-6">{tier.periodNote}</p>
-              ) : (
-                <div className="mb-6" />
-              )}
+              <div className="mb-6" />
 
               {/* Usage limit */}
               <div className="border border-border rounded-lg px-4 py-3 mb-8">
@@ -166,7 +163,7 @@ export default function PricingPage() {
               </span>
               <span className="text-sm text-muted">/ mo</span>
             </div>
-            <p className="text-xs text-muted mb-6">Custom pricing at scale</p>
+            <div className="mb-6" />
 
             {/* Usage limit */}
             <div className="border border-ladder-purple/30 rounded-lg px-4 py-3 mb-8">


### PR DESCRIPTION
## Summary
- Removed "Custom pricing at scale" from Pulse column
- Moved seat pricing ("Up to 5 team members, $100 / additional seat") into Team features list
- Added "Access to Pulse data if subscribed" as a Team feature bullet
- Free and Team columns now have a green border ring (border-ladder-green/30) for higher contrast

## Test plan
- [ ] Free and Team cards have visible green border ring
- [ ] Professional card retains solid green border (unchanged)
- [ ] Pulse card retains purple border (unchanged)
- [ ] No "Custom pricing at scale" text under Pulse price
- [ ] Team features list shows seat pricing and Pulse data access bullets

Generated with [Claude Code](https://claude.com/claude-code)