### PR TITLE
Remove Figma, gate Pro features, add score page promo

### DIFF
--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -376,7 +376,7 @@ But there are two fundamentally different ways to arrive at that number. And und
 
 A Screen Score is what you get when you drop a screenshot into Ladder. Our AI evaluates the interface against the [five levels of the Ladder framework](/framework): visual hierarchy, layout patterns, spacing, interaction design, accessibility, feedback, and information architecture. It scores what a user sees the moment they land.
 
-Screen Scores are fast. You can score any screen in seconds through [runladder.com](/score), the Figma plugin, or the API. No user research required. No data collection. Just the interface, evaluated honestly.
+Screen Scores are fast. You can score any screen in seconds through [runladder.com](/score) or the API. No user research required. No data collection. Just the interface, evaluated honestly.
 
 A Screen Score answers: *does this interface look and function like it respects the user's time?*
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -148,7 +148,10 @@ export default function DashboardPage() {
           >
             <span className="text-[10px] text-ladder-green uppercase tracking-widest font-semibold">Pro</span>
             <span className="text-[11px] text-muted font-sans group-hover:text-foreground transition-colors">
-              Unlimited scores, private, per-dimension scoring
+              Unlimited scores, private, per-dimension scoring, a11y audit, UX copy
+            </span>
+            <span className="text-[9px] text-[#555] font-sans">
+              + Figma plugin coming soon
             </span>
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#6AC89B" strokeWidth="2" className="flex-shrink-0">
               <path d="M5 12h14M12 5l7 7-7 7" />

--- a/src/app/organizations/page.tsx
+++ b/src/app/organizations/page.tsx
@@ -411,14 +411,13 @@ export default function OrganizationsPage() {
               <p className="text-body leading-relaxed">
                 Ladder isn&apos;t a destination. It&apos;s a layer that sits
                 on top of your existing tools and workflows. Designers score
-                screens in Figma. PMs track trends on the dashboard. Leadership
+                screens on the web. PMs track trends on the dashboard. Leadership
                 pairs Screen Scores with Pulse Scores to see the full picture.
               </p>
             </div>
             <div className="space-y-4">
               {[
                 { surface: "runladder.com", desc: "Upload a screenshot and get a score in seconds. No installs, no configuration." },
-                { surface: "Ladder for Figma", desc: "Score screens without leaving your design tool. Built into the workflow designers already use." },
                 { surface: "Ladder for Claude", desc: "Get a quality check mid-conversation. Know if what you generated is a 2.1 or a 3.8 before anyone else sees it." },
                 { surface: "Ladder Pulse", desc: "Turn customer feedback, support logs, and field reports into a quality score that tracks real experience." },
               ].map((s) => (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,12 +47,6 @@ const PRODUCTS = [
     cta: "Score a screen free",
   },
   {
-    name: "Ladder for Figma",
-    desc: "Stop designing in the dark. Know your Ladder score before you hand off, so you never ship something that looks done but feels broken.",
-    href: "/products",
-    cta: "Install the plugin",
-  },
-  {
     name: "Ladder Pulse",
     desc: "Every organization generates signals: customer reviews, field reports, internal ops feedback, support logs. Pulse turns all of it into a quality score that tracks whether the people you serve are actually better off.",
     href: "/pulse",
@@ -361,8 +355,8 @@ export default function Home() {
               <span className="text-ladder-green">Everywhere.</span>
             </h2>
             <p className="text-body max-w-lg mx-auto leading-relaxed">
-              Score in your browser, in Figma, in Claude, from customer feedback,
-              or through the API. Every score feeds the same account, the same
+              Score in your browser, in Claude, or from customer feedback.
+              Every score feeds the same account, the same
               history, the same dashboard.
             </p>
           </div>

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -16,9 +16,7 @@ const SCREEN_SCORE_TIERS = [
     limit: "5 scores / month",
     features: [
       "Overall Ladder score + coaching",
-      "UX copy suggestions",
-      "Accessibility audit",
-      "Web, Figma, or Claude",
+      "Web or Claude",
       "Scores may be published publicly",
     ],
     cta: "Start free",
@@ -33,6 +31,8 @@ const SCREEN_SCORE_TIERS = [
     features: [
       "Everything in Free",
       "All scores are private",
+      "UX copy suggestions",
+      "Accessibility audit",
       "Per-dimension scoring (hierarchy, spacing, copy, a11y, navigation, visual)",
       "Full score history + trend line",
       "Fix suggestions with score uplift",
@@ -70,7 +70,7 @@ export default function PricingPage() {
             Simple pricing. Score your first screen free.
           </h1>
           <p className="text-body max-w-lg mx-auto leading-relaxed">
-            One subscription works across every Ladder surface: web, Figma,
+            One subscription works across every Ladder surface: web
             and Claude. Start free, upgrade when you need more.
           </p>
         </div>
@@ -256,7 +256,7 @@ export default function PricingPage() {
               },
               {
                 q: "Does one subscription cover all surfaces?",
-                a: "Yes. Your Ladder account works on runladder.com, in the Figma plugin, and the Claude Skill. One subscription, one usage meter.",
+                a: "Yes. Your Ladder account works on runladder.com and the Claude Skill. One subscription, one usage meter.",
               },
               {
                 q: "What counts as a score?",

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -21,7 +21,7 @@ export default function PrivacyPage() {
             <p>
               This Privacy Policy explains how Drawbackwards LLC ("we", "us",
               "our") collects, uses, and protects your information when you use
-              Ladder, including runladder.com, Ladder for Figma, Ladder for Claude,
+              Ladder, including runladder.com, Ladder for Claude,
               the Ladder API, and Ladder Pulse (collectively, the "Service").
             </p>
           </section>
@@ -152,14 +152,6 @@ export default function PrivacyPage() {
                   <strong className="text-foreground">runladder.com:</strong>{" "}
                   Content is submitted directly to our servers. Screenshots may be
                   captured via our URL capture service.
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-ladder-green mt-0.5">+</span>
-                <span>
-                  <strong className="text-foreground">Ladder for Figma:</strong>{" "}
-                  Selected frames are sent from the Figma plugin to our API for
-                  scoring. We receive the image data but not your full Figma file.
                 </span>
               </li>
               <li className="flex items-start gap-2">

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Products | Ladder",
   description:
-    "One quality score across every surface. Score in your browser, in Figma, from customer feedback, or through Claude.",
+    "One quality score across every surface. Score in your browser, from customer feedback, or through Claude.",
 };
 
 const SURFACES = [
@@ -23,23 +23,6 @@ const SURFACES = [
     ],
     cta: "Score a screen free",
     href: "/score",
-    available: true,
-  },
-  {
-    name: "Ladder for Figma",
-    badge: "Plugin",
-    tagline: "Know your score before you hand off.",
-    description:
-      "Score any frame while you design. The plugin sees your actual layout, typography, color, spacing, and hierarchy, then scores it against the Ladder framework in context. Stop shipping screens that look done but feel broken.",
-    features: [
-      "In-canvas scoring: select a frame, get a score",
-      "Per-rung breakdown (Meaningful through Functional)",
-      "Coaching cards with fix-by-fix guidance",
-      "Design system generation from your existing patterns",
-      "Score history per frame with trend indicators",
-    ],
-    cta: "Install from Figma Community",
-    href: "#",
     available: true,
   },
   {
@@ -108,7 +91,7 @@ export default function ProductsPage() {
             <span className="text-ladder-green">Every surface.</span>
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto leading-relaxed">
-            Score in your browser, in Figma, from customer feedback, or through
+            Score in your browser, from customer feedback, or through
             Claude. Every score feeds the same account, the same history, the
             same truth.
           </p>
@@ -128,12 +111,6 @@ export default function ProductsPage() {
                 <span>runladder.com</span>
                 <span className="flex-1 border-b border-dashed border-border" />
                 <span className="text-muted text-xs">web</span>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
-                <span>Ladder for Figma</span>
-                <span className="flex-1 border-b border-dashed border-border" />
-                <span className="text-muted text-xs">plugin</span>
               </div>
               <div className="flex items-center gap-3">
                 <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
@@ -228,7 +205,7 @@ export default function ProductsPage() {
             <span className="text-body">Everywhere.</span>
           </h2>
           <p className="text-body leading-relaxed max-w-xl mx-auto mb-10">
-            Score a screen on the web, check it in Figma, or reference it in
+            Score a screen on the web or reference it in
             Claude. It&apos;s the same score, the same history, the same
             account. One subscription unlocks every surface.
           </p>

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -5,6 +5,7 @@ import { useAuth } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
+import Link from "next/link";
 
 type Finding = {
   title: string;
@@ -850,6 +851,64 @@ export default function ScorePage() {
                 </div>
               </div>
             )}
+
+            {/* Pro upgrade promo */}
+            <div className="border border-ladder-green/20 bg-[#1e1e1e] p-8">
+              <div className="flex items-start gap-6">
+                <div className="flex-1">
+                  <span className="text-[10px] text-ladder-green uppercase tracking-widest font-semibold">Upgrade to Pro</span>
+                  <h3 className="text-lg font-bold text-foreground mt-2 font-sans">See more. Fix faster.</h3>
+                  <p className="text-sm text-body leading-relaxed mt-3 font-sans">
+                    Free scores show you where you stand. Pro shows you exactly how to move up.
+                  </p>
+                  <ul className="mt-4 space-y-2">
+                    {[
+                      "Accessibility audit",
+                      "UX copy suggestions",
+                      "Per-dimension scoring (hierarchy, spacing, copy, a11y, navigation, visual)",
+                      "Fix suggestions with score uplift estimates",
+                      "Full score history + trend line",
+                      "All scores are private",
+                    ].map((f) => (
+                      <li key={f} className="flex items-start gap-2 text-xs text-body font-sans">
+                        <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+                        {f}
+                      </li>
+                    ))}
+                    <li className="flex items-start gap-2 text-xs text-muted font-sans">
+                      <span className="text-[#555] mt-0.5 flex-shrink-0">+</span>
+                      Ladder for Figma — coming soon for Pro members
+                    </li>
+                  </ul>
+                  <Link
+                    href="/pricing"
+                    className="inline-block mt-6 text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
+                  >
+                    $50/mo — Upgrade to Pro
+                  </Link>
+                </div>
+
+                {/* Pro preview thumbnail mockup */}
+                <div className="hidden md:block flex-shrink-0 w-48 border border-[#333] bg-[#161616] p-3 opacity-60">
+                  <span className="text-[8px] text-muted uppercase tracking-widest block mb-2">Pro preview</span>
+                  <div className="space-y-2">
+                    {["Hierarchy", "Spacing", "Copy", "A11y", "Navigation", "Visual"].map((dim) => (
+                      <div key={dim} className="flex items-center gap-2">
+                        <span className="text-[8px] text-[#555] w-14 truncate">{dim}</span>
+                        <div className="flex-1 h-1 bg-[#333] rounded-full">
+                          <div className="h-full bg-ladder-green/40 rounded-full" style={{ width: `${40 + Math.random() * 40}%` }} />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="mt-3 border-t border-[#333] pt-2">
+                    <span className="text-[8px] text-[#555] block">A11y audit</span>
+                    <div className="mt-1 h-2 bg-[#333] rounded w-full" />
+                    <div className="mt-1 h-2 bg-[#333] rounded w-3/4" />
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         )}
 

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -26,7 +26,7 @@ const CAPABILITIES = [
   {
     name: "Design System Compliance",
     desc: "Connect your design system. Ladder checks every screen against your tokens, components, and patterns, then tells designers exactly where they drifted.",
-    detail: "Figma library sync, token validation, component coverage, drift detection",
+    detail: "Token validation, component coverage, drift detection",
   },
   {
     name: "Custom Rubric Weights",
@@ -73,7 +73,7 @@ const TIER = {
     "Team knowledge base (brand standards + leadership lens)",
     "Per-designer scores, trends, and leaderboard",
     "Design system compliance scoring",
-    "Unlimited scores on all surfaces (web, Figma, Claude)",
+    "Unlimited scores on all surfaces (web and Claude)",
     "Priority support",
   ],
 };
@@ -248,7 +248,7 @@ export default function TeamsPage() {
           </h2>
           <div className="space-y-6 text-body leading-relaxed">
             <p>
-              Designers keep using the Figma plugin or runladder.com
+              Designers keep using runladder.com
               exactly as they do now. They hit &ldquo;Score This
               Screen&rdquo; and get a Ladder score with coaching cards.
             </p>
@@ -313,7 +313,7 @@ export default function TeamsPage() {
                   "Ladder score with coaching cards",
                   "Per-dimension scoring breakdown",
                   "Full score history + trend line",
-                  "Web, Figma, and Claude access",
+                  "Web and Claude access",
                 ].map((f: string) => (
                   <li
                     key={f}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -23,9 +23,8 @@ export default function TermsPage() {
             </h2>
             <p>
               <strong className="text-foreground">
-                By using Ladder in any form — scoring a screen on runladder.com,
-                installing or using the Ladder for Figma plugin, or using the
-                Ladder for Claude skill — you are agreeing to these Terms of
+                By using Ladder in any form — scoring a screen on runladder.com
+                or using the Ladder for Claude skill — you are agreeing to these Terms of
                 Service.
               </strong>{" "}
               No separate sign-up or checkbox is required. If you do not agree to
@@ -60,8 +59,8 @@ export default function TermsPage() {
                 <span className="text-ladder-green mt-0.5">1.</span>
                 <span>
                   <strong className="text-foreground">Ladder Scoring</strong> —
-                  the self-serve scoring tool available on runladder.com, the
-                  Figma plugin, and the Claude skill (covered by these Terms)
+                  the self-serve scoring tool available on runladder.com
+                  and the Claude skill (covered by these Terms)
                 </span>
               </li>
               <li className="flex items-start gap-2">
@@ -99,13 +98,6 @@ export default function TermsPage() {
                   the web application for scoring screens, viewing the Top 100,
                   browsing teardowns, managing your dashboard, and all other site
                   features
-                </span>
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="text-ladder-green mt-0.5">+</span>
-                <span>
-                  <strong className="text-foreground">Ladder for Figma</strong> —
-                  the Figma plugin for in-canvas scoring
                 </span>
               </li>
               <li className="flex items-start gap-2">
@@ -202,7 +194,7 @@ export default function TermsPage() {
               </strong>{" "}
               This includes the Top 100, teardowns, blog content, social media,
               and other public-facing materials. By scoring on the free tier —
-              whether on the website, in Figma, or through Claude — you grant us a
+              whether on the website or through Claude — you grant us a
               non-exclusive, worldwide, royalty-free license to display, reproduce,
               and distribute the submitted content and resulting scores for
               promotional and educational purposes.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -21,7 +21,6 @@ export function Footer() {
               Surfaces
             </h4>
             <ul className="space-y-3 text-sm text-body">
-              <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Figma</Link></li>
               <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Claude</Link></li>
               <li><Link href="/pulse" className="hover:text-foreground transition-colors">Ladder Pulse</Link></li>
             </ul>


### PR DESCRIPTION
## Summary
- Removes all Ladder for Figma references sitewide (homepage, products, pricing, footer, terms, privacy, organizations, teams, blog)
- Keeps Figma as a "coming soon for Pro members" teaser in score results promo and dashboard
- Moves accessibility audit and UX copy suggestions from Free tier to Pro tier on pricing page
- Adds Pro upgrade promo card after score results showing feature preview with per-dimension scoring mockup
- Editorial content about Figma the product (Top 100, blog) is unchanged

## Files changed
- `src/app/pricing/page.tsx` — a11y + copy moved to Pro, Figma removed from Free features + FAQ
- `src/app/score/page.tsx` — Pro promo card added after findings
- `src/app/dashboard/page.tsx` — Pro promo updated with a11y/copy + Figma coming soon
- `src/app/products/page.tsx` — Figma surface removed from product list + architecture diagram
- `src/app/page.tsx` — Figma product card removed from homepage
- `src/components/Footer.tsx` — Figma link removed
- `src/app/terms/page.tsx` — Figma references removed
- `src/app/privacy/page.tsx` — Figma references removed
- `src/app/organizations/page.tsx` — Figma references removed
- `src/app/teams/page.tsx` — Figma references removed
- `src/app/blog/posts.ts` — Figma plugin mention removed (product mentions kept)

## Test plan
- [ ] Visit /pricing — verify a11y + copy are under Pro, not Free; no Figma in features or FAQ
- [ ] Score a screen at /score — verify Pro promo appears after results with feature list + preview
- [ ] Visit /dashboard — verify Pro promo shows updated copy with Figma coming soon
- [ ] Visit /products — verify no Figma surface card or architecture line
- [ ] Visit homepage — verify no Figma product card
- [ ] Check footer — no Figma link
- [ ] Visit /terms, /privacy — no Figma mentions
- [ ] Visit /top-100/figma — still exists (editorial, not removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)