### PR TITLE
Pro price to $250/mo, 3-day refund policy in FAQ

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Pricing | Ladder",
   description:
-    "Score your first screen free. Screen Score from $0 to $500/mo. Ladder Pulse starting at $5,000/mo.",
+    "Score your first screen free. Professional from $250/mo. Team and Pulse pricing is custom.",
 };
 
 const SCREEN_SCORE_TIERS = [
@@ -25,7 +25,7 @@ const SCREEN_SCORE_TIERS = [
   },
   {
     name: "Professional",
-    price: "$50",
+    price: "$250",
     period: "/ mo",
     highlight: true,
     limit: "Unlimited scores",
@@ -269,11 +269,11 @@ export default function PricingPage() {
               },
               {
                 q: "Can I cancel anytime?",
-                a: "Yes. Professional and Team are month-to-month. Cancel anytime from your account settings, no questions asked.",
+                a: "Yes. Professional is month-to-month with a 3-day money-back guarantee. If you cancel within 3 days, we refund you in full. After that, cancel anytime from your account settings, no questions asked.",
               },
               {
                 q: "How does Team seat pricing work?",
-                a: "Team is $500/mo and includes up to 5 team members. Each additional seat is $100/mo. You get team leaderboards, compliance scoring, and manager dashboards.",
+                a: "Team pricing is custom. It includes up to 5 team members with additional seats available. You get team leaderboards, compliance scoring, and manager dashboards. Contact us for details.",
               },
               {
                 q: "What\u2019s the difference between Screen Score and Pulse?",

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -885,7 +885,7 @@ export default function ScorePage() {
                     href="/pricing"
                     className="inline-block mt-6 text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
                   >
-                    $50/mo — Upgrade to Pro
+                    $250/mo — Upgrade to Pro
                   </Link>
                 </div>
 


### PR DESCRIPTION
## Summary
- Updates Professional price from $50 to $250/mo
- Adds 3-day money-back guarantee to FAQ (not visually promoted on the tier card)
- Updates Team FAQ to reflect custom pricing
- Updates score page Pro promo price to $250/mo
- Updates page metadata description

🤖 Generated with [Claude Code](https://claude.com/claude-code)