### PR TITLE
Top 100: drop "definitive" from headline

### DIFF
--- a/src/app/top-100/page.tsx
+++ b/src/app/top-100/page.tsx
@@ -21,7 +21,7 @@ export default function Top100Page() {
             Ladder Top 100
           </p>
           <h1 className="text-3xl md:text-[2.75rem] font-bold leading-[1.15] tracking-tight mb-6 text-foreground">
-            The definitive ranking of<br />
+            A monthly leaderboard of<br />
             digital experience quality.
           </h1>
           <p className="text-base text-body max-w-xl mx-auto leading-relaxed">


### PR DESCRIPTION
One-line fix. The hero H1 called the Top 100 \"the definitive ranking\" while the subhead calls it a quick-scan snapshot for fun. Internal contradiction after yesterday's Pulse/Top 100 rebrand.

Changed:
- Before: \"The definitive ranking of digital experience quality.\"
- After: \"A monthly leaderboard of digital experience quality.\"

Matches the honest, ongoing-ranking framing that the subhead already sets up.