### PR TITLE
Admin: CRM drawer + Expires column + ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,73 @@
+# Roadmap
+
+Deferred work, parked ideas, and multi-phase migrations for runladder.com and the Ladder ecosystem. Items move from here into `CHANGELOG.md` when shipped.
+
+Not a promise of order or priority — this is a capture list so nothing falls on the floor. Promotions to active work happen in PR discussions.
+
+---
+
+## Admin — CRM
+
+- **Search + filter** on the users list (by email, company, tier, last-active window)
+- **Segments / tags** — admin-assigned labels on users (e.g. `agency`, `qualified`, `reviewer`). Filter by tag.
+- **Lifecycle stages** — `new → active → engaged → at-risk → churned`. Auto-computed from activity signals.
+- **CSV export** — users, invite codes, activity windows
+- **Bulk actions** on selected users (email, re-tier, tag)
+- **Custom limits per user** — override the default monthly cap without promoting tier
+- **Flags** — admin-only booleans on a user (OG beta, reviewer, internal, do-not-contact)
+- **Admin activity log** — who (which admin) edited what, when. Accountability for multi-admin teams.
+
+## Admin — analytics & visibility
+
+- **Score trend sparkline** per user in the drawer (score over last 30d)
+- **Mode usage breakdown** per user (pie or bar: improve / audit / a11y / copy / compare / generate)
+- **Team-level aggregation** that isn't just `/dashboard/team` (admin-side roll-up across all teams)
+- **Usage forecast** — project monthly usage based on current pace
+- **Cohort view** — new users by week, retention by cohort
+
+## Admin — auth & infra
+
+- **`admin.runladder.com` subdomain** (currently `/admin` subpath — fine for v1)
+- **Clerk roles instead of email allowlist** — once other team members need admin access
+- **Admin-key-less operations** — move invite/user storage from ai-design-assistant Redis into runladder Redis alongside Clerk, so proxying disappears
+- **Audit log export** — CSV of admin actions for compliance/legal
+
+## Billing & Stripe
+
+- **Stripe sync in admin** — show subscription state, next billing date, invoice history per user
+- **Manual upgrade/downgrade** that writes to Stripe (not just the local tier field)
+- **Dunning visibility** — failed-payment users surfaced in admin
+- **Seat management for Teams tier** (when Teams becomes a real product)
+
+## Scoring engine
+
+- **Chat endpoint migration** — `ai-design-assistant/api/chat.js` should proxy to runladder like scoring already does. Currently still uses the thin-fetcher framework pattern locally.
+- **Feedback-scoring endpoint migration** — same pattern for `api/score-feedback.js`.
+- **Per-rung refinement dashboard** — let Ward tune individual rung scoring without a deploy.
+- **Model selection as an admin setting** — toggle Sonnet vs Haiku per mode for cost/quality tradeoff.
+
+## Plugin (Ladder for Figma)
+
+- **Compare-mode activity logging** — currently only single-frame modes log to `user:{id}:activity`
+- **Generate-mode activity logging** — same
+- **Plugin-side version check** — plugin fetches current version from API, shows "update available" pill when outdated (like the Skill does today)
+- **First-run tour** inside the plugin
+- **Analytics: which Figma file / project** is being scored (aggregate, not per-user privacy-respecting)
+
+## runladder.com — public surfaces
+
+- **Public changelog page** at `/changelog` that renders `CHANGELOG.md`
+- **Public roadmap page** at `/roadmap` — curated subset of this file (customer-facing only)
+- **`/status` page** with API uptime + recent deploy times
+- **API docs site** for the forthcoming public Ladder API
+- **Pricing page reality check** — sync copy with actual Stripe plans after Stripe sync lands
+
+## Ops
+
+- **Error aggregation** beyond per-user — surface global error rate, top error types, deploy correlation
+- **Vercel deploy promotion workflow** — staging → prod with a confirmation step (today: push to main = prod)
+- **Scheduled runladder-framework sync health check** — alert if `/api/framework` 5xx rate crosses threshold
+
+---
+
+*Last touch-up: 2026-04-19 after the light-CRM v1 ship.*

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -11,6 +11,7 @@ type InviteRecord = {
   claimedBy: string | null;
   claimedAt?: string | null;
   createdAt: string;
+  expiresAt?: string | null;
 };
 
 type UserRecord = {
@@ -35,6 +36,28 @@ function fmtDate(iso: string | null | undefined) {
     day: "numeric",
     year: "numeric",
   });
+}
+
+/**
+ * Human relative time until the given ISO date.
+ * Returns "—" if missing, "expired" if past, "in 5 days" / "in 3 hours" etc otherwise.
+ */
+function fmtExpires(iso: string | null | undefined): {
+  label: string;
+  tone: "none" | "ok" | "soon" | "past";
+} {
+  if (!iso) return { label: "never", tone: "none" };
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return { label: "—", tone: "none" };
+  const diff = d.getTime() - Date.now();
+  if (diff <= 0) return { label: "expired", tone: "past" };
+  const mins = Math.floor(diff / 60000);
+  if (mins < 60) return { label: `in ${mins}m`, tone: "soon" };
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return { label: `in ${hours}h`, tone: "soon" };
+  const days = Math.floor(hours / 24);
+  const tone: "ok" | "soon" = days < 3 ? "soon" : "ok";
+  return { label: `in ${days}d`, tone };
 }
 
 export default function AdminPage() {
@@ -270,39 +293,52 @@ export default function AdminPage() {
                   <th className="text-left p-3">Status</th>
                   <th className="text-left p-3">Claimed by</th>
                   <th className="text-left p-3">Created</th>
+                  <th className="text-left p-3">Expires</th>
                 </tr>
               </thead>
               <tbody>
                 {invites.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="p-6 text-center text-muted font-sans">
+                    <td colSpan={6} className="p-6 text-center text-muted font-sans">
                       No codes yet.
                     </td>
                   </tr>
                 ) : (
-                  invites.map((inv) => (
-                    <tr key={inv.code} className="border-b border-[#222] last:border-0 hover:bg-[#222]">
-                      <td className="p-3">
-                        <button
-                          onClick={() => copyCode(inv.code)}
-                          className="tabular-nums text-foreground hover:text-ladder-green transition-colors"
-                          title="Click to copy"
-                        >
-                          {inv.code}
-                        </button>
-                      </td>
-                      <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{inv.tier}</td>
-                      <td className="p-3">
-                        {inv.claimed ? (
-                          <span className="text-muted">Claimed</span>
-                        ) : (
-                          <span className="text-ladder-green">Open</span>
-                        )}
-                      </td>
-                      <td className="p-3 text-muted">{inv.claimedBy ?? "—"}</td>
-                      <td className="p-3 text-muted">{fmtDate(inv.createdAt)}</td>
-                    </tr>
-                  ))
+                  invites.map((inv) => {
+                    const expires = inv.claimed
+                      ? { label: "claimed", tone: "none" as const }
+                      : fmtExpires(inv.expiresAt);
+                    const expiresClass =
+                      expires.tone === "past"
+                        ? "text-ladder-red"
+                        : expires.tone === "soon"
+                          ? "text-ladder-orange"
+                          : "text-muted";
+                    return (
+                      <tr key={inv.code} className="border-b border-[#222] last:border-0 hover:bg-[#222]">
+                        <td className="p-3">
+                          <button
+                            onClick={() => copyCode(inv.code)}
+                            className="tabular-nums text-foreground hover:text-ladder-green transition-colors"
+                            title="Click to copy"
+                          >
+                            {inv.code}
+                          </button>
+                        </td>
+                        <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{inv.tier}</td>
+                        <td className="p-3">
+                          {inv.claimed ? (
+                            <span className="text-muted">Claimed</span>
+                          ) : (
+                            <span className="text-ladder-green">Open</span>
+                          )}
+                        </td>
+                        <td className="p-3 text-muted">{inv.claimedBy ?? "—"}</td>
+                        <td className="p-3 text-muted">{fmtDate(inv.createdAt)}</td>
+                        <td className={`p-3 tabular-nums ${expiresClass}`}>{expires.label}</td>
+                      </tr>
+                    );
+                  })
                 )}
               </tbody>
             </table>

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 
 type InviteRecord = {
@@ -23,9 +23,96 @@ type UserRecord = {
   inviteCode: string | null;
   xp: number;
   usageThisMonth: number;
+  company?: string | null;
+  role?: string | null;
+};
+
+type UserDetailFields = {
+  company: string;
+  role: string;
+  notes: string;
+  instagram: string;
+  x: string;
+  linkedin: string;
+  youtube: string;
+};
+
+type ActivityEvent = {
+  type: "joined" | "score";
+  timestamp: string;
+  mode?: string;
+  score?: number | null;
+  label?: string | null;
+  frameName?: string | null;
+  hasImage?: boolean;
+  via?: string;
+  tier?: string;
+};
+
+type ErrorEvent = {
+  timestamp: string;
+  mode?: string;
+  message: string;
+  statusCode?: number | null;
+};
+
+type UserDetail = {
+  user: UserRecord & Partial<UserDetailFields>;
+  activity: ActivityEvent[];
+  errors: ErrorEvent[];
 };
 
 const TIERS = ["beta", "free", "paid"] as const;
+
+const EMPTY_FIELDS: UserDetailFields = {
+  company: "",
+  role: "",
+  notes: "",
+  instagram: "",
+  x: "",
+  linkedin: "",
+  youtube: "",
+};
+
+function LabeledInput({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div>
+      <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">{label}</label>
+      <input
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+      />
+    </div>
+  );
+}
+
+function fmtTime(iso: string | null | undefined) {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  const diff = Date.now() - d.getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" });
+}
 
 function fmtDate(iso: string | null | undefined) {
   if (!iso) return "—";
@@ -75,6 +162,72 @@ export default function AdminPage() {
   const [newCodes, setNewCodes] = useState<string[]>([]);
 
   const [busyUser, setBusyUser] = useState<string | null>(null);
+
+  // User detail drawer state
+  const [openUserId, setOpenUserId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailErr, setDetailErr] = useState<string | null>(null);
+  const [fields, setFields] = useState<UserDetailFields>(EMPTY_FIELDS);
+  const [saving, setSaving] = useState(false);
+
+  async function toggleUser(userId: string) {
+    if (openUserId === userId) {
+      setOpenUserId(null);
+      setDetail(null);
+      setFields(EMPTY_FIELDS);
+      setDetailErr(null);
+      return;
+    }
+    setOpenUserId(userId);
+    setDetail(null);
+    setDetailLoading(true);
+    setDetailErr(null);
+    try {
+      const res = await fetch(`/api/admin/users?userId=${encodeURIComponent(userId)}`);
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Detail fetch failed (${res.status})`);
+      }
+      const json = (await res.json()) as UserDetail;
+      setDetail(json);
+      setFields({
+        company: json.user.company ?? "",
+        role: json.user.role ?? "",
+        notes: (json.user as Partial<UserDetailFields>).notes ?? "",
+        instagram: (json.user as Partial<UserDetailFields>).instagram ?? "",
+        x: (json.user as Partial<UserDetailFields>).x ?? "",
+        linkedin: (json.user as Partial<UserDetailFields>).linkedin ?? "",
+        youtube: (json.user as Partial<UserDetailFields>).youtube ?? "",
+      });
+    } catch (e) {
+      setDetailErr(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  async function saveDetail() {
+    if (!openUserId) return;
+    setSaving(true);
+    setDetailErr(null);
+    try {
+      const res = await fetch("/api/admin/users", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ userId: openUserId, fields }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Save failed (${res.status})`);
+      }
+      await refresh();
+    } catch (e) {
+      setDetailErr(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function refresh() {
     setLoading(true);
@@ -356,12 +509,12 @@ export default function AdminPage() {
             <table className="w-full text-xs">
               <thead>
                 <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3 w-6"></th>
                   <th className="text-left p-3">Email</th>
+                  <th className="text-left p-3">Company</th>
                   <th className="text-left p-3">Tier</th>
                   <th className="text-left p-3">Joined</th>
-                  <th className="text-left p-3">Last login</th>
-                  <th className="text-right p-3">Usage (month)</th>
-                  <th className="text-left p-3">Invite</th>
+                  <th className="text-right p-3">Usage</th>
                   <th className="text-right p-3">Actions</th>
                 </tr>
               </thead>
@@ -373,32 +526,157 @@ export default function AdminPage() {
                     </td>
                   </tr>
                 ) : (
-                  users.map((u) => (
-                    <tr key={u.userId} className="border-b border-[#222] last:border-0 hover:bg-[#222]">
-                      <td className="p-3 text-foreground">{u.email}</td>
-                      <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{u.tier}</td>
-                      <td className="p-3 text-muted">{fmtDate(u.joinedAt)}</td>
-                      <td className="p-3 text-muted">{fmtDate(u.lastLoginAt)}</td>
-                      <td className="p-3 text-right tabular-nums text-muted">{u.usageThisMonth}</td>
-                      <td className="p-3 tabular-nums text-muted">{u.inviteCode ?? "—"}</td>
-                      <td className="p-3 text-right">
-                        <button
-                          onClick={() => resetUser(u.userId)}
-                          disabled={busyUser === u.userId}
-                          className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors mr-3 disabled:opacity-40"
+                  users.map((u) => {
+                    const open = openUserId === u.userId;
+                    return (
+                      <Fragment key={u.userId}>
+                        <tr
+                          className={`border-b border-[#222] hover:bg-[#222] cursor-pointer ${open ? "bg-[#222]" : ""}`}
+                          onClick={() => toggleUser(u.userId)}
                         >
-                          Reset
-                        </button>
-                        <button
-                          onClick={() => deleteUser(u.userId)}
-                          disabled={busyUser === u.userId}
-                          className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
-                        >
-                          Delete
-                        </button>
-                      </td>
-                    </tr>
-                  ))
+                          <td className="p-3 text-muted tabular-nums">{open ? "▾" : "▸"}</td>
+                          <td className="p-3 text-foreground">{u.email}</td>
+                          <td className="p-3 text-muted">{u.company || "—"}</td>
+                          <td className="p-3 text-muted uppercase tracking-widest text-[10px]">{u.tier}</td>
+                          <td className="p-3 text-muted">{fmtDate(u.joinedAt)}</td>
+                          <td className="p-3 text-right tabular-nums text-muted">{u.usageThisMonth}</td>
+                          <td className="p-3 text-right" onClick={(e) => e.stopPropagation()}>
+                            <button
+                              onClick={() => resetUser(u.userId)}
+                              disabled={busyUser === u.userId}
+                              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors mr-3 disabled:opacity-40"
+                            >
+                              Reset
+                            </button>
+                            <button
+                              onClick={() => deleteUser(u.userId)}
+                              disabled={busyUser === u.userId}
+                              className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
+                            >
+                              Delete
+                            </button>
+                          </td>
+                        </tr>
+                        {open && (
+                          <tr className="border-b border-[#222] bg-[#161616]">
+                            <td colSpan={7} className="p-0">
+                              {detailLoading ? (
+                                <div className="p-6 text-center text-muted font-sans">Loading…</div>
+                              ) : detailErr ? (
+                                <div className="p-4 text-ladder-red font-sans">{detailErr}</div>
+                              ) : detail ? (
+                                <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 p-5">
+                                  {/* ── Contact + notes ── */}
+                                  <div className="space-y-3">
+                                    <div className="text-[10px] uppercase tracking-widest text-muted mb-1">Contact &amp; notes</div>
+                                    <div className="grid grid-cols-2 gap-3">
+                                      <LabeledInput label="Company" value={fields.company} onChange={(v) => setFields({ ...fields, company: v })} />
+                                      <LabeledInput label="Role" value={fields.role} onChange={(v) => setFields({ ...fields, role: v })} />
+                                    </div>
+                                    <div className="grid grid-cols-2 gap-3">
+                                      <LabeledInput label="Instagram" value={fields.instagram} onChange={(v) => setFields({ ...fields, instagram: v })} />
+                                      <LabeledInput label="X (Twitter)" value={fields.x} onChange={(v) => setFields({ ...fields, x: v })} />
+                                    </div>
+                                    <div className="grid grid-cols-2 gap-3">
+                                      <LabeledInput label="LinkedIn" value={fields.linkedin} onChange={(v) => setFields({ ...fields, linkedin: v })} />
+                                      <LabeledInput label="YouTube" value={fields.youtube} onChange={(v) => setFields({ ...fields, youtube: v })} />
+                                    </div>
+                                    <div>
+                                      <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">Notes</label>
+                                      <textarea
+                                        value={fields.notes}
+                                        onChange={(e) => setFields({ ...fields, notes: e.target.value })}
+                                        rows={6}
+                                        placeholder="Sales context, call summaries, anything worth remembering…"
+                                        className="w-full bg-[#111] border border-[#333] text-sm text-foreground p-2.5 focus:outline-none focus:border-muted placeholder:text-[#555] resize-y font-sans"
+                                      />
+                                    </div>
+                                    <div className="flex items-center gap-3 pt-2">
+                                      <button
+                                        onClick={saveDetail}
+                                        disabled={saving}
+                                        className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+                                      >
+                                        {saving ? "Saving…" : "Save"}
+                                      </button>
+                                      <button
+                                        onClick={() => toggleUser(u.userId)}
+                                        className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+                                      >
+                                        Close
+                                      </button>
+                                    </div>
+                                  </div>
+
+                                  {/* ── Activity + errors ── */}
+                                  <div className="space-y-5">
+                                    <div>
+                                      <div className="text-[10px] uppercase tracking-widest text-muted mb-2">
+                                        Activity <span className="text-[#555]">({detail.activity.length})</span>
+                                      </div>
+                                      <ul className="divide-y divide-[#222] border border-[#222]">
+                                        {detail.activity.length === 0 ? (
+                                          <li className="p-3 text-muted font-sans">No activity yet.</li>
+                                        ) : (
+                                          detail.activity.map((ev, i) => (
+                                            <li key={i} className="p-2.5 flex items-center gap-3 font-sans">
+                                              {ev.type === "joined" ? (
+                                                <span className="text-[9px] uppercase tracking-widest text-ladder-green flex-shrink-0">Joined</span>
+                                              ) : (
+                                                <span className="text-[9px] uppercase tracking-widest text-muted flex-shrink-0 w-14">{ev.mode}</span>
+                                              )}
+                                              {ev.type === "score" && typeof ev.score === "number" && (
+                                                <span className="text-xs tabular-nums text-foreground font-semibold">
+                                                  {ev.score.toFixed(1)}
+                                                </span>
+                                              )}
+                                              {ev.type === "score" && ev.frameName && (
+                                                <span className="text-xs text-muted truncate flex-1">{ev.frameName}</span>
+                                              )}
+                                              {ev.type === "joined" && (
+                                                <span className="text-xs text-muted flex-1">via {ev.via ?? "invite"}</span>
+                                              )}
+                                              <span className="text-[10px] text-muted flex-shrink-0">{fmtTime(ev.timestamp)}</span>
+                                            </li>
+                                          ))
+                                        )}
+                                      </ul>
+                                    </div>
+
+                                    <div>
+                                      <div className="text-[10px] uppercase tracking-widest text-muted mb-2">
+                                        Errors <span className="text-[#555]">({detail.errors.length})</span>
+                                      </div>
+                                      <ul className="divide-y divide-[#222] border border-[#222]">
+                                        {detail.errors.length === 0 ? (
+                                          <li className="p-3 text-muted font-sans">No errors recorded.</li>
+                                        ) : (
+                                          detail.errors.map((ev, i) => (
+                                            <li key={i} className="p-2.5 font-sans">
+                                              <div className="flex items-center gap-3">
+                                                <span className="text-[9px] uppercase tracking-widest text-ladder-red flex-shrink-0">
+                                                  {ev.statusCode ?? "err"}
+                                                </span>
+                                                {ev.mode && (
+                                                  <span className="text-[9px] uppercase tracking-widest text-muted flex-shrink-0">{ev.mode}</span>
+                                                )}
+                                                <span className="text-[10px] text-muted flex-shrink-0 ml-auto">{fmtTime(ev.timestamp)}</span>
+                                              </div>
+                                              <div className="text-xs text-muted mt-1 break-words">{ev.message}</div>
+                                            </li>
+                                          ))
+                                        )}
+                                      </ul>
+                                    </div>
+                                  </div>
+                                </div>
+                              ) : null}
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })
                 )}
               </tbody>
             </table>

--- a/src/app/api/admin/invites/route.ts
+++ b/src/app/api/admin/invites/route.ts
@@ -12,6 +12,7 @@ type InviteRecord = {
   claimedBy: string | null;
   claimedAt?: string | null;
   createdAt: string;
+  expiresAt?: string | null;
 };
 
 /**

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -13,19 +13,50 @@ type UserRecord = {
   inviteCode: string | null;
   xp: number;
   usageThisMonth: number;
+  company?: string | null;
+  role?: string | null;
 };
 
 /**
- * Admin users — list, delete, reset invite.
- * Proxies the plugin backend's /api/auth/users. Clerk-admin-gated.
+ * Admin users — list, detail, patch, delete, reset invite.
+ *
+ * GET                    → list all users (summary)
+ * GET ?userId=X          → single-user detail bundle (user + activity + errors)
+ * GET ?userId=X&view=activity → just that user's activity
+ * GET ?userId=X&view=errors   → just that user's errors
+ * PATCH { userId, fields }    → edit whitelisted CRM fields
+ * DELETE { userId }           → hard-delete + unclaim invite
+ * POST { userId, action:"reset" } → unclaim invite without deleting
+ *
+ * All gated by Clerk admin email allowlist (getAdminEmail).
  */
-export async function GET() {
+export async function GET(req: NextRequest) {
   const admin = await getAdminEmail();
   if (!admin) {
     return NextResponse.json(
       { error: "Admin access required" },
       { status: 403, headers: API_VERSION_HEADERS },
     );
+  }
+
+  const url = new URL(req.url);
+  const userId = url.searchParams.get("userId");
+  const view = url.searchParams.get("view");
+
+  if (userId) {
+    const search: Record<string, string> = { userId };
+    if (view) search.view = view;
+    const result = await pluginFetch<unknown>("/api/auth/users", {
+      method: "GET",
+      search,
+    });
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: result.status, headers: API_VERSION_HEADERS },
+      );
+    }
+    return NextResponse.json(result.data, { headers: API_VERSION_HEADERS });
   }
 
   const result = await pluginFetch<{ users: UserRecord[] }>(
@@ -43,6 +74,41 @@ export async function GET() {
     { users: result.data.users ?? [] },
     { headers: API_VERSION_HEADERS },
   );
+}
+
+export async function PATCH(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: { userId?: string; fields?: Record<string, string | null> } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  if (!body.userId || !body.fields) {
+    return NextResponse.json(
+      { error: "userId and fields required" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const result = await pluginFetch<{ user: UserRecord }>("/api/auth/users", {
+    method: "PATCH",
+    body: { userId: body.userId, fields: body.fields },
+  });
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.error },
+      { status: result.status, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  return NextResponse.json(result.data, { headers: API_VERSION_HEADERS });
 }
 
 export async function DELETE(req: NextRequest) {


### PR DESCRIPTION
## Summary
Combined admin surface expansion. Three related concerns in one PR because they all touch the admin page.

### CRM drawer (new — depends on [ai-design-assistant#167](https://github.com/drawbackwards/ai-design-assistant/pull/167))
Expandable per-user drawer with:
- **Editable fields:** company, role, instagram, x, linkedin, youtube, notes — whitelisted PATCH to the plugin backend
- **Activity feed:** last 20 events (joined, score entries with mode + score + frame + relative time)
- **Error feed:** last 10 captured errors with status code + mode + message + time
- User list now shows a \"Company\" column at a glance without expanding

### Expires column on invite codes
Shows relative time until an unclaimed code expires (\"in 29d\", \"in 2d\", \"expired\"), tone-coded by urgency. Claimed codes say \"claimed\". Legacy codes without expiresAt say \"never\". Pairs with [ai-design-assistant#166](https://github.com/drawbackwards/ai-design-assistant/pull/166).

### ROADMAP.md
Captures everything we parked:
- Admin CRM extras (search, segments, lifecycle, CSV, bulk actions, custom limits, flags, audit log)
- Analytics (score trend, mode breakdown, cohort views)
- Auth/infra (admin subdomain, Clerk roles, data migration to runladder Redis)
- Stripe sync (subscription state, dunning, seat mgmt)
- Remaining plugin-backend migrations (chat, score-feedback)
- Public surfaces (/changelog page, /roadmap page, /status, API docs)

## Required env var (still)
\`PLUGIN_ADMIN_KEY\` in runladder Vercel (same value as ai-design-assistant's \`ADMIN_KEY\`).

## Merge order
This PR is safe to merge before or after the two plugin-backend PRs:
- Without #166: Expires column shows \"never\" on new codes
- Without #167: CRM drawer opens but PATCH 500s (plugin backend doesn't accept the fields yet) and activity/errors feeds are empty

Ideal: merge #166 and #167 first, then #78 lights up all three features at once.

## Test plan (post-deploy)
- [ ] Sign in as Ward, visit /admin — user row shows company column
- [ ] Click row → drawer expands, fetches detail
- [ ] Edit notes + save → refresh list confirms persistence
- [ ] Score something as Ward → reopen drawer → activity shows the new entry
- [ ] Generate a new beta code → Expires shows \"in 30d\"