### PR TITLE
Skill card: Copy button yields full install command, not just raw token

### DIFF
--- a/src/components/SkillTokenCard.tsx
+++ b/src/components/SkillTokenCard.tsx
@@ -60,9 +60,13 @@ export function SkillTokenCard() {
     }
   }
 
+  function installCommand(token: string): string {
+    return `mkdir -p ~/.ladder && printf '%s' '${token}' > ~/.ladder/token && chmod 600 ~/.ladder/token`;
+  }
+
   function copy() {
     if (!rawToken) return;
-    navigator.clipboard.writeText(rawToken);
+    navigator.clipboard.writeText(installCommand(rawToken));
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   }
@@ -102,11 +106,11 @@ export function SkillTokenCard() {
       {rawToken ? (
         <div className="border border-ladder-green/40 bg-ladder-green/5 p-4 mb-3">
           <p className="text-[10px] text-ladder-green uppercase tracking-widest mb-2 font-semibold">
-            Copy this token — you won&apos;t see it again
+            Copy and paste into Terminal — you won&apos;t see this again
           </p>
           <div className="flex items-center gap-2">
             <code className="flex-1 text-xs font-mono text-foreground bg-[#111] border border-[#333] px-3 py-2 break-all">
-              {rawToken}
+              {installCommand(rawToken)}
             </code>
             <button
               onClick={copy}
@@ -115,6 +119,9 @@ export function SkillTokenCard() {
               {copied ? "Copied" : "Copy"}
             </button>
           </div>
+          <p className="text-[10px] text-muted font-sans mt-3">
+            Saves your token to <code className="text-foreground">~/.ladder/token</code> so the Skill can authenticate. macOS &amp; Linux.
+          </p>
         </div>
       ) : null}
 


### PR DESCRIPTION
## Summary
When a user generates a Skill token, the Copy button now puts a full paste-ready install command on the clipboard, not just the raw token.

**Before:** Copy → user gets just the token → they assemble mkdir/echo/chmod themselves → common failure mode: clipboard gets overwritten between steps and pbpaste writes the wrong thing.

**After:** Copy → user gets the whole line, paste once in Terminal, done.

\`\`\`
mkdir -p ~/.ladder && printf '%s' 'ladder_skl_…' > ~/.ladder/token && chmod 600 ~/.ladder/token
\`\`\`

printf '%s' (not echo) so no trailing newline is written to the file.

## Test plan
- [ ] Rotate token on /dashboard
- [ ] Verify the green reveal shows the full install command, not a bare token
- [ ] Click Copy, paste into Terminal, verify the token installs correctly
- [ ] Verify cat ~/.ladder/token outputs only the token (no trailing newline, no extra text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)