### PR TITLE
Scrub CHANGELOG + bump text contrast to WCAG AA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ## app 0.2.0 / api 1.0.0 — 2026-04-19
 
-**Ladder framework unified across the suite.**
+**Scoring engine alignment across the suite.**
 
-- **Scoring engine rebuilt on the full Ladder framework.** `/api/score` and `/api/skill/score` now use the same rich rubric the Figma plugin has used in beta — levels with signals, seven evaluation dimensions, the AI-experience lens for AI-powered products, and scoring principles. No change to the response shape.
-- **New `/api/framework` endpoint.** Serves the Ladder framework (levels, dimensions, design types, AI lens, survey domains, pre-rendered prompts) to trusted service callers. Shared-secret auth via `X-Ladder-Service-Token`.
-- **New `/api/plugin/analyze` endpoint.** Service-to-service scoring endpoint for Ladder plugin backends. Takes an image + optional `designType`, returns the plugin's `improve` response shape. Shared-secret auth.
-- **API version header.** Every endpoint now returns `X-Ladder-API-Version`, and the framework + plugin-analyze endpoints carry it today. Clients can log which contract they hit.
-- **App version visible in footer.** Added `CURRENT_APP_VERSION` source of truth in `src/lib/app-version.ts`, surfaced in the footer so "which build is live?" is answerable at a glance.
+- **Consistent scoring everywhere.** runladder.com and the Claude Skill now run the same scoring engine as the Figma plugin — one evaluation, same result, regardless of surface. No change to the public response shape.
+- **Internal sync endpoint.** Added a service-to-service endpoint for trusted backends to stay aligned. Shared-secret auth.
+- **Internal plugin-scoring endpoint.** Added an internal scoring endpoint for Ladder plugin backends. Shared-secret auth.
+- **API version header.** Every API response now returns `X-Ladder-API-Version` so callers can log which contract they hit.
+- **App version visible in footer.** Added a source-of-truth constant (`src/lib/app-version.ts`) surfaced in the footer — "which build is live?" is now answerable at a glance.
 
 ---
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,8 +4,8 @@
   /* Core palette — matches drawbackwards.com */
   --color-background: #1a1a1a;
   --color-foreground: #ffffff;
-  --color-body: #A0A0A0;
-  --color-muted: #666666;
+  --color-body: #B8B8B8;
+  --color-muted: #9A9A9A;
   --color-border: #333333;
   --color-card: #2a2a2a;
   --color-card-hover: #333333;

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,7 +56,7 @@ export function Footer() {
             <span className="text-xs text-muted">
               Made with love by <a href="https://drawbackwards.com" className="text-body hover:text-foreground transition-colors">Drawbackwards</a> since 2003
             </span>
-            <span className="text-[10px] text-muted/60 tabular-nums ml-auto">
+            <span className="text-[10px] text-muted tabular-nums ml-auto">
               v{CURRENT_APP_VERSION}
             </span>
           </div>


### PR DESCRIPTION
## Summary
Two related polish items.

**IP scrub:** Rewrite the app-0.2.0 CHANGELOG entry so it describes the user benefit (consistent scoring across surfaces) rather than naming internal framework structure (dimensions, AI lens, survey domains, pre-rendered prompts). Paired with a matching scrub of the Figma plugin changelog in a separate PR on ai-design-assistant.

**Contrast:** The site-wide \`--color-muted\` was #666666 on a #1a1a1a background — a 2.8:1 contrast ratio, **below WCAG AA minimum** (4.5:1 for normal text). Bumped to #9A9A9A (6:1, AA normal). Also bumped \`--color-body\` from #A0A0A0 to #B8B8B8 (7.7:1, AAA) for a clearer hierarchy. Footer version pill drops a stacking \`/60\` opacity that was pushing it below 2:1.

## Test plan
- [x] Local: \`text-muted\` resolves to rgb(154, 154, 154) on homepage
- [x] Local: \`text-body\` resolves to rgb(184, 184, 184)
- [ ] Post-deploy: scan dashboard, admin, score, top-100 for any remaining surprise-low-contrast spots. The global bump fixes the majority; any stragglers are hardcoded \`text-[#444]\` / \`text-[#555]\` values we'll pick off as we see them.