### PR TITLE
Route all site email to hello@drawbackwards.com

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -56,7 +56,7 @@ export async function POST(req: NextRequest) {
         },
         body: JSON.stringify({
           from: "Ladder <contact@runladder.com>",
-          to: ["ward@drawbackwards.com"],
+          to: ["hello@drawbackwards.com"],
           subject: `[Ladder] ${safeInterest || "New inquiry"} from ${name}`,
           text: [
             `Name: ${name}`,

--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -62,10 +62,10 @@ export default function LegalPage() {
           <p className="mt-6 text-sm text-body">
             Need a commercial license?{" "}
             <a
-              href="mailto:licensing@runladder.com?subject=Ladder%20commercial%20licensing%20inquiry"
+              href="mailto:hello@drawbackwards.com?subject=Ladder%20commercial%20licensing%20inquiry"
               className="text-ladder-green hover:text-ladder-green/80 transition-colors"
             >
-              licensing@runladder.com
+              hello@drawbackwards.com
             </a>
           </p>
         </section>
@@ -241,7 +241,7 @@ export default function LegalPage() {
               Building an AI-native product that needs experience scoring? Use the
               official Ladder API or{" "}
               <a
-                href="mailto:licensing@runladder.com?subject=Ladder%20AI%20partner%20program"
+                href="mailto:hello@drawbackwards.com?subject=Ladder%20AI%20partner%20program"
                 className="text-ladder-purple hover:text-ladder-purple/80 transition-colors"
               >
                 talk to us about an AI partner program
@@ -323,10 +323,10 @@ export default function LegalPage() {
                 </span>
                 <br />
                 <a
-                  href="mailto:licensing@runladder.com?subject=Ladder%20commercial%20licensing%20inquiry"
+                  href="mailto:hello@drawbackwards.com?subject=Ladder%20commercial%20licensing%20inquiry"
                   className="text-ladder-green hover:text-ladder-green/80 transition-colors"
                 >
-                  licensing@runladder.com
+                  hello@drawbackwards.com
                 </a>
               </p>
               <p>


### PR DESCRIPTION
## Summary

- /legal: all three licensing + AI partner mailtos now point to hello@drawbackwards.com (subject lines preserved for triage)
- /api/contact: form submissions now deliver to hello@drawbackwards.com instead of ward@drawbackwards.com
- Resend sender "from" (contact@runladder.com) is unchanged since it depends on the verified sending domain

## Test plan

- [ ] /legal summary card, Section 4 AI policy, and Section 7 Licensing contact all link to mailto:hello@drawbackwards.com with the right subject
- [ ] Contact form submission lands in hello@drawbackwards.com (submit a test from the preview URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)