### PR TITLE
Fix scoring timeout — add maxDuration to score API

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -3,6 +3,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { redis } from "@/lib/redis";
 
+export const maxDuration = 60;
+
 const FREE_MONTHLY_LIMIT = 5;
 const ANON_LIMIT = 1;
 


### PR DESCRIPTION
## Summary
- Adds `export const maxDuration = 60` to `/api/score` route
- The scoring endpoint makes two sequential Claude API calls (moderation + scoring) which can exceed the default Vercel function timeout with large images

🤖 Generated with [Claude Code](https://claude.com/claude-code)