### PR TITLE
Fix avatar badge, update pricing page tiers and CTAs

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -9,18 +9,19 @@ export const metadata: Metadata = {
 
 const SCREEN_SCORE_TIERS = [
   {
-    name: "Free",
+    name: "Web and Claude",
     price: "$0",
     period: "forever",
     highlight: false,
     limit: "5 scores / month",
     features: [
       "Overall Ladder score + coaching",
-      "Web or Claude",
+      "Score from the web or Claude",
       "Scores may be published publicly",
     ],
     cta: "Start free",
     href: "/score",
+    solidCta: true,
   },
   {
     name: "Professional",
@@ -36,14 +37,16 @@ const SCREEN_SCORE_TIERS = [
       "Per-dimension scoring (hierarchy, spacing, copy, a11y, navigation, visual)",
       "Full score history + trend line",
       "Fix suggestions with score uplift",
+      "Access to Pulse data (if subscribed)",
     ],
     cta: "Subscribe",
     href: "/score",
+    solidCta: false,
   },
   {
     name: "Team",
-    price: "$500",
-    period: "/ mo",
+    price: "Custom",
+    period: "",
     highlight: false,
     limit: "Unlimited everything",
     features: [
@@ -53,10 +56,11 @@ const SCREEN_SCORE_TIERS = [
       "Team leaderboard + portfolio score",
       "Design system compliance scoring",
       "Manager dashboard + performance tracking",
-      "Access to Pulse data if subscribed",
+      "Access to Pulse data (if subscribed)",
     ],
-    cta: "Subscribe",
-    href: "/score",
+    cta: "Talk to us about Ladder",
+    href: "/contact",
+    solidCta: false,
   },
 ];
 
@@ -139,6 +143,8 @@ export default function PricingPage() {
                 className={`text-center text-sm font-semibold py-3 rounded-full transition-colors ${
                   tier.highlight
                     ? "bg-ladder-green text-background hover:bg-ladder-green/90"
+                    : tier.solidCta
+                    ? "bg-foreground text-background hover:bg-foreground/90"
                     : "border border-border text-foreground hover:bg-card-hover"
                 }`}
               >
@@ -162,9 +168,8 @@ export default function PricingPage() {
             {/* Price */}
             <div className="flex items-baseline gap-1.5 mb-1">
               <span className="text-[2.5rem] font-bold text-foreground leading-none">
-                $5,000
+                Custom
               </span>
-              <span className="text-sm text-muted">/ mo</span>
             </div>
             <div className="mb-6" />
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -56,12 +56,14 @@ export function Nav() {
                     },
                   }}
                 />
+                <span className="text-[9px] uppercase tracking-widest font-semibold text-muted border border-[#333] px-2 py-1">
+                  Free
+                </span>
                 <Link
                   href="/pricing"
-                  className="flex items-center gap-1.5 text-[9px] uppercase tracking-widest font-semibold border border-[#333] px-2 py-1 hover:border-ladder-green transition-colors group"
+                  className="text-[9px] uppercase tracking-widest font-semibold text-ladder-green hover:text-ladder-green/80 transition-colors"
                 >
-                  <span className="text-muted group-hover:text-foreground transition-colors">Free</span>
-                  <span className="text-ladder-green">Upgrade</span>
+                  Upgrade
                 </Link>
               </div>
             </>


### PR DESCRIPTION
## Summary
- Separates Free badge from Upgrade link in nav so it no longer reads as "free upgrade"
- Renames Free tier to "Web and Claude" on pricing page
- Adds "Access to Pulse data (if subscribed)" to Professional and Team tiers
- Removes price from Team (now "Custom") and Pulse (now "Custom")
- Changes Team CTA to "Talk to us about Ladder"
- Makes "Start free" button solid white instead of thin outline for visibility

## Test plan
- [ ] Check nav badge — "Free" in bordered badge, "Upgrade" as separate green link
- [ ] Visit /pricing — first column says "Web and Claude" not "Free"
- [ ] Professional lists Pulse data access
- [ ] Team shows "Custom" price, CTA says "Talk to us about Ladder"
- [ ] Pulse shows "Custom" price
- [ ] "Start free" button is clearly visible (solid, not thin outline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)