### PR TITLE
Add admin dashboard at /admin

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,374 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+
+type InviteRecord = {
+  code: string;
+  tier: string;
+  email: string | null;
+  claimed: boolean;
+  claimedBy: string | null;
+  claimedAt?: string | null;
+  createdAt: string;
+};
+
+type UserRecord = {
+  userId: string;
+  email: string;
+  tier: string;
+  joinedAt: string | null;
+  lastLoginAt: string | null;
+  inviteCode: string | null;
+  xp: number;
+  usageThisMonth: number;
+};
+
+const TIERS = ["beta", "free", "paid"] as const;
+
+function fmtDate(iso: string | null | undefined) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function AdminPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  const [invites, setInvites] = useState<InviteRecord[]>([]);
+  const [users, setUsers] = useState<UserRecord[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [genCount, setGenCount] = useState(1);
+  const [genTier, setGenTier] = useState<(typeof TIERS)[number]>("beta");
+  const [generating, setGenerating] = useState(false);
+  const [newCodes, setNewCodes] = useState<string[]>([]);
+
+  const [busyUser, setBusyUser] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [invRes, usrRes] = await Promise.all([
+        fetch("/api/admin/invites"),
+        fetch("/api/admin/users"),
+      ]);
+      if (invRes.status === 403 || usrRes.status === 403) {
+        setAuthorized(false);
+        return;
+      }
+      setAuthorized(true);
+      if (!invRes.ok) throw new Error(`Invites fetch ${invRes.status}`);
+      if (!usrRes.ok) throw new Error(`Users fetch ${usrRes.status}`);
+      const invJson = await invRes.json();
+      const usrJson = await usrRes.json();
+      setInvites(invJson.codes || []);
+      setUsers(usrJson.users || []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    refresh();
+  }, [isSignedIn]);
+
+  async function generate() {
+    setGenerating(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/invites", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ count: genCount, tier: genTier }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Generate failed (${res.status})`);
+      setNewCodes(json.codes || []);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Generate failed");
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function resetUser(userId: string) {
+    if (!confirm("Reset this user's access? Their invite code becomes reusable.")) return;
+    setBusyUser(userId);
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId, action: "reset" }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Reset failed (${res.status})`);
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Reset failed");
+    } finally {
+      setBusyUser(null);
+    }
+  }
+
+  async function deleteUser(userId: string) {
+    if (!confirm("Delete this user? This cannot be undone.")) return;
+    setBusyUser(userId);
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Delete failed (${res.status})`);
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setBusyUser(null);
+    }
+  }
+
+  async function copyCode(code: string) {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      // noop — user can select manually
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (authorized === false) {
+    return (
+      <div className="pt-20 max-w-2xl mx-auto px-6 py-20">
+        <h1 className="text-xl font-bold font-sans mb-3">Admin access required</h1>
+        <p className="text-sm text-muted font-sans">
+          Your Clerk account is signed in but not on the admin allowlist. If this is a
+          mistake, check <code className="text-foreground">ADMIN_EMAILS</code> in runladder&apos;s
+          Vercel env vars.
+        </p>
+      </div>
+    );
+  }
+
+  const unclaimedInvites = invites.filter((i) => !i.claimed);
+  const claimedInvites = invites.filter((i) => i.claimed);
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8 flex items-baseline justify-between">
+          <div>
+            <h1 className="text-xl text-foreground font-sans">Admin</h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              Plugin beta — invite codes and users
+            </p>
+          </div>
+          <button
+            onClick={refresh}
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            disabled={loading}
+          >
+            {loading ? "Loading…" : "Refresh"}
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* ── Invite codes ───────────────────────────────────────── */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Invite codes
+            </span>
+            <span className="text-[10px] text-muted">
+              {unclaimedInvites.length} unclaimed · {claimedInvites.length} claimed
+            </span>
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e] p-4 mb-3">
+            <div className="flex items-center gap-3 flex-wrap">
+              <label className="text-xs text-muted font-sans">Count</label>
+              <input
+                type="number"
+                min={1}
+                max={50}
+                value={genCount}
+                onChange={(e) => setGenCount(Math.max(1, Math.min(50, Number(e.target.value) || 1)))}
+                className="bg-[#111] border border-[#333] text-sm w-20 px-2 py-1 text-foreground focus:outline-none focus:border-muted"
+              />
+              <label className="text-xs text-muted font-sans ml-2">Tier</label>
+              <select
+                value={genTier}
+                onChange={(e) => setGenTier(e.target.value as (typeof TIERS)[number])}
+                className="bg-[#111] border border-[#333] text-sm px-2 py-1 text-foreground focus:outline-none focus:border-muted"
+              >
+                {TIERS.map((t) => (
+                  <option key={t} value={t}>
+                    {t}
+                  </option>
+                ))}
+              </select>
+              <button
+                onClick={generate}
+                disabled={generating}
+                className="ml-auto text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+              >
+                {generating ? "Generating…" : "Generate"}
+              </button>
+            </div>
+            {newCodes.length > 0 && (
+              <div className="mt-3 pt-3 border-t border-[#2a2a2a]">
+                <p className="text-[10px] text-muted uppercase tracking-widest mb-2">
+                  Just generated
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  {newCodes.map((c) => (
+                    <button
+                      key={c}
+                      onClick={() => copyCode(c)}
+                      className="text-xs bg-[#111] border border-ladder-green/40 text-ladder-green px-2 py-1 tabular-nums hover:bg-ladder-green/10 transition-colors"
+                      title="Click to copy"
+                    >
+                      {c}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3">Code</th>
+                  <th className="text-left p-3">Tier</th>
+                  <th className="text-left p-3">Status</th>
+                  <th className="text-left p-3">Claimed by</th>
+                  <th className="text-left p-3">Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {invites.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="p-6 text-center text-muted font-sans">
+                      No codes yet.
+                    </td>
+                  </tr>
+                ) : (
+                  invites.map((inv) => (
+                    <tr key={inv.code} className="border-b border-[#222] last:border-0 hover:bg-[#222]">
+                      <td className="p-3">
+                        <button
+                          onClick={() => copyCode(inv.code)}
+                          className="tabular-nums text-foreground hover:text-ladder-green transition-colors"
+                          title="Click to copy"
+                        >
+                          {inv.code}
+                        </button>
+                      </td>
+                      <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{inv.tier}</td>
+                      <td className="p-3">
+                        {inv.claimed ? (
+                          <span className="text-muted">Claimed</span>
+                        ) : (
+                          <span className="text-ladder-green">Open</span>
+                        )}
+                      </td>
+                      <td className="p-3 text-muted">{inv.claimedBy ?? "—"}</td>
+                      <td className="p-3 text-muted">{fmtDate(inv.createdAt)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Users ─────────────────────────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">Users</span>
+            <span className="text-[10px] text-muted">{users.length} total</span>
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3">Email</th>
+                  <th className="text-left p-3">Tier</th>
+                  <th className="text-left p-3">Joined</th>
+                  <th className="text-left p-3">Last login</th>
+                  <th className="text-right p-3">Usage (month)</th>
+                  <th className="text-left p-3">Invite</th>
+                  <th className="text-right p-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.length === 0 ? (
+                  <tr>
+                    <td colSpan={7} className="p-6 text-center text-muted font-sans">
+                      No users yet.
+                    </td>
+                  </tr>
+                ) : (
+                  users.map((u) => (
+                    <tr key={u.userId} className="border-b border-[#222] last:border-0 hover:bg-[#222]">
+                      <td className="p-3 text-foreground">{u.email}</td>
+                      <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{u.tier}</td>
+                      <td className="p-3 text-muted">{fmtDate(u.joinedAt)}</td>
+                      <td className="p-3 text-muted">{fmtDate(u.lastLoginAt)}</td>
+                      <td className="p-3 text-right tabular-nums text-muted">{u.usageThisMonth}</td>
+                      <td className="p-3 tabular-nums text-muted">{u.inviteCode ?? "—"}</td>
+                      <td className="p-3 text-right">
+                        <button
+                          onClick={() => resetUser(u.userId)}
+                          disabled={busyUser === u.userId}
+                          className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors mr-3 disabled:opacity-40"
+                        >
+                          Reset
+                        </button>
+                        <button
+                          onClick={() => deleteUser(u.userId)}
+                          disabled={busyUser === u.userId}
+                          className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
+                        >
+                          Delete
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminEmail, pluginFetch } from "@/lib/admin";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+type InviteRecord = {
+  code: string;
+  tier: string;
+  email: string | null;
+  claimed: boolean;
+  claimedBy: string | null;
+  claimedAt?: string | null;
+  createdAt: string;
+};
+
+/**
+ * Admin invite codes — list + generate.
+ * Proxies the plugin backend's /api/auth/invite with the server-side admin
+ * key attached. Browser never sees the key; it authenticates via Clerk +
+ * admin-email allowlist (see getAdminEmail).
+ */
+export async function GET() {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const result = await pluginFetch<{ codes: InviteRecord[] }>(
+    "/api/auth/invite",
+    { method: "GET" },
+  );
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(
+    { codes: result.data.codes ?? [] },
+    { headers: API_VERSION_HEADERS },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: { count?: number; tier?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // allow empty body — defaults below
+  }
+
+  const count = Math.min(Math.max(1, Number(body.count) || 1), 50);
+  const tier = typeof body.tier === "string" ? body.tier : "beta";
+
+  const result = await pluginFetch<{ codes: string[] }>("/api/auth/invite", {
+    method: "POST",
+    body: { count, tier },
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(
+    { codes: result.data.codes ?? [] },
+    { headers: API_VERSION_HEADERS },
+  );
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminEmail, pluginFetch } from "@/lib/admin";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+type UserRecord = {
+  userId: string;
+  email: string;
+  tier: string;
+  joinedAt: string | null;
+  lastLoginAt: string | null;
+  inviteCode: string | null;
+  xp: number;
+  usageThisMonth: number;
+};
+
+/**
+ * Admin users — list, delete, reset invite.
+ * Proxies the plugin backend's /api/auth/users. Clerk-admin-gated.
+ */
+export async function GET() {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const result = await pluginFetch<{ users: UserRecord[] }>(
+    "/api/auth/users",
+    { method: "GET" },
+  );
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(
+    { users: result.data.users ?? [] },
+    { headers: API_VERSION_HEADERS },
+  );
+}
+
+export async function DELETE(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: { userId?: string } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  if (!body.userId) {
+    return NextResponse.json(
+      { error: "userId required" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const result = await pluginFetch<{ ok: boolean }>("/api/auth/users", {
+    method: "DELETE",
+    body: { userId: body.userId },
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: true },
+    { headers: API_VERSION_HEADERS },
+  );
+}
+
+/** Reset — unclaims the user's invite code so they (or someone else) can reuse it. */
+export async function POST(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: { userId?: string; action?: string } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  if (!body.userId) {
+    return NextResponse.json(
+      { error: "userId required" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const action = body.action ?? "reset";
+  if (action !== "reset") {
+    return NextResponse.json(
+      { error: `Unknown action: ${action}` },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const result = await pluginFetch<{ ok: boolean }>("/api/auth/users", {
+    method: "POST",
+    body: { userId: body.userId, action: "reset" },
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(
+    { ok: true },
+    { headers: API_VERSION_HEADERS },
+  );
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,100 @@
+/**
+ * Admin helpers — auth gate for /admin pages and /api/admin/* routes,
+ * plus a typed proxy for the plugin backend (ai-design-assistant) admin
+ * endpoints while plugin data still lives there.
+ *
+ * Env vars (runladder project):
+ *   PLUGIN_BACKEND_URL   — e.g. https://ai-design-assistant-ebon.vercel.app
+ *   PLUGIN_ADMIN_KEY     — same value as ai-design-assistant's ADMIN_KEY env var
+ *   ADMIN_EMAILS         — comma-separated allowlist. Defaults to Ward's emails.
+ */
+import { auth, clerkClient } from "@clerk/nextjs/server";
+
+const ADMIN_EMAILS = (
+  process.env.ADMIN_EMAILS || "ward@drawbackwards.com,ward.andrews@gmail.com"
+)
+  .split(",")
+  .map((e) => e.trim().toLowerCase())
+  .filter(Boolean);
+
+/**
+ * Returns the authenticated admin's email, or null if unauthorized.
+ * Throws no error — callers decide how to respond (UI redirect vs API 403).
+ */
+export async function getAdminEmail(): Promise<string | null> {
+  const { userId } = await auth();
+  if (!userId) return null;
+
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const email = user.primaryEmailAddress?.emailAddress?.toLowerCase();
+  if (!email) return null;
+  if (!ADMIN_EMAILS.includes(email)) return null;
+  return email;
+}
+
+/* ── Plugin backend proxy ────────────────────────────────────────────── */
+
+const PLUGIN_BACKEND_URL =
+  process.env.PLUGIN_BACKEND_URL || "https://ai-design-assistant-ebon.vercel.app";
+
+function pluginAdminKey(): string {
+  const k = process.env.PLUGIN_ADMIN_KEY;
+  if (!k) {
+    throw new Error(
+      "PLUGIN_ADMIN_KEY is not set in runladder env. Copy ai-design-assistant's ADMIN_KEY value here.",
+    );
+  }
+  return k;
+}
+
+type PluginFetchOpts = {
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: unknown;
+  search?: Record<string, string | number | undefined>;
+};
+
+/**
+ * Fetch against the plugin backend with the admin key attached.
+ * Never expose the admin key to the browser — this runs server-side only.
+ */
+export async function pluginFetch<T = unknown>(
+  path: string,
+  opts: PluginFetchOpts = {},
+): Promise<{ ok: true; status: number; data: T } | { ok: false; status: number; error: string }> {
+  const url = new URL(path.startsWith("/") ? path : `/${path}`, PLUGIN_BACKEND_URL);
+  for (const [k, v] of Object.entries(opts.search ?? {})) {
+    if (v !== undefined) url.searchParams.set(k, String(v));
+  }
+
+  try {
+    const res = await fetch(url.toString(), {
+      method: opts.method ?? "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-key": pluginAdminKey(),
+      },
+      body: opts.body ? JSON.stringify(opts.body) : undefined,
+    });
+
+    let data: unknown = null;
+    const text = await res.text();
+    try {
+      data = text ? JSON.parse(text) : null;
+    } catch {
+      data = text;
+    }
+
+    if (!res.ok) {
+      const err =
+        (data && typeof data === "object" && "error" in data && typeof (data as { error: unknown }).error === "string"
+          ? (data as { error: string }).error
+          : undefined) || `Plugin backend returned ${res.status}`;
+      return { ok: false, status: res.status, error: err };
+    }
+    return { ok: true, status: res.status, data: data as T };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    return { ok: false, status: 502, error: `Plugin backend unreachable: ${msg}` };
+  }
+}


### PR DESCRIPTION
## Summary
- Phase 2 of the Ladder admin story — unified console on runladder.com replacing the old \`ai-design-assistant/public/dashboard.html\` where you had to paste ADMIN_KEY every session.
- **\`/admin\`** — Clerk-gated (email allowlist), two sections: invite codes (generate + list + copy) and users (list + reset + delete).
- Backend: \`/api/admin/invites\` and \`/api/admin/users\` proxy the plugin backend with a server-side admin key. Browser never sees the key.

## Required setup before merge
Add one env var to the **runladder** Vercel project (Production + Preview + Development):
- \`PLUGIN_ADMIN_KEY\` = same value as ai-design-assistant's \`ADMIN_KEY\`

Optional:
- \`ADMIN_EMAILS\` = comma-separated override. Defaults to \`ward@drawbackwards.com,ward.andrews@gmail.com\`.

## Test plan
- [x] Local: type check passes
- [x] Local: unauthed hit to \`/admin\` redirects to /login
- [x] Local: unauthed hits to \`/api/admin/*\` return 403
- [ ] Post-deploy: sign in → \`/admin\` loads, invites list shows, users list shows (just Ward for now)
- [ ] Post-deploy: generate code, copy, claim in plugin → code disappears from unclaimed list
- [ ] Post-deploy: reset a user → their invite becomes claimable again

## What's NOT in this PR (follow-ups)
- Editing user tier (requires new PATCH endpoint in plugin backend)
- Flags/notes/custom limits
- Sort / search / filter
- Migrating plugin data to runladder's Redis (we're still proxying)
- \`admin.runladder.com\` subdomain (subpath is fine for v1)