### PR TITLE
Nav: Sign up to score for signed-out, logged-in info only for signed-in

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useAuth, UserButton, SignInButton } from "@clerk/nextjs";
+import { useAuth, UserButton, SignInButton, SignUpButton } from "@clerk/nextjs";
 import { LadderLogo } from "./LadderLogo";
 
 export function Nav() {
@@ -34,11 +34,18 @@ export function Nav() {
 
         <div className="flex items-center gap-6">
           {isLoaded && !isSignedIn && (
-            <SignInButton mode="redirect">
-              <button className="text-sm font-bold text-body hover:text-foreground transition-colors">
-                Log in
-              </button>
-            </SignInButton>
+            <>
+              <SignInButton mode="redirect">
+                <button className="text-sm font-bold text-body hover:text-foreground transition-colors">
+                  Log in
+                </button>
+              </SignInButton>
+              <SignUpButton mode="redirect">
+                <button className="text-sm font-semibold bg-ladder-green text-background px-8 py-3 rounded-full hover:bg-ladder-green/90 transition-colors">
+                  Sign up to score
+                </button>
+              </SignUpButton>
+            </>
           )}
           {isLoaded && isSignedIn && (
             <>
@@ -68,12 +75,6 @@ export function Nav() {
               </div>
             </>
           )}
-          <Link
-            href="/score"
-            className="text-sm font-semibold bg-ladder-green text-background px-8 py-3 rounded-full hover:bg-ladder-green/90 transition-colors"
-          >
-            Score a screen
-          </Link>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
## Summary
- Signed-out nav now shows **Log in** + **Sign up to score** (green pill, SignUpButton)
- Signed-in nav shows only logged-in info (Dashboard, avatar, Free badge, Upgrade) — no duplicate Score a screen CTA
- Removes the always-visible /score CTA that appeared for both auth states

## Test plan
- [x] Verified signed-out state in preview (Log in + Sign up to score visible)
- [ ] Verify signed-in state on production removes the /score CTA
- [ ] Verify Sign up to score triggers Clerk signup modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)