### PR TITLE
Dashboard thumbnails and AI screen names

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -47,6 +47,7 @@ RESPONSE FORMAT — Return ONLY valid JSON, no markdown:
 {
   "score": 2.4,
   "label": "Usable",
+  "screenName": "Product Name — Screen Type",
   "summary": "One honest sentence describing the user experience",
   "next": "One specific action to move to the next level",
   "rungs": {
@@ -80,6 +81,12 @@ RUNG SCORING RULES:
 - "functional" = do basic tasks work? Can the user find and use the core feature?
 - The total "score" should reflect the weighted combination — functional failures weigh more than absent delight.
 - Provide a one-sentence summary per rung, from the user's perspective.
+
+SCREEN NAME RULES:
+- "screenName" identifies the product and screen type, e.g. "ESPN — Homepage", "Figma — Canvas Editor", "Airbnb — Search Results", "Stripe — Dashboard"
+- If you can identify the brand/product, use its real name. If not, describe what it is: "Banking App — Transaction History", "E-commerce — Product Detail"
+- Format: "Product Name — Screen Type" (use an em dash)
+- Keep it short: max 6 words total
 
 FINDING RULES:
 - Return exactly 4 findings, ranked by impact (highest uplift first)
@@ -139,7 +146,7 @@ export async function POST(req: NextRequest) {
     }
 
     const body = await req.json();
-    const { image, source, isPublic } = body;
+    const { image, source, isPublic, thumbnail } = body;
 
     if (!image || typeof image !== "string") {
       return NextResponse.json(
@@ -283,8 +290,10 @@ export async function POST(req: NextRequest) {
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         score: result.score,
         label: result.label,
+        screenName: result.screenName || source || "upload",
         summary: result.summary,
         source: source || "upload",
+        thumbnail: typeof thumbnail === "string" ? thumbnail.slice(0, 50000) : undefined,
         isPublic: !!isPublic,
         timestamp: Date.now(),
       };
@@ -316,7 +325,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    return NextResponse.json(result);
+    return NextResponse.json({ ...result, screenName: result.screenName || source || "Screen" });
   } catch (err) {
     console.error("[LADDER:ERROR] Score endpoint:", err);
     return NextResponse.json(

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -9,8 +9,10 @@ type ScoreEntry = {
   id: string;
   score: number;
   label: string;
+  screenName?: string;
   summary: string;
   source: string;
+  thumbnail?: string;
   timestamp: number;
 };
 
@@ -200,9 +202,20 @@ export default function DashboardPage() {
                   key={entry.id}
                   className="border border-[#333] bg-[#1e1e1e] p-5 hover:border-muted transition-colors"
                 >
-                  <div className="flex items-center gap-6">
+                  <div className="flex items-center gap-5">
+                    {/* Thumbnail */}
+                    {entry.thumbnail ? (
+                      <div className="flex-shrink-0 w-16 h-16 border border-[#333] bg-[#111] overflow-hidden">
+                        <img src={entry.thumbnail} alt="" className="w-full h-full object-cover object-top" />
+                      </div>
+                    ) : (
+                      <div className="flex-shrink-0 w-16 h-16 border border-[#333] bg-[#111] flex items-center justify-center">
+                        <span className="text-[#333] text-xs">--</span>
+                      </div>
+                    )}
+
                     {/* Score */}
-                    <div className="flex-shrink-0 w-16 text-center">
+                    <div className="flex-shrink-0 w-14 text-center">
                       <span
                         className="text-2xl font-bold tabular-nums"
                         style={{ color: getScoreColor(entry.score) }}
@@ -219,7 +232,7 @@ export default function DashboardPage() {
 
                     {/* Details */}
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm text-foreground font-sans truncate">{entry.source}</p>
+                      <p className="text-sm text-foreground font-sans truncate">{entry.screenName || entry.source}</p>
                       <p className="text-xs text-muted font-sans mt-1 truncate">{entry.summary}</p>
                     </div>
 

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -133,6 +133,28 @@ function ShareButtons({ score, label, summary }: { score: number; label: string;
   );
 }
 
+/* ── Generate a small thumbnail from a data URL ── */
+function generateThumbnail(dataUrl: string, maxWidth = 200): Promise<string> {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => {
+      const canvas = document.createElement("canvas");
+      const ratio = Math.min(maxWidth / img.width, maxWidth / img.height);
+      canvas.width = img.width * ratio;
+      canvas.height = img.height * ratio;
+      const ctx = canvas.getContext("2d");
+      if (ctx) {
+        ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+        resolve(canvas.toDataURL("image/jpeg", 0.6));
+      } else {
+        resolve("");
+      }
+    };
+    img.onerror = () => resolve("");
+    img.src = dataUrl;
+  });
+}
+
 /* ── Past scores from localStorage ── */
 function loadPastScores(): PastScore[] {
   if (typeof window === "undefined") return [];
@@ -289,10 +311,13 @@ export default function ScorePage() {
     }, 2200);
 
     try {
+      // Generate thumbnail for dashboard storage
+      const thumb = await generateThumbnail(imageToScore);
+
       const res = await fetch("/api/score", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ image: imageToScore, source: fileName || "Upload", isPublic }),
+        body: JSON.stringify({ image: imageToScore, source: fileName || "Upload", isPublic, thumbnail: thumb }),
       });
       const text = await res.text();
       let data;


### PR DESCRIPTION
## Summary
- Scoring prompt now identifies screen name (e.g. "ESPN — Homepage" instead of "Screenshot 2026-04-01 at 11.52.10 AM.png")
- Client generates a 200px JPEG thumbnail before scoring and sends it with the request
- Thumbnail and screenName stored in Redis alongside score data
- Dashboard displays thumbnail preview and real screen name for each score entry

## Test plan
- [ ] Score a screen — dashboard should show thumbnail and identified name
- [ ] Verify thumbnail is small (~5-15KB JPEG, not the full image)
- [ ] Verify screenName identifies the product (e.g. "Figma — Canvas" not "upload")

Generated with [Claude Code](https://claude.com/claude-code)