### PR TITLE
Auth-aware score page with privacy toggle and delete

### DIFF
--- a/src/app/api/dashboard/scores/route.ts
+++ b/src/app/api/dashboard/scores/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { redis } from "@/lib/redis";
+
+export async function DELETE(req: NextRequest) {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { scoreId } = await req.json();
+  if (!scoreId) {
+    return NextResponse.json({ error: "scoreId required" }, { status: 400 });
+  }
+
+  // Find and remove the score entry from the sorted set
+  const scores = await redis.zrange(`user:${userId}:scores`, 0, -1);
+
+  for (const entry of scores) {
+    const str = typeof entry === "string" ? entry : JSON.stringify(entry);
+    try {
+      const parsed = JSON.parse(str);
+      if (parsed.id === scoreId) {
+        await redis.zrem(`user:${userId}:scores`, str);
+        return NextResponse.json({ success: true });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return NextResponse.json({ error: "Score not found" }, { status: 404 });
+}

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -139,7 +139,7 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const { image, source } = body;
+    const { image, source, isPublic } = body;
 
     if (!image || typeof image !== "string") {
       return NextResponse.json(
@@ -285,6 +285,7 @@ export async function POST(req: NextRequest) {
         label: result.label,
         summary: result.summary,
         source: source || "upload",
+        isPublic: !!isPublic,
         timestamp: Date.now(),
       };
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -59,6 +59,7 @@ export default function DashboardPage() {
   const { isSignedIn, isLoaded } = useAuth();
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [deleting, setDeleting] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isSignedIn) return;
@@ -79,6 +80,27 @@ export default function DashboardPage() {
 
     fetchData();
   }, [isSignedIn]);
+
+  async function deleteScore(scoreId: string) {
+    setDeleting(scoreId);
+    try {
+      const res = await fetch("/api/dashboard/scores", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scoreId }),
+      });
+      if (res.ok && data) {
+        setData({
+          ...data,
+          scores: data.scores.filter((s) => s.id !== scoreId),
+        });
+      }
+    } catch {
+      // Silently fail
+    } finally {
+      setDeleting(null);
+    }
+  }
 
   if (!isLoaded) return null;
   if (!isSignedIn) return <RedirectToSignIn />;
@@ -201,10 +223,22 @@ export default function DashboardPage() {
                       <p className="text-xs text-muted font-sans mt-1 truncate">{entry.summary}</p>
                     </div>
 
-                    {/* Time */}
-                    <span className="text-[10px] text-[#444] flex-shrink-0">
-                      {timeAgo(entry.timestamp)}
-                    </span>
+                    {/* Time + delete */}
+                    <div className="flex items-center gap-3 flex-shrink-0">
+                      <span className="text-[10px] text-[#444]">
+                        {timeAgo(entry.timestamp)}
+                      </span>
+                      <button
+                        onClick={() => deleteScore(entry.id)}
+                        disabled={deleting === entry.id}
+                        className="text-[#444] hover:text-ladder-red transition-colors disabled:opacity-30"
+                        title="Delete score"
+                      >
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                          <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14" />
+                        </svg>
+                      </button>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useAuth } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
@@ -166,6 +167,7 @@ function timeAgo(ts: number): string {
 }
 
 export default function ScorePage() {
+  const { isSignedIn, isLoaded } = useAuth();
   const [image, setImage] = useState<string | null>(null);
   const [fileName, setFileName] = useState<string>("");
   const [urlInput, setUrlInput] = useState("");
@@ -178,6 +180,7 @@ export default function ScorePage() {
   const [scanPhase, setScanPhase] = useState(0);
   const [isDragOver, setIsDragOver] = useState(false);
   const [pastScores, setPastScores] = useState<PastScore[]>([]);
+  const [isPublic, setIsPublic] = useState(false);
   const fileRef = useRef<HTMLInputElement>(null);
 
   // Load past scores on mount
@@ -289,7 +292,7 @@ export default function ScorePage() {
       const res = await fetch("/api/score", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ image: imageToScore, source: fileName || "Upload" }),
+        body: JSON.stringify({ image: imageToScore, source: fileName || "Upload", isPublic }),
       });
       const text = await res.text();
       let data;
@@ -401,15 +404,39 @@ export default function ScorePage() {
                 <p className="text-[11px] text-muted tracking-wide">
                   PNG / JPG / WebP &middot; up to 10MB
                 </p>
-                <p className="text-[10px] text-[#555] mt-4 max-w-xs mx-auto leading-relaxed">
-                  By scoring, you agree to our{" "}
-                  <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Terms</a>{" "}
-                  and{" "}
-                  <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Privacy Policy</a>.
-                  Free scores may be published on runladder.com.{" "}
-                  <a href="/pricing" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Upgrade</a>{" "}
-                  for private evaluations.
-                </p>
+                {isLoaded && isSignedIn ? (
+                  <div className="mt-4 max-w-sm mx-auto">
+                    <div className="flex items-center justify-center gap-3 mb-2">
+                      <button
+                        onClick={(e) => { e.stopPropagation(); setIsPublic(!isPublic); }}
+                        className={`relative w-8 h-[18px] rounded-full transition-colors ${
+                          isPublic ? "bg-ladder-green" : "bg-[#333]"
+                        }`}
+                      >
+                        <span className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${
+                          isPublic ? "left-[16px]" : "left-[2px]"
+                        }`} />
+                      </button>
+                      <span className="text-[10px] text-[#555]">
+                        {isPublic ? "Public score — visible on runladder.com" : "Private score — only you can see this"}
+                      </span>
+                    </div>
+                    <p className="text-[10px] text-[#444] leading-relaxed text-center">
+                      Signed in. Scores saved to your{" "}
+                      <a href="/dashboard" className="text-ladder-green hover:text-ladder-green/80 transition-colors">dashboard</a>.
+                    </p>
+                  </div>
+                ) : (
+                  <p className="text-[10px] text-[#555] mt-4 max-w-xs mx-auto leading-relaxed">
+                    By scoring, you agree to our{" "}
+                    <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Terms</a>{" "}
+                    and{" "}
+                    <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Privacy Policy</a>.
+                    Free scores may be published on runladder.com.{" "}
+                    <a href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Sign in</a>{" "}
+                    for private scoring.
+                  </p>
+                )}
               </div>
               <input
                 ref={fileRef}


### PR DESCRIPTION
## Summary
- Signed-in users see "Private score — only you can see this" with a toggle to make public
- Anonymous users see terms/privacy notice with sign-in prompt
- Scores stored with `isPublic` flag in Redis
- New DELETE endpoint at `/api/dashboard/scores` for removing scores
- Dashboard score rows now have delete buttons

## Test plan
- [ ] Visit /score logged out — should see public terms notice
- [ ] Visit /score logged in — should see private/public toggle
- [ ] Toggle to public — text should change to "visible on runladder.com"
- [ ] Score a screen — should save to dashboard
- [ ] Delete a score from dashboard — should remove from list

Generated with [Claude Code](https://claude.com/claude-code)