### PR TITLE
Tighten Skill invocation to "Run Ladder"

### DIFF
--- a/skill/README.md
+++ b/skill/README.md
@@ -27,7 +27,7 @@ Drop a screenshot into any Claude chat, ask for its Ladder score, and get back:
 
 Start a new Claude chat, attach a screenshot, and say:
 
-> Score this against the Ladder framework.
+> Run Ladder
 
 Claude will run the Skill, call the Ladder API, and return the result.
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ladder-quality-score
-description: Score a UI screenshot, website, or design mockup against the Ladder quality framework. Use whenever the user asks to "score", "rate", "evaluate", "review", "audit", "grade", or check the UX/UI/design quality of a screen, page, app, or interface — including phrases like "what's the Ladder score", "run Ladder on this", or "how good is this design". Returns a 1.0–5.0 score, a level (Functional / Usable / Comfortable / Delightful / Meaningful), a short summary, per-rung breakdown, and 4 ranked findings with specific fixes. Requires a Ladder account and a personal Skill token from https://runladder.com/dashboard.
+description: Score a UI screenshot, website, or design mockup against the Ladder quality framework. Treat short phrasings like "Run Ladder", "Ladder this", "Ladder score", or "Ladder it" as direct invocations of this Skill. Also use whenever the user asks to "score", "rate", "evaluate", "review", "audit", "grade", or check the UX/UI/design quality of a screen, page, app, or interface — including "what's the Ladder score" or "how good is this design". Returns a 1.0–5.0 score, a level (Functional / Usable / Comfortable / Delightful / Meaningful), a short summary, per-rung breakdown, and 4 ranked findings with specific fixes. Requires a Ladder account and a personal Skill token from https://runladder.com/dashboard.
 ---
 
 # Ladder Quality Score

--- a/src/components/SkillTokenCard.tsx
+++ b/src/components/SkillTokenCard.tsx
@@ -42,7 +42,12 @@ const SETUP_STEPS: { title: string; body: React.ReactNode }[] = [
   },
   {
     title: "Score something",
-    body: `Start a new chat, attach a screenshot, and say "Score this against the Ladder framework."`,
+    body: (
+      <>
+        Start a new chat, attach a screenshot, and say{" "}
+        <code className="text-foreground">Run Ladder</code>.
+      </>
+    ),
   },
 ];
 


### PR DESCRIPTION
## Summary
- Shortens the Skill trigger phrase from \"Score this against the Ladder framework.\" to **Run Ladder** — matches the product URL and is ~5x shorter.
- SKILL.md description now leads with short trigger phrasings (\"Run Ladder\", \"Ladder this\", \"Ladder score\", \"Ladder it\") so Claude reliably invokes on tight prompts.
- README example and dashboard setup guide step 5 updated to match.
- prebuild rebuilds ladder-skill.zip on deploy, so the published zip picks up the new SKILL.md automatically.

## Test plan
- [ ] Verify dashboard setup guide step 5 shows \"Run Ladder\" in a code span
- [ ] Download the new ladder-skill.zip after deploy, verify SKILL.md and README contain the new phrasing
- [ ] In Claude, attach a screenshot and say \"Run Ladder\" — confirm the Skill triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)