### PR TITLE
Blog: repair Pulse voice — Top 100 analysis isn't Pulse

### DIFF
--- a/src/app/blog/posts.ts
+++ b/src/app/blog/posts.ts
@@ -15,296 +15,296 @@ export const BLOG_POSTS: BlogPost[] = [
   {
     slug: "the-looks-vs-reality-gap",
     title: "The Looks vs. Reality Gap",
-    subtitle: "We pointed Ladder Pulse at 36 of the world's most-used products. The gap between how they look and how they actually feel is the most honest thing we've ever measured.",
+    subtitle: "We pointed Ladder at 36 of the world's most-used products. The gap between how they look and how they actually feel is the most honest thing we've ever measured.",
     date: "2026-03-19",
     readTime: "7 min read",
-    category: "Pulse Intelligence",
+    category: "Ladder Top 100 Analysis",
     featured: true,
     excerpt:
-      "Pulse analyzed 42,000+ data points across Airbnb and scored the lived experience at 2.3, while the interface scores 3.7. That 1.4-point gap isn't a rounding error. It's exactly the kind of hidden truth Pulse was built to find.",
+      "Ladder analyzed 42,000+ data points across Airbnb and scored the lived experience at 2.3, while the interface scores 3.7. That 1.4-point gap isn't a rounding error. It's exactly the kind of hidden truth Ladder was built to find.",
     products: ["notion", "airbnb", "arc", "apple-music", "raycast", "linear"],
-    content: `We built [Ladder Pulse](/pulse) to answer a question most product teams avoid: does your product actually feel as good as it looks?
+    content: `We built Ladder to answer a question most product teams avoid: does your product actually feel as good as it looks?
 
-Pulse is Ladder's proprietary experience intelligence engine. It ingests real customer sentiment from 3,000+ online sources and runs it through the [Ladder framework](/framework) to produce a single, honest score: the Pulse Score.
+[Ladder Pulse](/pulse) is our enterprise VOC product — it ingests the voice of your customers (support tickets, NPS responses, interview transcripts, in-app feedback, survey verbatim) and runs it through the [Ladder framework](/framework) to produce real Ladder scores for the lived experience. For the Ladder Top 100 study below, we used a lighter-weight public-signal analysis, not Pulse itself, since these products aren't our customers.
 
-To put Pulse to the test, we pointed it at 36 of the most-used digital products in the world. We scored each one twice. Once on the interface: the screens, the visual design, the information architecture. And once through Pulse, analyzing what thousands of real users actually say about the lived experience.
+We pointed Ladder at 36 of the most-used digital products in the world. We scored each one twice. Once on the interface: the screens, the visual design, the information architecture. And once against aggregated public sentiment — what thousands of real users actually say about the lived experience.
 
 The gap between those two numbers is the most honest thing we've ever measured.
 
-## What Pulse found: the biggest gaps
+## What Ladder found: the biggest gaps
 
-**[Airbnb](/top-100/airbnb): Screen 3.7, Pulse 2.3 (gap: -1.4)**
+**[Airbnb](/top-100/airbnb): Screen 3.7, Sentiment 2.3 (gap: -1.4)**
 
-Pulse ingested 42,000+ data points across 3,000+ online sources. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." Pulse says "surprise costs." [See how Airbnb's full score breaks down on the Top 100.](/top-100/airbnb)
+Ladder ingested 42,000+ data points across 3,000+ online sources. The signal was overwhelming: hidden fees at checkout, a host experience that feels like a different product, and a review system that's increasingly gamed. The screen says "discovery." The data says "surprise costs." [See how Airbnb's full score breaks down on the Top 100.](/top-100/airbnb)
 
-**[Notion](/top-100/notion): Screen 4.1, Pulse 2.8 (gap: -1.3)**
+**[Notion](/top-100/notion): Screen 4.1, Sentiment 2.8 (gap: -1.3)**
 
-Pulse analyzed 4,100+ data points across 3,000+ online sources. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. [See Notion's full Pulse breakdown.](/top-100/notion)
+Ladder analyzed 4,100+ data points across 3,000+ online sources. The pattern was clear: performance degrades with large workspaces, the blank-page syndrome is real, and search (the most critical feature in a knowledge tool) is not fast enough. The product that can do anything struggles to do the one thing users need most. [See Notion's full Top 100 breakdown.](/top-100/notion)
 
-**[Arc Browser](/top-100/arc): Screen 3.8, Pulse 2.6 (gap: -1.2)**
+**[Arc Browser](/top-100/arc): Screen 3.8, Sentiment 2.6 (gap: -1.2)**
 
-Pulse processed 1,800+ data points and surfaced a consistent theme: innovative sidebar navigation is undermined by stability issues, high memory consumption, and a learning curve that punishes people who just want to browse the web. Innovation without reliability is a demo, not a product.
+Ladder processed 1,800+ data points and surfaced a consistent theme: innovative sidebar navigation is undermined by stability issues, high memory consumption, and a learning curve that punishes people who just want to browse the web. Innovation without reliability is a demo, not a product.
 
-**[Apple Music](/top-100/apple-music): Screen 3.6, Pulse 2.4 (gap: -1.2)**
+**[Apple Music](/top-100/apple-music): Screen 3.6, Sentiment 2.4 (gap: -1.2)**
 
-Pulse analyzed 8,500+ data points across 3,000+ online sources, where app store ratings average 2.4 out of 5. Users consistently describe library management issues, inconsistent navigation, and discovery algorithms that trail Spotify by miles. Beautiful surfaces don't compensate for friction in daily tasks.
+Ladder analyzed 8,500+ data points across 3,000+ online sources, where app store ratings average 2.4 out of 5. Users consistently describe library management issues, inconsistent navigation, and discovery algorithms that trail Spotify by miles. Beautiful surfaces don't compensate for friction in daily tasks.
 
-## What Pulse found: products where reality exceeds appearance
+## What Ladder found: products where reality exceeds appearance
 
-Not every gap goes the wrong direction. Pulse identified products where the lived experience actually outperforms the interface.
+Not every gap goes the wrong direction. Ladder identified products where the lived experience actually outperforms the interface.
 
-**[Raycast](/top-100/raycast): Screen 3.8, Pulse 4.2 (gap: +0.4)**
+**[Raycast](/top-100/raycast): Screen 3.8, Sentiment 4.2 (gap: +0.4)**
 
-Pulse analyzed 1,500+ data points and found something remarkable: users rate this product higher than its interface suggests. The UI is minimal: a command bar and extensions. It doesn't photograph well. But Pulse surfaced language usually reserved for products people can't live without: "replaced five apps," "fastest tool I've ever used." When speed is the design, screenshots undersell it. [Explore Raycast's score on the Top 100.](/top-100/raycast)
+Ladder analyzed 1,500+ data points and found something remarkable: users rate this product higher than its interface suggests. The UI is minimal: a command bar and extensions. It doesn't photograph well. But Ladder surfaced language usually reserved for products people can't live without: "replaced five apps," "fastest tool I've ever used." When speed is the design, screenshots undersell it. [Explore Raycast's score on the Top 100.](/top-100/raycast)
 
-**[Linear](/top-100/linear): Screen 4.3, Pulse 4.2 (gap: -0.1)**
+**[Linear](/top-100/linear): Screen 4.3, Sentiment 4.2 (gap: -0.1)**
 
-Across 3,200+ data points, Pulse found a gap of just 0.1. That near-zero delta means the product is honest. The interface promises speed; the experience delivers speed. There's no marketing layer hiding a different reality underneath. [See why Linear leads the entire Top 100.](/top-100/linear)
+Across 3,200+ data points, Ladder found a gap of just 0.1. That near-zero delta means the product is honest. The interface promises speed; the experience delivers speed. There's no marketing layer hiding a different reality underneath. [See why Linear leads the entire Top 100.](/top-100/linear)
 
-**[Superhuman](/top-100/superhuman): Screen 3.8, Pulse 3.8 (gap: 0.0)**
+**[Superhuman](/top-100/superhuman): Screen 3.8, Sentiment 3.8 (gap: 0.0)**
 
-Pulse identified zero gap. The email client that charges $30/month looks like a $30/month email client and feels like one too. No bait-and-switch.
+Ladder identified zero gap. The email client that charges $30/month looks like a $30/month email client and feels like one too. No bait-and-switch.
 
 ## What the gap actually measures
 
-The Screen-to-Pulse delta isn't a quality score. It's a trust score. Products with small gaps are honest. Products with large gaps are making promises their experience can't keep.
+The Screen-to-Sentiment delta isn't a quality score. It's a trust score. Products with small gaps are honest. Products with large gaps are making promises their experience can't keep.
 
-This is exactly what Pulse was designed to reveal. Traditional metrics like NPS or CSAT give you a single sentiment number. Pulse maps customer voice data against the five levels of the Ladder framework and tells you not just *how* people feel, but *why*, and what to fix first.
+This is exactly what Ladder was designed to reveal. Traditional metrics like NPS or CSAT give you a single sentiment number. Ladder maps customer voice data against the five levels of the Ladder framework and tells you not just *how* people feel, but *why*, and what to fix first.
 
-A beautiful interface with a low Pulse Score is a warning: this team invests in appearance over substance. An unremarkable interface with a high Pulse Score is an opportunity: this team builds things that work, and hasn't yet invested in making them look as good as they feel.
+A beautiful interface with a low Ladder Top 100 score is a warning: this team invests in appearance over substance. An unremarkable interface with a high Ladder Top 100 score is an opportunity: this team builds things that work, and hasn't yet invested in making them look as good as they feel.
 
-The gap is where the real story lives. [Explore all 36 products and their Pulse Scores on the Ladder Top 100.](/top-100)
+The gap is where the real story lives. [Explore all 36 products and their Ladder Top 100 scores on the Ladder Top 100.](/top-100)
 
-## How Pulse works
+## How Ladder measures
 
-**Data ingestion:** Pulse scans 3,000+ online sources, aggregating thousands of data points per product. Ladder Pulse subscribers can also feed internal signals: support tickets, NPS responses, field reports, employee surveys, customer interviews, CSAT data, in-app feedback, and churn interviews.
+**Data ingestion:** Ladder scans 3,000+ online sources, aggregating thousands of data points per product. Ladder Pulse customers feed their own internal signals — support tickets, NPS responses, field reports, employee surveys, customer interviews, CSAT data, in-app feedback, churn interviews — to get the lived-experience score for their own product.
 
 **Ladder mapping:** Our AI, trained on 20 years of experience evaluation at Drawbackwards, analyzes sentiment, identifies friction patterns, and maps the quality of the described experience to Ladder's 1.0-5.0 scale. Not just positive or negative. Five distinct levels of experience quality.
 
-**Continuous scoring:** Pulse Scores update as new signal flows in. Both scores in this study will be updated monthly. The [Top 100](/top-100) is a living dataset.
+**Continuous scoring:** Ladder Top 100 scores update as new signal flows in. Both scores in this study will be updated monthly. The [Top 100](/top-100) is a living dataset.
 
-Want to see what Pulse reveals about your product or organization? [Request a Pulse demo](/contact) and see your real score from the people who use what you build.`,
+Want to see what Ladder reveals about your product or organization? [Request a Pulse demo](/contact) and see your real score from the people who use what you build.`,
   },
   {
     slug: "why-linear-is-number-one",
     title: "Why Linear Is #1 (and What Everyone Else Gets Wrong)",
-    subtitle: "Pulse analyzed 3,200+ data points on Linear and found the smallest gap between promise and reality in the entire Top 100.",
+    subtitle: "Ladder analyzed 3,200+ data points on Linear and found the smallest gap between promise and reality in the entire Top 100.",
     date: "2026-03-19",
     readTime: "5 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     featured: true,
     excerpt:
-      "Pulse scored Linear's lived experience at 4.2, within 0.1 of its Screen Score. That's the smallest gap in our dataset. Here's what Pulse found inside 3,200+ reviews, forum posts, and community discussions.",
+      "Ladder scored Linear's lived experience at 4.2, within 0.1 of its Screen Score. That's the smallest gap in our dataset. Here's what Ladder found inside 3,200+ reviews, forum posts, and community discussions.",
     products: ["linear", "jira", "notion"],
-    content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when [Pulse](/pulse) analyzed 3,200+ data points across 3,000+ online sources, it found something rare: the experience matches the interface almost exactly.
+    content: `[Linear](/top-100/linear) sits at #1 on the [Ladder Top 100](/top-100) with a 4.3. Not because it's the most visually impressive product, and not because it's the most feature-rich. Linear is #1 because when Ladder analyzed 3,200+ data points across 3,000+ online sources, it found something rare: the experience matches the interface almost exactly.
 
-## What Pulse found
+## What Ladder found
 
-Linear's Screen Score is 4.3. Its Pulse Score (the number our intelligence engine produces after ingesting and analyzing thousands of real user signals) is 4.2. That 0.1-point gap is the smallest in our entire dataset.
+Linear's Screen Score is 4.3. Its Ladder Top 100 score (the number our intelligence engine produces after ingesting and analyzing thousands of real user signals) is 4.2. That 0.1-point gap is the smallest in our entire dataset.
 
-For context: Pulse measured [Notion's](/top-100/notion) gap at -1.3. [Airbnb's](/top-100/airbnb) at -1.4. The average gap across all 36 products is -0.6.
+For context: Ladder measured [Notion's](/top-100/notion) gap at -1.3. [Airbnb's](/top-100/airbnb) at -1.4. The average gap across all 36 products is -0.6.
 
-A near-zero gap means the product is honest. Pulse couldn't find a meaningful difference between what Linear promises and what Linear delivers. That's the signal that separates a good-looking product from a genuinely great one. [See Linear's full score profile on the Top 100.](/top-100/linear)
+A near-zero gap means the product is honest. Ladder couldn't find a meaningful difference between what Linear promises and what Linear delivers. That's the signal that separates a good-looking product from a genuinely great one. [See Linear's full score profile on the Top 100.](/top-100/linear)
 
-## What Pulse identified as strengths
+## What Ladder identified as strengths
 
-**Speed as a design constraint.** Across professional reviews and developer forums, Pulse consistently surfaced speed as the defining sentiment. Not "it's fast for a project management tool," just "it's fast." Users describe every interaction completing in under 100ms. Pulse categorized this as a core experience differentiator, not just a feature.
+**Speed as a design constraint.** Across professional reviews and developer forums, Ladder consistently surfaced speed as the defining sentiment. Not "it's fast for a project management tool," just "it's fast." Users describe every interaction completing in under 100ms. Ladder categorized this as a core experience differentiator, not just a feature.
 
-**Keyboard-first interaction.** Pulse detected a pattern: users who mention keyboard shortcuts consistently rate the product higher than those who don't. The shortcuts follow a grammar (C for create, V for views, G for go-to) that users internalize within days. Pulse flagged this as a signal of "Delightful" level design: the product anticipates how expert users want to work.
+**Keyboard-first interaction.** Ladder detected a pattern: users who mention keyboard shortcuts consistently rate the product higher than those who don't. The shortcuts follow a grammar (C for create, V for views, G for go-to) that users internalize within days. Ladder flagged this as a signal of "Delightful" level design: the product anticipates how expert users want to work.
 
-**Information density without noise.** Pulse analyzed sentiment around Linear's data-heavy screens and found almost zero complaints about visual clutter. Issue lists, project boards, cycles, roadmaps: there's always a lot visible. Users don't describe it as overwhelming. Pulse attributes this to precise visual hierarchy: bold for what matters now, muted for context, invisible until needed for everything else.
+**Information density without noise.** Ladder analyzed sentiment around Linear's data-heavy screens and found almost zero complaints about visual clutter. Issue lists, project boards, cycles, roadmaps: there's always a lot visible. Users don't describe it as overwhelming. Ladder attributes this to precise visual hierarchy: bold for what matters now, muted for context, invisible until needed for everything else.
 
-## What Pulse identified as weaknesses
+## What Ladder identified as weaknesses
 
-No product scores 5.0. Pulse surfaced consistent friction points:
+No product scores 5.0. Ladder surfaced consistent friction points:
 
-The mobile experience trails the desktop product significantly. Pulse found that mobile-related reviews score measurably lower. Reporting and analytics generate negative sentiment among team leads who need to present progress, so they export to other tools. Custom workflows, while improving, still generate complaints from teams migrating from Jira.
+The mobile experience trails the desktop product significantly. Ladder found that mobile-related reviews score measurably lower. Reporting and analytics generate negative sentiment among team leads who need to present progress, so they export to other tools. Custom workflows, while improving, still generate complaints from teams migrating from Jira.
 
-## The Jira comparison: what Pulse reveals
+## The Jira comparison: what Ladder reveals
 
-[Jira](/top-100/jira) scores 2.1 on Ladder. Pulse analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Pulse Score on the Top 100.](/top-100/jira)
+[Jira](/top-100/jira) scores 2.1 on Ladder. Ladder analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions, and found overwhelming evidence that this is a product users tolerate because of switching costs, not because of experience quality. [See Jira's full Ladder Top 100 score on the Top 100.](/top-100/jira)
 
-The comparison is instructive: Jira was built to serve methodologies (Scrum, Kanban, SAFe). Linear was built to serve humans. Pulse can measure the difference. Products designed for process consistently score lower on lived experience because humans aren't processes.
+The comparison is instructive: Jira was built to serve methodologies (Scrum, Kanban, SAFe). Linear was built to serve humans. Ladder can measure the difference. Products designed for process consistently score lower on lived experience because humans aren't processes.
 
-## What Pulse proves here
+## What Ladder proves here
 
-The best products aren't the ones with the most features or the most beautiful interfaces. They're the ones where the gap between promise and reality approaches zero. Pulse was built to find that gap, and to measure it with precision.
+The best products aren't the ones with the most features or the most beautiful interfaces. They're the ones where the gap between promise and reality approaches zero. Ladder was built to find that gap, and to measure it with precision.
 
-Linear's lesson: make fewer promises and keep all of them. Pulse will know the difference.
+Linear's lesson: make fewer promises and keep all of them. Ladder will know the difference.
 
-[Explore the full Ladder Top 100](/top-100) to see how every product compares. And if you want to know what Pulse would reveal about your own product or organization, [request a demo](/contact). We'll show you your real score from the people who use what you build.`,
+[Explore the full Ladder Top 100](/top-100) to see how every product compares. And if you want to know what Ladder would reveal about your own product or organization, [request a demo](/contact). We'll show you your real score from the people who use what you build.`,
   },
   {
     slug: "notion-the-4-1-product-with-a-2-8-reality",
     title: "Notion: The 4.1 Product with a 2.8 Reality",
-    subtitle: "Pulse processed 4,100+ reviews and forum posts and found a -1.3 gap between Notion's interface promise and its lived experience.",
+    subtitle: "Ladder processed 4,100+ reviews and forum posts and found a -1.3 gap between Notion's interface promise and its lived experience.",
     date: "2026-03-18",
     readTime: "6 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     excerpt:
-      "Notion's interface scores 4.1. When Pulse ingested 4,100+ real user signals across 3,000+ online sources, it scored the lived experience at 2.8. The gap reveals a product that's better at promising than delivering.",
+      "Notion's interface scores 4.1. When Ladder ingested 4,100+ real user signals across 3,000+ online sources, it scored the lived experience at 2.8. The gap reveals a product that's better at promising than delivering.",
     products: ["notion", "linear", "airtable"],
     content: `[Notion's](/top-100/notion) interface is genuinely impressive. The block-based editor is flexible, the database views are powerful, and the visual design is clean and confident. It scores 4.1 on screen quality, putting it in Delightful territory.
 
-Then we pointed [Pulse](/pulse) at it.
+Then we pointed Ladder at it.
 
-## What 4,100+ data points told Pulse
+## What 4,100+ data points revealed
 
-Pulse ingested public reviews, forums, and community discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
+Ladder ingested public reviews, forums, and community discussions, totaling over 4,100 individual data points. Our intelligence engine analyzed the sentiment, identified recurring friction patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
-The result: a Pulse Score of 2.8. Upper Usable. A -1.3 gap from the Screen Score.
+The result: a Ladder Top 100 score of 2.8. Upper Usable. A -1.3 gap from the Screen Score.
 
-Here's what Pulse surfaced as the dominant themes:
+Here's what Ladder surfaced as the dominant themes:
 
-**Performance.** Pulse flagged performance as the #1 negative signal. "Notion is great until your workspace gets big." This complaint appeared across more than 30% of negative reviews. Pages load slowly. Search takes seconds when it should take milliseconds. Pulse categorized this as a structural issue, not a temporary bug. The product's flexibility creates a performance ceiling that hits harder as usage scales.
+**Performance.** Ladder flagged performance as the #1 negative signal. "Notion is great until your workspace gets big." This complaint appeared across more than 30% of negative reviews. Pages load slowly. Search takes seconds when it should take milliseconds. Ladder categorized this as a structural issue, not a temporary bug. The product's flexibility creates a performance ceiling that hits harder as usage scales.
 
-**The blank page problem.** Pulse detected strong negative sentiment around onboarding and first-use experience. New users face an empty workspace and a block menu with 50+ options. The same flexibility that makes power users love Notion makes new users freeze. Pulse scored this as a Usable-level experience: the task can be completed, but with effort.
+**The blank page problem.** Ladder detected strong negative sentiment around onboarding and first-use experience. New users face an empty workspace and a block menu with 50+ options. The same flexibility that makes power users love Notion makes new users freeze. Ladder scored this as a Usable-level experience: the task can be completed, but with effort.
 
-**Search.** For a product that positions itself as your team's knowledge base, Pulse found search-related complaints across every data source. Users report difficulty finding documents they wrote last week. In a tool where you're supposed to put everything, not being able to find anything is what Pulse identifies as a critical experience failure. [See Notion's full score on the Top 100.](/top-100/notion)
+**Search.** For a product that positions itself as your team's knowledge base, Ladder found search-related complaints across every data source. Users report difficulty finding documents they wrote last week. In a tool where you're supposed to put everything, not being able to find anything is what Ladder identifies as a critical experience failure. [See Notion's full score on the Top 100.](/top-100/notion)
 
-## The flexibility trap, as Pulse sees it
+## The flexibility trap, as Ladder sees it
 
-Pulse identified something deeper than individual complaints: a structural pattern. The more flexible the product, the more the experience depends on how you configure it. A well-structured Notion workspace is genuinely powerful. A poorly structured one is a maze.
+Ladder identified something deeper than individual complaints: a structural pattern. The more flexible the product, the more the experience depends on how you configure it. A well-structured Notion workspace is genuinely powerful. A poorly structured one is a maze.
 
-This means Notion's quality varies by user in a way most products don't. Your Notion and my Notion are different products. The 4.1 Screen Score reflects the best Notion can be. The 2.8 Pulse Score reflects what Notion actually is for most people, as measured by thousands of real voices.
+This means Notion's quality varies by user in a way most products don't. Your Notion and my Notion are different products. The 4.1 Screen Score reflects the best Notion can be. The 2.8 Ladder Top 100 score reflects what Notion actually is for most people, as measured by thousands of real voices.
 
-## What Pulse would tell Notion's product team
+## What Ladder would tell Notion's product team
 
-The -1.3 delta isn't just a number. It's Pulse translating thousands of user voices into a clear signal:
+The -1.3 delta isn't just a number. It's Ladder translating thousands of user voices into a clear signal:
 
-**Invest in performance before features.** Pulse ranked performance as the #1 friction driver. Every new block type, every new database view, every new AI feature adds to the load. Users will forgive missing features. They won't forgive a slow knowledge base.
+**Invest in performance before features.** Ladder ranked performance as the #1 friction driver. Every new block type, every new database view, every new AI feature adds to the load. Users will forgive missing features. They won't forgive a slow knowledge base.
 
-**Solve the blank page.** Pulse detected that onboarding-related sentiment is significantly more negative than established-user sentiment. Guided setup, workspace templates that actually structure your work, progressive disclosure. These are the path from 2.8 to 3.5.
+**Solve the blank page.** Ladder detected that onboarding-related sentiment is significantly more negative than established-user sentiment. Guided setup, workspace templates that actually structure your work, progressive disclosure. These are the path from 2.8 to 3.5.
 
-**Fix search.** A knowledge tool that can't find knowledge isn't a knowledge tool. Pulse identified this as the single highest-leverage improvement Notion can make.
+**Fix search.** A knowledge tool that can't find knowledge isn't a knowledge tool. Ladder identified this as the single highest-leverage improvement Notion can make.
 
 ## The comparison
 
-Pulse scored [Linear's](/top-100/linear) gap at -0.1. Notion's at -1.3. Both are well-designed products. The difference: Linear chose speed and constraints. Notion chose flexibility and power. Pulse's data suggests users value the former more than the latter.
+Ladder scored [Linear's](/top-100/linear) gap at -0.1. Notion's at -1.3. Both are well-designed products. The difference: Linear chose speed and constraints. Notion chose flexibility and power. Ladder's data suggests users value the former more than the latter.
 
-This is what Pulse does. It takes the noise of thousands of reviews and turns it into a signal you can act on. [Explore how Notion compares against every product on the Ladder Top 100](/top-100), and if you want Pulse to analyze the experience your product or organization delivers, [request a demo](/contact).`,
+This is what Ladder does. It takes the noise of thousands of reviews and turns it into a signal you can act on. [Explore how Notion compares against every product on the Ladder Top 100](/top-100), and if you want Ladder Pulse to analyze your own customers' voice on the experience your product or organization delivers, [request a demo](/contact).`,
   },
   {
     slug: "the-enterprise-ux-crisis",
     title: "The Enterprise UX Crisis in Three Scores",
-    subtitle: "Pulse analyzed over 114,000 data points across Jira, Salesforce, and Workday. The software millions use daily is the software nobody would choose.",
+    subtitle: "Ladder analyzed over 114,000 data points across Jira, Salesforce, and Workday. The software millions use daily is the software nobody would choose.",
     date: "2026-03-18",
     readTime: "5 min read",
-    category: "Pulse Intelligence",
+    category: "Ladder Top 100 Analysis",
     excerpt:
-      "Pulse scored the three most-used enterprise products in the world: Jira (2.1), Salesforce (2.2), Workday (1.4). Over 114,000 data points across 3,000+ online sources reveal an experience crisis hiding in plain sight.",
+      "Ladder scored the three most-used enterprise products in the world: Jira (2.1), Salesforce (2.2), Workday (1.4). Over 114,000 data points across 3,000+ online sources reveal an experience crisis hiding in plain sight.",
     products: ["jira", "salesforce", "workday"],
-    content: `We pointed [Pulse](/pulse) at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Pulse ingested over 114,000 data points across 3,000+ online sources, including public reviews, forums, and community discussions.
+    content: `We pointed Ladder at the backbone of enterprise software: the three products that collectively touch hundreds of millions of knowledge workers every day. Ladder ingested over 114,000 data points across 3,000+ online sources, including public reviews, forums, and community discussions.
 
 The results:
 
-- **[Jira](/top-100/jira)**: Pulse Score 2.1 (Usable), 15,000+ data points
-- **[Salesforce](/top-100/salesforce)**: Pulse Score 2.2 (Usable), 94,000+ data points
-- **[Workday](/top-100/workday)**: Pulse Score 1.4 (Functional), 5,000+ data points
+- **[Jira](/top-100/jira)**: Ladder Top 100 score 2.1 (Usable), 15,000+ data points
+- **[Salesforce](/top-100/salesforce)**: Ladder Top 100 score 2.2 (Usable), 94,000+ data points
+- **[Workday](/top-100/workday)**: Ladder Top 100 score 1.4 (Functional), 5,000+ data points
 
-These aren't obscure tools. They're the products that define enterprise software. And Pulse scored them lower than almost everything else in the [Top 100](/top-100). [See all three scores on the Ladder Top 100.](/top-100)
+These aren't obscure tools. They're the products that define enterprise software. And Ladder scored them lower than almost everything else in the [Top 100](/top-100). [See all three scores on the Ladder Top 100.](/top-100)
 
-## What Pulse reveals: the buying problem
+## What Ladder reveals: the buying problem
 
-Pulse doesn't just score sentiment. It identifies *why* the experience is what it is. Across all three products, Pulse surfaced the same structural pattern: enterprise software isn't chosen by the people who use it.
+Ladder doesn't just score sentiment. It identifies *why* the experience is what it is. Across all three products, Ladder surfaced the same structural pattern: enterprise software isn't chosen by the people who use it.
 
 It's chosen by procurement teams evaluating feature checklists, IT departments evaluating security requirements, and executives evaluating vendor relationships. The person who submits their time off in Workday every Friday had no say in the decision.
 
-Pulse can measure the cost of that disconnect. Here's what it found.
+Ladder can measure the cost of that disconnect. Here's what it found.
 
-## Jira: Pulse Score 2.1
+## Jira: Ladder Top 100 score 2.1
 
-Pulse analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions. The intelligence was clear: Jira's 4.3/5 on traditional review platforms reflects buyer satisfaction. Pulse's 2.1 reflects user experience.
+Ladder analyzed 15,000+ data points across professional review platforms, community forums, and developer discussions. The intelligence was clear: Jira's 4.3/5 on traditional review platforms reflects buyer satisfaction. Ladder's 2.1 reflects user experience.
 
-The dominant signal: every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Pulse detected overwhelming negative sentiment around the 2025 navigation redesign, which users described as making an already complex product worse. [See Jira's full Pulse analysis on the Top 100.](/top-100/jira)
+The dominant signal: every simple action (creating an issue, checking a sprint, finding a dashboard) requires more steps and more cognitive load than it should. Ladder detected overwhelming negative sentiment around the 2025 navigation redesign, which users described as making an already complex product worse. [See Jira's full Top 100 analysis on the Top 100.](/top-100/jira)
 
-For context: [Linear](/top-100/linear) does much less and Pulse scores it at 4.2. The features Jira has that Linear doesn't? Pulse found that most users don't need them.
+For context: [Linear](/top-100/linear) does much less and Ladder scores it at 4.2. The features Jira has that Linear doesn't? Ladder found that most users don't need them.
 
-## Salesforce: Pulse Score 2.2
+## Salesforce: Ladder Top 100 score 2.2
 
-Pulse processed 94,000+ data points, the largest dataset of any product in the Top 100. Public reviews, professional platforms, community forums, and independent analysis all fed into the Pulse engine.
+Ladder processed 94,000+ data points, the largest dataset of any product in the Top 100. Public reviews, professional platforms, community forums, and independent analysis all fed into the Ladder engine.
 
-What Pulse found: a massive gap between capability and experience. Salesforce can do almost anything. But Pulse identified that end users (the sales reps and support agents who click through it 8 hours a day) generate overwhelmingly negative experience signals. The Lightning redesign improved surface aesthetics but didn't address the labyrinthine navigation and inconsistent patterns across modules that Pulse flagged as structural issues.
+What Ladder found: a massive gap between capability and experience. Salesforce can do almost anything. But Ladder identified that end users (the sales reps and support agents who click through it 8 hours a day) generate overwhelmingly negative experience signals. The Lightning redesign improved surface aesthetics but didn't address the labyrinthine navigation and inconsistent patterns across modules that Ladder flagged as structural issues.
 
-The most common sentiment Pulse extracted: "It's the industry standard, so we use it." That's not a product endorsement. It's a resignation. [Explore Salesforce's full score.](/top-100/salesforce)
+The most common sentiment Ladder extracted: "It's the industry standard, so we use it." That's not a product endorsement. It's a resignation. [Explore Salesforce's full score.](/top-100/salesforce)
 
-## Workday: Pulse Score 1.4
+## Workday: Ladder Top 100 score 1.4
 
-Pulse scored Workday the lowest of any product in the entire Top 100. Across 5,000+ data points from public reviews, forums, and employee sentiment platforms, Pulse identified a product in the Functional tier, meaning users fight it to complete basic tasks.
+Ladder scored Workday the lowest of any product in the entire Top 100. Across 5,000+ data points from public reviews, forums, and employee sentiment platforms, Ladder identified a product in the Functional tier, meaning users fight it to complete basic tasks.
 
-The most striking signal: Pulse found that even simple actions like submitting time off, checking a pay stub, or updating personal information generate measurably negative sentiment. The interface feels dated. Navigation requires memorizing paths rather than following intuition. And the job applicant experience, which touches millions of people, is what Pulse classifies as a UX crisis. [See Workday's full score.](/top-100/workday)
+The most striking signal: Ladder found that even simple actions like submitting time off, checking a pay stub, or updating personal information generate measurably negative sentiment. The interface feels dated. Navigation requires memorizing paths rather than following intuition. And the job applicant experience, which touches millions of people, is what Ladder classifies as a UX crisis. [See Workday's full score.](/top-100/workday)
 
-## What Pulse proves about enterprise software
+## What Ladder proves about enterprise software
 
-This is exactly the problem Pulse was built to solve. Traditional review platforms aggregate buyer satisfaction, which is why Jira, Salesforce, and Workday all score 4.0+ on professional review platforms. Pulse measures something different: the quality of the lived experience, from the perspective of the person who has to use the product every day.
+This is exactly the problem Ladder was built to solve. Traditional review platforms aggregate buyer satisfaction, which is why Jira, Salesforce, and Workday all score 4.0+ on professional review platforms. Ladder measures something different: the quality of the lived experience, from the perspective of the person who has to use the product every day.
 
-The enterprise UX crisis isn't about technology. It's about incentives. When the buyer isn't the user, the user's experience becomes secondary. Pulse makes that gap visible. And measurable. And impossible to ignore.
+The enterprise UX crisis isn't about technology. It's about incentives. When the buyer isn't the user, the user's experience becomes secondary. Ladder makes that gap visible. And measurable. And impossible to ignore.
 
-But the pressure is building. Pulse Scores prove that tools like [Linear](/top-100/linear) (4.2), [Mercury](/top-100/mercury) (3.2), and [Figma](/top-100/figma) (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
+But the pressure is building. Ladder Top 100 scores prove that tools like [Linear](/top-100/linear) (4.2), [Mercury](/top-100/mercury) (3.2), and [Figma](/top-100/figma) (3.8) deliver business-class capability at Comfortable-or-better experience levels. As the generation that grew up with consumer-grade software moves into decision-making roles, the tolerance for 1.4-level experiences will evaporate.
 
-The scores won't lie. Pulse will make sure of it. [Explore the full Ladder Top 100](/top-100) and see where every product stands.
+The scores won't lie. Ladder will make sure of it. [Explore the full Ladder Top 100](/top-100) and see where every product stands.
 
-If your organization relies on enterprise tools and wants to measure the real experience your people have (not what the vendor says, but what your users feel), Pulse can do for your internal tools what we just did for these 36 products. [Request a Pulse demo.](/contact)`,
+If your organization relies on enterprise tools and wants to measure the real experience your people have (not what the vendor says, but what your users feel), Ladder can do for your internal tools what we just did for these 36 products. [Request a Pulse demo.](/contact)`,
   },
   {
     slug: "airbnb-the-most-beautiful-2-3",
     title: "Airbnb: The Most Beautiful 2.3 in the World",
-    subtitle: "Pulse ingested 42,000+ reviews, forum posts, and community discussions about Airbnb. The product that defined emotional design is failing the people who use it.",
+    subtitle: "Ladder ingested 42,000+ reviews, forum posts, and community discussions about Airbnb. The product that defined emotional design is failing the people who use it.",
     date: "2026-03-17",
     readTime: "5 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     excerpt:
-      "Airbnb's interface scores 3.7: emotional design, beautiful photography, discovery that feels like exploring. Pulse analyzed 42,000+ real user signals and scored the lived experience at 2.3. The gap is about trust.",
+      "Airbnb's interface scores 3.7: emotional design, beautiful photography, discovery that feels like exploring. Ladder analyzed 42,000+ real user signals and scored the lived experience at 2.3. The gap is about trust.",
     products: ["airbnb", "shopify"],
     content: `[Airbnb](/top-100/airbnb) wrote the playbook on emotional design. The listing photography, the map integration, the category browsing (OMG!, Icons, Treehouses). Every pixel is engineered to make you feel something. It works. The Screen Score is 3.7.
 
-Then we ran it through [Pulse](/pulse).
+Then we ran it through Ladder.
 
-## What Pulse found across 42,000+ signals
+## What Ladder found across 42,000+ signals
 
-Pulse ingested data across 3,000+ online sources, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
+Ladder ingested data across 3,000+ online sources, totaling over 42,000 individual data points. Our intelligence engine analyzed the sentiment, identified experience patterns, and mapped the lived experience to the [Ladder framework](/framework).
 
-The Pulse Score: 2.3. Usable. A -1.4 gap from the Screen Score, one of the largest in the entire Top 100.
+The Ladder Top 100 score: 2.3. Usable. A -1.4 gap from the Screen Score, one of the largest in the entire Top 100.
 
-Here's what Pulse surfaced as the three dominant signals:
+Here's what Ladder surfaced as the three dominant signals:
 
-**Hidden fees.** Pulse identified pricing transparency as the #1 negative signal by volume. The listing says $150/night. At checkout, it's $245 after cleaning fees, service fees, and taxes that weren't visible during browsing. Users describe this as "bait and switch." Pulse categorized this not as a UX issue but as a trust issue: the emotional design that drew you in sets expectations that the pricing structure breaks.
+**Hidden fees.** Ladder identified pricing transparency as the #1 negative signal by volume. The listing says $150/night. At checkout, it's $245 after cleaning fees, service fees, and taxes that weren't visible during browsing. Users describe this as "bait and switch." Ladder categorized this not as a UX issue but as a trust issue: the emotional design that drew you in sets expectations that the pricing structure breaks.
 
-**The host experience.** Pulse detected a significant quality split between guest-facing and host-facing experiences. The guest product scores well on visual dimensions. The host tools generate overwhelmingly negative sentiment: cluttered, inconsistent, and spread across interfaces that don't share the same design language. This matters because frustrated hosts create worse guest experiences. Pulse can see both sides of a two-sided marketplace.
+**The host experience.** Ladder detected a significant quality split between guest-facing and host-facing experiences. The guest product scores well on visual dimensions. The host tools generate overwhelmingly negative sentiment: cluttered, inconsistent, and spread across interfaces that don't share the same design language. This matters because frustrated hosts create worse guest experiences. Ladder can see both sides of a two-sided marketplace.
 
-**Review system erosion.** Pulse surfaced growing distrust in Airbnb's review system. The reciprocal review structure creates social pressure that inflates ratings. Users increasingly describe reviews as unreliable. Pulse flagged this as a platform credibility issue that compounds over time.
+**Review system erosion.** Ladder surfaced growing distrust in Airbnb's review system. The reciprocal review structure creates social pressure that inflates ratings. Users increasingly describe reviews as unreliable. Ladder flagged this as a platform credibility issue that compounds over time.
 
 [See Airbnb's full score breakdown on the Top 100.](/top-100/airbnb)
 
-## The emotional design paradox, quantified by Pulse
+## The emotional design paradox, quantified by Ladder
 
-Pulse revealed something important about emotional design: it can be a liability. When your interface creates strong positive feelings during browsing, any negative surprise during booking hits harder. The delta between expectation and reality is *amplified* by the quality of the initial experience.
+Ladder revealed something important about emotional design: it can be a liability. When your interface creates strong positive feelings during browsing, any negative surprise during booking hits harder. The delta between expectation and reality is *amplified* by the quality of the initial experience.
 
-A product with a neutral interface and hidden fees is annoying. A product with a beautiful, emotionally engaging interface and hidden fees feels like a betrayal. Pulse measured that betrayal at -1.4 points.
+A product with a neutral interface and hidden fees is annoying. A product with a beautiful, emotionally engaging interface and hidden fees feels like a betrayal. Ladder measured that betrayal at -1.4 points.
 
-## What Pulse would tell Airbnb
+## What Ladder would tell Airbnb
 
-A Pulse Score of 2.3 puts Airbnb at "Usable," meaning users can complete tasks but tolerate the experience rather than enjoy it. For a product whose entire brand is built on emotional connection, scoring "tolerable" is a crisis.
+A Ladder Top 100 score of 2.3 puts Airbnb at "Usable," meaning users can complete tasks but tolerate the experience rather than enjoy it. For a product whose entire brand is built on emotional connection, scoring "tolerable" is a crisis.
 
 The fix isn't more emotional design. It's transparent pricing, a host experience that matches the guest experience, and a review system users trust. None of these are screen-level problems. They're product-level problems that no amount of beautiful UI can solve.
 
-Pulse found the gap. It's -1.4 points wide. That's the distance between how Airbnb looks and how Airbnb feels.
+Ladder found the gap. It's -1.4 points wide. That's the distance between how Airbnb looks and how Airbnb feels.
 
-This is what Pulse does: it ingests the signal your customers are already broadcasting and translates it into a score you can act on. [Explore the full Ladder Top 100](/top-100) to see how every product compares, or [request a Pulse demo](/contact) to see what your customers are really saying about you.`,
+This is what Ladder does: it ingests the signal your customers are already broadcasting and translates it into a score you can act on. [Explore the full Ladder Top 100](/top-100) to see how every product compares, or [request a Pulse demo](/contact) to see what your customers are really saying about you.`,
   },
   {
     slug: "what-a-3-0-actually-means",
     title: "What a 3.0 Actually Means",
-    subtitle: "When Pulse scored 36 products, only 15 cleared the Comfortable threshold. The modern minimum bar is higher than most teams think.",
+    subtitle: "When Ladder scored 36 products, only 15 cleared the Comfortable threshold. The modern minimum bar is higher than most teams think.",
     date: "2026-03-17",
     readTime: "4 min read",
     category: "Framework",
     excerpt:
-      "On the Ladder scale, 3.0 is 'Comfortable': the point where a product stops making you think. When Pulse scored 36 of the most-used digital products, only 15 cleared this bar.",
+      "On the Ladder scale, 3.0 is 'Comfortable': the point where a product stops making you think. When Ladder scored 36 of the most-used digital products, only 15 cleared this bar.",
     products: [],
     content: `The [Ladder framework](/framework) scores products from 1.0 to 5.0. Most people focus on the high scores: what does a 4.0 look like? What earns a 5.0?
 
-The more important question, and the one [Pulse](/pulse) answers with data, is: what does a 3.0 mean?
+The more important question, and the one Ladder answers with data, is: what does a 3.0 mean?
 
 ## The Comfortable threshold
 
@@ -317,13 +317,13 @@ Level 3 on the Ladder is called "Comfortable." It means:
 
 This sounds basic. It is basic. That's the point. A 3.0 doesn't mean a product is exciting, innovative, or beautiful. It means the product works without making you fight it.
 
-## Pulse data: most products don't clear it
+## Ladder data: most products don't clear it
 
-When we pointed Pulse at 36 of the most prominent digital products in the world, ingesting millions of data points across 3,000+ online sources, only 15 scored 3.0 or above.
+When we pointed Ladder at 36 of the most prominent digital products in the world, ingesting millions of data points across 3,000+ online sources, only 15 scored 3.0 or above.
 
 That means 21 of the most-used digital products in the world still make their users think more than they should.
 
-The products Pulse scored below 3.0 include names you'd expect ([Jira](/top-100/jira) at 2.1, [Salesforce](/top-100/salesforce) at 2.2, [Workday](/top-100/workday) at 1.4) and names you might not ([Shopify](/top-100/shopify) at 2.9, [Airtable](/top-100/airtable) at 2.7, [ChatGPT](/top-100/chatgpt) at 2.8, [Coinbase](/top-100/coinbase) at 2.7). [See the full rankings on the Ladder Top 100.](/top-100)
+The products Ladder scored below 3.0 include names you'd expect ([Jira](/top-100/jira) at 2.1, [Salesforce](/top-100/salesforce) at 2.2, [Workday](/top-100/workday) at 1.4) and names you might not ([Shopify](/top-100/shopify) at 2.9, [Airtable](/top-100/airtable) at 2.7, [ChatGPT](/top-100/chatgpt) at 2.8, [Coinbase](/top-100/coinbase) at 2.7). [See the full rankings on the Ladder Top 100.](/top-100)
 
 ## Why 3.0 is the bar
 
@@ -331,36 +331,36 @@ We call 3.0 the "modern minimum" because it's what users now expect. Not because
 
 The average person uses 30+ digital products. They use Uber and expect clear status. They use iMessage and expect instant send. They use Google and expect useful results in milliseconds. These baseline experiences set a 3.0 floor in users' minds.
 
-When Pulse scores your product below 3.0, you're not competing against some theoretical standard. You're competing against the best interaction your user had today on any other product.
+When Ladder scores your product below 3.0, you're not competing against some theoretical standard. You're competing against the best interaction your user had today on any other product.
 
-## The 2.0 trap: what Pulse sees most often
+## The 2.0 trap: what Ladder sees most often
 
-Many products get stuck in what Pulse data reveals as the most common territory: the 2.0 trap. They're usable (tasks can be completed), but every interaction requires slightly more effort than it should. Finding a setting takes two extra clicks. The loading state doesn't tell you what's happening. The error message doesn't tell you how to fix it.
+Many products get stuck in what Ladder data reveals as the most common territory: the 2.0 trap. They're usable (tasks can be completed), but every interaction requires slightly more effort than it should. Finding a setting takes two extra clicks. The loading state doesn't tell you what's happening. The error message doesn't tell you how to fix it.
 
-No single issue is a dealbreaker. The accumulation is. And Pulse sees the accumulation, because it analyzes thousands of individual experience signals, not a single survey question.
+No single issue is a dealbreaker. The accumulation is. And Ladder sees the accumulation, because it analyzes thousands of individual experience signals, not a single survey question.
 
 Products in the 2.0-2.9 range often have strong underlying technology, capable teams, and reasonable feature sets. What they lack is the editorial discipline to remove friction from every common task. They shipped the feature but didn't stay long enough to make it effortless.
 
 ## Getting from 2.0 to 3.0
 
-The path from 2.0 to 3.0 isn't about adding features. Pulse data across all 36 products consistently shows the same friction patterns:
+The path from 2.0 to 3.0 isn't about adding features. Ladder data across all 36 products consistently shows the same friction patterns:
 
-**Reducing steps.** Every common task should take the minimum possible actions. If users do something 10 times a day and it takes 4 clicks, making it take 2 clicks saves 20 clicks daily. Multiply by your user base. Pulse detects this friction in user language, in phrases like "too many clicks," "why can't I just," "should be simpler."
+**Reducing steps.** Every common task should take the minimum possible actions. If users do something 10 times a day and it takes 4 clicks, making it take 2 clicks saves 20 clicks daily. Multiply by your user base. Ladder detects this friction in user language, in phrases like "too many clicks," "why can't I just," "should be simpler."
 
-**Meeting expectations.** Put things where people look for them first. Use patterns that match what users know from other products. Surprise is the enemy of Comfortable. Pulse detects unmet expectations through phrases like "I couldn't find," "where is," "not intuitive."
+**Meeting expectations.** Put things where people look for them first. Use patterns that match what users know from other products. Surprise is the enemy of Comfortable. Ladder detects unmet expectations through phrases like "I couldn't find," "where is," "not intuitive."
 
-**Removing friction.** Every loading state, every ambiguous label, every confirmation dialog that doesn't need to exist. Remove it. Friction compounds. Pulse measures the compound effect across thousands of user touchpoints.
+**Removing friction.** Every loading state, every ambiguous label, every confirmation dialog that doesn't need to exist. Remove it. Friction compounds. Ladder measures the compound effect across thousands of user touchpoints.
 
 **Defaulting correctly.** The best settings are the ones users never change. If 80% of users would choose the same option, make it the default and hide the setting.
 
-3.0 isn't ambitious. It's table stakes. And Pulse proves that most of the software world hasn't earned it yet.
+3.0 isn't ambitious. It's table stakes. And Ladder proves that most of the software world hasn't earned it yet.
 
-Want to know where your product really stands? [Explore the full Top 100](/top-100) to see how the world's best products score, or get your own Pulse Score. [Request a demo](/contact) and we'll show you what your users are really saying.`,
+Want to know where your product really stands? [Explore the full Top 100](/top-100) to see how the world's best products score, or get your own Ladder Top 100 score. [Request a demo](/contact) and we'll show you what your users are really saying.`,
   },
   {
     slug: "your-ladder-score-is-only-half-the-story",
     title: "Your Ladder Score Is Only Half the Story",
-    subtitle: "A Screen Score tells you what users see. A Pulse Score tells you what they feel. You need both to know the truth.",
+    subtitle: "A Screen Score tells you what users see. A Ladder Top 100 score tells you what they feel. You need both to know the truth.",
     date: "2026-03-20",
     readTime: "5 min read",
     category: "Framework",
@@ -380,47 +380,47 @@ Screen Scores are fast. You can score any screen in seconds through [runladder.c
 
 A Screen Score answers: *does this interface look and function like it respects the user's time?*
 
-## Pulse Score: what real users feel
+## Ladder Top 100 score: what real users feel
 
-A [Pulse Score](/pulse) is different. Ladder Pulse ingests real customer signals from 3,000+ online sources: public reviews, forums, and community discussions. Thousands of data points per product, run through the same Ladder framework.
+A Sentiment score is different. For public analyses like the [Ladder Top 100](/top-100), we aggregate public sentiment — reviews, forums, community discussions — and run it through the same Ladder framework. Thousands of data points per product.
 
-A Pulse Score doesn't care what the interface looks like. It cares what people say when they talk about using it. The frustrations they describe. The moments they celebrate. The features they beg for. The ones they curse.
+A Ladder Top 100 score doesn't care what the interface looks like. It cares what people say when they talk about using it. The frustrations they describe. The moments they celebrate. The features they beg for. The ones they curse.
 
-A Pulse Score answers: *does using this product actually feel as good as it looks?*
+A Ladder Top 100 score answers: *does using this product actually feel as good as it looks?*
 
 ## The gap is the insight
 
 When you have both numbers, the gap between them tells a story no individual score can.
 
-**[Airbnb](/top-100/airbnb): Screen 3.7, Pulse 2.3 (gap: -1.4)**
+**[Airbnb](/top-100/airbnb): Screen 3.7, Sentiment 2.3 (gap: -1.4)**
 The interface is beautiful. Emotional photography, generous whitespace, discovery-driven browsing. It looks like a 3.7. But 42,000+ real data points tell a different story: hidden fees at checkout, a host experience that feels like a separate product, and a review system losing credibility. The screen promises one thing. Reality delivers another.
 
-**[Pinterest](/top-100/pinterest): Screen 3.2, Pulse 1.8 (gap: -1.4)**
+**[Pinterest](/top-100/pinterest): Screen 3.2, Sentiment 1.8 (gap: -1.4)**
 Visual discovery remains best-in-class, but 25,000+ data points reveal an experience overrun by ad pressure and declining content quality. The interface still works. The experience behind it has eroded.
 
-**[Raycast](/top-100/raycast): Screen 3.8, Pulse 4.2 (gap: +0.4)**
+**[Raycast](/top-100/raycast): Screen 3.8, Sentiment 4.2 (gap: +0.4)**
 The interface is minimal. A command bar and some extensions. It doesn't photograph well. But 1,500+ reviews use language usually reserved for products people can't live without: "replaced five apps," "fastest tool I've ever used." When speed is the design, screenshots undersell it.
 
-**[Monzo](/top-100/monzo): Screen 3.3, Pulse 3.9 (gap: +0.6)**
+**[Monzo](/top-100/monzo): Screen 3.3, Sentiment 3.9 (gap: +0.6)**
 A banking app that doesn't look remarkable scores remarkably well with 325,000+ real users. Transparency, instant notifications, and human-readable language build trust that no amount of visual polish can replicate.
 
-**[Superhuman](/top-100/superhuman): Screen 3.8, Pulse 3.8 (gap: 0.0)**
+**[Superhuman](/top-100/superhuman): Screen 3.8, Sentiment 3.8 (gap: 0.0)**
 Zero gap. The email client that charges $30/month looks like a $30/month email client and feels like one too. No promises the experience can't keep.
 
-**[Linear](/top-100/linear): Screen 4.3, Pulse 4.2 (gap: -0.1)**
+**[Linear](/top-100/linear): Screen 4.3, Sentiment 4.2 (gap: -0.1)**
 Near-zero gap. 3,200+ data points confirm that what you see is what you get. That honesty is why Linear is #1 on the [Ladder Top 100](/top-100).
 
 ## What the gap means for your product
 
-A large negative gap (Screen > Pulse) means your interface is writing checks your experience can't cash. You're investing in appearance and underinvesting in substance. Users feel the disconnect, and they talk about it.
+A large negative gap (Screen > Sentiment) means your interface is writing checks your experience can't cash. You're investing in appearance and underinvesting in substance. Users feel the disconnect, and they talk about it.
 
-A positive gap (Pulse > Screen) means your product is better than it looks. Users love it despite the interface. That's an opportunity: improve the visual layer and the scores converge upward.
+A positive gap (Sentiment > Screen) means your product is better than it looks. Users love it despite the interface. That's an opportunity: improve the visual layer and the scores converge upward.
 
 A near-zero gap means the product is honest. What you see is what you get. That's the foundation trust is built on.
 
 ## One score is a starting point. Two scores are the truth.
 
-A Screen Score alone is a valid Ladder Score. It tells you exactly where the interface stands. But it's an incomplete picture. Without a Pulse Score, you know what the interface shows, not what users feel.
+A Screen Score alone is a valid Ladder Score. It tells you exactly where the interface stands. But it's an incomplete picture. Without a Ladder Top 100 score, you know what the interface shows, not what users feel.
 
 The products that score highest on the [Top 100](/top-100) aren't the ones with the best-looking interfaces. They're the ones where the gap is smallest. Where the promise matches the reality.
 
@@ -431,50 +431,50 @@ Your Screen Score is free. [Score a screen right now.](/score) When you're ready
   {
     slug: "the-ugly-ducklings",
     title: "The Ugly Ducklings: 8 Products That Feel Better Than They Look",
-    subtitle: "Pulse found products where real user sentiment outscores the interface. These teams built something users love before they built something that looks lovable.",
+    subtitle: "Ladder found products where real user sentiment outscores the interface. These teams built something users love before they built something that looks lovable.",
     date: "2026-03-20",
     readTime: "6 min read",
-    category: "Pulse Intelligence",
+    category: "Ladder Top 100 Analysis",
     excerpt:
-      "Monzo's interface scores 3.3. Its Pulse Score is 3.9. Discord scores 2.8 on screen but 3.4 in reality. These products are better than they look, and the data proves it.",
+      "Monzo's interface scores 3.3. Its Ladder Top 100 score is 3.9. Discord scores 2.8 on screen but 3.4 in reality. These products are better than they look, and the data proves it.",
     products: ["monzo", "discord", "raycast", "canva", "zoom", "midjourney", "slack", "salesforce"],
-    content: `Most products look better than they feel. That's the pattern [Pulse](/pulse) surfaced across the [Ladder Top 100](/top-100): the average product has a Screen Score 0.6 points higher than its Pulse Score. The interface oversells the experience.
+    content: `Most products look better than they feel. That's the pattern Ladder surfaced across the [Ladder Top 100](/top-100): the average product has a Screen Score 0.6 points higher than its Ladder Top 100 score. The interface oversells the experience.
 
-But eight products break the pattern. Their Pulse Scores are *higher* than their Screen Scores. Real users rate the experience better than the interface suggests. These are the ugly ducklings: products that earned love before they earned visual polish.
+But eight products break the pattern. Their Ladder Top 100 scores are *higher* than their Screen Scores. Real users rate the experience better than the interface suggests. These are the ugly ducklings: products that earned love before they earned visual polish.
 
 ## The positive-gap products
 
-**[Monzo](/top-100/monzo): Screen 3.3, Pulse 3.9 (gap: +0.6)**
+**[Monzo](/top-100/monzo): Screen 3.3, Sentiment 3.9 (gap: +0.6)**
 
-325,000+ data points. The largest positive gap in the dataset. Monzo's interface is competent but unremarkable. Mid-range typography, standard card layouts, nothing that screenshots well on a design blog. But Pulse found something the screen can't show: users describe Monzo with trust language. "Honest." "Transparent." "Tells me exactly what's happening with my money." Instant spend notifications, fee-free international spending, and plain-English transaction descriptions build a relationship that no amount of visual polish can replicate. Monzo proves that in banking, clarity is the design.
+325,000+ data points. The largest positive gap in the dataset. Monzo's interface is competent but unremarkable. Mid-range typography, standard card layouts, nothing that screenshots well on a design blog. But Ladder found something the screen can't show: users describe Monzo with trust language. "Honest." "Transparent." "Tells me exactly what's happening with my money." Instant spend notifications, fee-free international spending, and plain-English transaction descriptions build a relationship that no amount of visual polish can replicate. Monzo proves that in banking, clarity is the design.
 
-**[Discord](/top-100/discord): Screen 2.8, Pulse 3.4 (gap: +0.6)**
+**[Discord](/top-100/discord): Screen 2.8, Sentiment 3.4 (gap: +0.6)**
 
-6.6 million data points. Discord's interface is objectively messy. Settings are a labyrinth. Channel management is overwhelming for newcomers. Server permissions require a tutorial. The Screen Score reflects all of this. But Pulse tells a different story: communities that form around Discord become dependent on it. The voice chat is frictionless. The threading model works for real-time groups in a way Slack and Teams don't. Users complain about the interface constantly, and they also describe it as irreplaceable. That's a +0.6 gap built entirely on community infrastructure.
+6.6 million data points. Discord's interface is objectively messy. Settings are a labyrinth. Channel management is overwhelming for newcomers. Server permissions require a tutorial. The Screen Score reflects all of this. But Ladder tells a different story: communities that form around Discord become dependent on it. The voice chat is frictionless. The threading model works for real-time groups in a way Slack and Teams don't. Users complain about the interface constantly, and they also describe it as irreplaceable. That's a +0.6 gap built entirely on community infrastructure.
 
-**[Zoom](/top-100/zoom): Screen 2.7, Pulse 3.2 (gap: +0.5)**
+**[Zoom](/top-100/zoom): Screen 2.7, Sentiment 3.2 (gap: +0.5)**
 
-56,000+ data points. Zoom's interface outside the meeting window is a patchwork. Chat, whiteboard, phone, clips, notes: features bolted on with visible seams. But the core meeting experience remains the most reliable in its category. Pulse found that users separate "Zoom the meeting tool" from "Zoom the platform." The meeting tool earns forgiveness for everything around it. When reliability is the product, the interface is forgiven.
+56,000+ data points. Zoom's interface outside the meeting window is a patchwork. Chat, whiteboard, phone, clips, notes: features bolted on with visible seams. But the core meeting experience remains the most reliable in its category. Ladder found that users separate "Zoom the meeting tool" from "Zoom the platform." The meeting tool earns forgiveness for everything around it. When reliability is the product, the interface is forgiven.
 
-**[Canva](/top-100/canva): Screen 3.3, Pulse 3.7 (gap: +0.4)**
+**[Canva](/top-100/canva): Screen 3.3, Sentiment 3.7 (gap: +0.4)**
 
-2.1 million data points. The largest sample in our dataset. Canva's interface is dense. Template grids, toolbar overload, a design surface that professional designers find limiting. Screen Score: 3.3. But Pulse surfaced a population that design-focused scoring often misses: the millions of non-designers who use Canva to make presentations, social posts, and marketing materials. For them, the experience is empowering. "I made this myself" appears across thousands of reviews. Canva's Pulse Score reflects the experience of its actual users, not the hypothetical expert.
+2.1 million data points. The largest sample in our dataset. Canva's interface is dense. Template grids, toolbar overload, a design surface that professional designers find limiting. Screen Score: 3.3. But Ladder surfaced a population that design-focused scoring often misses: the millions of non-designers who use Canva to make presentations, social posts, and marketing materials. For them, the experience is empowering. "I made this myself" appears across thousands of reviews. Canva's Ladder Top 100 score reflects the experience of its actual users, not the hypothetical expert.
 
-**[Raycast](/top-100/raycast): Screen 3.8, Pulse 4.2 (gap: +0.4)**
+**[Raycast](/top-100/raycast): Screen 3.8, Sentiment 4.2 (gap: +0.4)**
 
-1,500+ data points. A command bar and extensions. It barely has an interface in the traditional sense. But Pulse found users describing Raycast in language reserved for products they can't live without: "replaced Spotlight, Alfred, and three other apps," "fastest tool I've ever used," "can't imagine working without it." When every interaction completes in under 200ms, the interface becomes invisible. Speed *is* the design. Screenshots undersell it completely.
+1,500+ data points. A command bar and extensions. It barely has an interface in the traditional sense. But Ladder found users describing Raycast in language reserved for products they can't live without: "replaced Spotlight, Alfred, and three other apps," "fastest tool I've ever used," "can't imagine working without it." When every interaction completes in under 200ms, the interface becomes invisible. Speed *is* the design. Screenshots undersell it completely.
 
-**[Midjourney](/top-100/midjourney): Screen 2.8, Pulse 3.2 (gap: +0.4)**
+**[Midjourney](/top-100/midjourney): Screen 2.8, Sentiment 3.2 (gap: +0.4)**
 
-550+ data points (smaller sample, but consistent signal). Midjourney's interface is barely held together. The Discord-bot origins still show. The web UI is basic. Screen Score: 2.8. But users don't come to Midjourney for the interface. They come for the output. Pulse surfaced consistent awe at generation quality, and a community that shares techniques and results with genuine enthusiasm. The product is the output, not the wrapper.
+550+ data points (smaller sample, but consistent signal). Midjourney's interface is barely held together. The Discord-bot origins still show. The web UI is basic. Screen Score: 2.8. But users don't come to Midjourney for the interface. They come for the output. Ladder surfaced consistent awe at generation quality, and a community that shares techniques and results with genuine enthusiasm. The product is the output, not the wrapper.
 
-**[Slack](/top-100/slack): Screen 3.4, Pulse 3.6 (gap: +0.2)**
+**[Slack](/top-100/slack): Screen 3.4, Sentiment 3.6 (gap: +0.2)**
 
-45,000+ data points. A smaller gap, but significant because Slack's Screen Score already reflects years of feature accumulation. The interface is crowded. Channel proliferation is real. Thread UX is divisive. But Pulse found that Slack's role as the default workplace communication layer gives it a gravity that transcends UI quality. Users describe it as "where work happens," not "a tool I chose." When a product becomes infrastructure, the interface matters less than the network.
+45,000+ data points. A smaller gap, but significant because Slack's Screen Score already reflects years of feature accumulation. The interface is crowded. Channel proliferation is real. Thread UX is divisive. But Ladder found that Slack's role as the default workplace communication layer gives it a gravity that transcends UI quality. Users describe it as "where work happens," not "a tool I chose." When a product becomes infrastructure, the interface matters less than the network.
 
-**[Salesforce](/top-100/salesforce): Screen 1.8, Pulse 2.2 (gap: +0.4)**
+**[Salesforce](/top-100/salesforce): Screen 1.8, Sentiment 2.2 (gap: +0.4)**
 
-94,000+ data points. The lowest Screen Score on this list, but even Salesforce shows a positive gap. The interface is widely acknowledged as one of the worst in enterprise software. But Pulse found something: users who've invested years mastering Salesforce describe a kind of Stockholm-syndrome competence. "Once you learn it, it's powerful." The Pulse Score is still low (2.2, Usable), but it's higher than the interface alone would suggest. Mastery creates tolerance.
+94,000+ data points. The lowest Screen Score on this list, but even Salesforce shows a positive gap. The interface is widely acknowledged as one of the worst in enterprise software. But Ladder found something: users who've invested years mastering Salesforce describe a kind of Stockholm-syndrome competence. "Once you learn it, it's powerful." The Ladder Top 100 score is still low (2.2, Usable), but it's higher than the interface alone would suggest. Mastery creates tolerance.
 
 ## What the ugly ducklings teach us
 
@@ -482,25 +482,25 @@ The positive-gap pattern reveals something important: great experiences can hide
 
 Every product on this list has invested in something the screen can't show. Monzo built trust. Discord built community. Zoom built reliability. Canva built accessibility. Raycast built speed. Midjourney built output quality. Slack built ubiquity.
 
-If your Screen Score is higher than your Pulse Score, you're working on the wrong layer. Fix the experience first. The interface can catch up later.
+If your Screen Score is higher than your Ladder Top 100 score, you're working on the wrong layer. Fix the experience first. The interface can catch up later.
 
-If your Pulse Score is higher than your Screen Score, you've already built something people care about. Now invest in the visual layer and watch both numbers rise.
+If your Ladder Top 100 score is higher than your Screen Score, you've already built something people care about. Now invest in the visual layer and watch both numbers rise.
 
 [Score your own screen](/score) to see where you stand, then [request a Pulse demo](/contact) to find out what your users are really saying.`,
   },
   {
     slug: "pinterest-25000-reviews-vs-one-screenshot",
     title: "Pinterest: 25,000 Reviews vs. One Beautiful Screenshot",
-    subtitle: "Pinterest's interface scores 3.2. Its Pulse Score is 1.8. That -1.4 gap is the largest negative delta in the Top 100, tied with Airbnb.",
+    subtitle: "Pinterest's interface scores 3.2. Its Ladder Top 100 score is 1.8. That -1.4 gap is the largest negative delta in the Top 100, tied with Airbnb.",
     date: "2026-03-20",
     readTime: "5 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     products: ["pinterest", "airbnb"],
     excerpt:
       "Pinterest still owns visual discovery. But 25,000+ real user signals reveal an experience eroding under ad pressure, declining content quality, and a platform that's stopped serving the people who made it valuable.",
     content: `[Pinterest](/top-100/pinterest) invented the modern visual discovery feed. The grid layout, the infinite scroll, the pin-and-board model that a dozen other platforms copied. On screen, it still works. The interface is clean, the visual density is appropriate, and the browsing experience is fluid. Screen Score: 3.2.
 
-Then we pointed [Pulse](/pulse) at 25,000+ real data points across 3,000+ online sources. Pulse Score: 1.8.
+Then we pointed Ladder at 25,000+ real data points across 3,000+ online sources. Ladder Top 100 score: 1.8.
 
 That -1.4 gap ties [Airbnb](/top-100/airbnb) for the largest negative delta in the entire [Top 100](/top-100).
 
@@ -508,15 +508,15 @@ That -1.4 gap ties [Airbnb](/top-100/airbnb) for the largest negative delta in t
 
 **Ad saturation has crossed a threshold.**
 
-Pulse identified ad-related complaints as the single largest negative signal. Users describe a feed that's now 40-60% promoted content. The interface doesn't distinguish ads aggressively enough from organic pins, so the discovery experience feels corrupted. "I can't tell what's real anymore" appeared across multiple review sources. The core promise of Pinterest (discover beautiful, useful things) is being undermined by the business model that funds it.
+Ladder identified ad-related complaints as the single largest negative signal. Users describe a feed that's now 40-60% promoted content. The interface doesn't distinguish ads aggressively enough from organic pins, so the discovery experience feels corrupted. "I can't tell what's real anymore" appeared across multiple review sources. The core promise of Pinterest (discover beautiful, useful things) is being undermined by the business model that funds it.
 
 **Content quality is declining.**
 
-Pulse surfaced a pattern that Screen Score can't detect: the quality of what's *in* the pins has degraded. AI-generated spam pins, SEO-optimized junk boards, and recycled content are diluting what was once a curated visual experience. Users who joined Pinterest for inspiration now describe it as cluttered. The interface is the same. The content flowing through it is worse.
+Ladder surfaced a pattern that Screen Score can't detect: the quality of what's *in* the pins has degraded. AI-generated spam pins, SEO-optimized junk boards, and recycled content are diluting what was once a curated visual experience. Users who joined Pinterest for inspiration now describe it as cluttered. The interface is the same. The content flowing through it is worse.
 
 **The creator side is broken.**
 
-Pinterest has a two-sided market: people who pin and people who browse. Pulse found that the creator experience scores significantly lower than the consumer experience. Analytics are limited, reach is unpredictable, and the algorithm changes without communication. Creators who invested in building audiences describe feeling abandoned. When creators leave, content quality drops further, and the consumer experience degrades. It's a compounding problem.
+Pinterest has a two-sided market: people who pin and people who browse. Ladder found that the creator experience scores significantly lower than the consumer experience. Analytics are limited, reach is unpredictable, and the algorithm changes without communication. Creators who invested in building audiences describe feeling abandoned. When creators leave, content quality drops further, and the consumer experience degrades. It's a compounding problem.
 
 ## The -1.4 gap in context
 
@@ -532,7 +532,7 @@ Airbnb's gap comes from hidden fees and a split host/guest experience. Pinterest
 
 ## What Pinterest would need to close the gap
 
-Pulse identified three interventions that would move the Pulse Score:
+Ladder identified three interventions that would move the Ladder Top 100 score:
 
 **1. Restore the signal-to-noise ratio.** The feed needs fewer ads or more clearly distinguished ads. Users don't object to monetization. They object to deception. When promoted content is indistinguishable from organic content, trust erodes.
 
@@ -542,23 +542,23 @@ Pulse identified three interventions that would move the Pulse Score:
 
 None of these are interface changes. That's the point. Pinterest's Screen Score is 3.2. It's Comfortable. The interface is fine. The problem is everything behind it.
 
-A Screen Score tells you the interface works. A Pulse Score tells you whether the experience does. When the gap is -1.4, the interface is lying.
+A Screen Score tells you the interface works. A Ladder Top 100 score tells you whether the experience does. When the gap is -1.4, the interface is lying.
 
 [See Pinterest's full score on the Top 100](/top-100/pinterest), or [request a Pulse demo](/contact) to see what your own users are saying behind the screen.`,
   },
   {
     slug: "why-monzo-users-love-a-3-3-interface",
     title: "Why Monzo Users Love a 3.3 Interface",
-    subtitle: "325,000 real reviews. A Screen Score of 3.3. A Pulse Score of 3.9. Monzo proves that trust outperforms visual polish in every category that matters.",
+    subtitle: "325,000 real reviews. A Screen Score of 3.3. A Ladder Top 100 score of 3.9. Monzo proves that trust outperforms visual polish in every category that matters.",
     date: "2026-03-20",
     readTime: "5 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     products: ["monzo", "mercury", "robinhood"],
     excerpt:
-      "Monzo's interface is competent but unremarkable. Its Pulse Score is +0.6 higher than its Screen Score, the largest positive gap in the Top 100. 325,000 data points explain why.",
+      "Monzo's interface is competent but unremarkable. Its Ladder Top 100 score is +0.6 higher than its Screen Score, the largest positive gap in the Top 100. 325,000 data points explain why.",
     content: `[Monzo](/top-100/monzo) doesn't look special. Open the app and you'll find standard card layouts, mid-range typography, and a color scheme (hot coral on white) that's distinctive but not sophisticated. A design blog wouldn't feature it. The Screen Score reflects this: 3.3, solidly Comfortable but not pushing toward Delightful.
 
-Then [Pulse](/pulse) ingested 325,000+ data points across 3,000+ online sources. Pulse Score: 3.9.
+Then Ladder ingested 325,000+ data points across 3,000+ online sources. Ladder Top 100 score: 3.9.
 
 That +0.6 gap is the largest positive delta in the entire [Top 100](/top-100). Monzo's users love it significantly more than its interface would predict.
 
@@ -566,31 +566,31 @@ That +0.6 gap is the largest positive delta in the entire [Top 100](/top-100). M
 
 **Trust through transparency.**
 
-Pulse identified transparency as Monzo's single strongest experience signal. Instant push notifications for every transaction. Real-time balance updates. Fee breakdowns in plain English. Currency conversion rates shown before you spend, not after. Users describe the experience with language Pulse maps to the Delightful level of the [Ladder framework](/framework): "I always know exactly where my money is." That's not a visual design achievement. It's an information design achievement.
+Ladder identified transparency as Monzo's single strongest experience signal. Instant push notifications for every transaction. Real-time balance updates. Fee breakdowns in plain English. Currency conversion rates shown before you spend, not after. Users describe the experience with language Ladder maps to the Delightful level of the [Ladder framework](/framework): "I always know exactly where my money is." That's not a visual design achievement. It's an information design achievement.
 
 **Speed as emotional reassurance.**
 
-Instant notifications aren't just convenient. They're reassuring. Pulse surfaced a pattern: users who switched from traditional banks describe the instant feedback as the single biggest quality-of-life improvement. "I spent, and my phone buzzed before I put my card away." In financial services, latency creates anxiety. Monzo eliminates it.
+Instant notifications aren't just convenient. They're reassuring. Ladder surfaced a pattern: users who switched from traditional banks describe the instant feedback as the single biggest quality-of-life improvement. "I spent, and my phone buzzed before I put my card away." In financial services, latency creates anxiety. Monzo eliminates it.
 
 **Human language in an inhuman category.**
 
-Banking is full of jargon: "pending transactions," "available balance," "settlement period." Monzo translates all of it. Pulse found that users consistently describe Monzo as "feeling like it was made by humans." This is a design decision that doesn't show up in screenshots. It shows up in experience.
+Banking is full of jargon: "pending transactions," "available balance," "settlement period." Monzo translates all of it. Ladder found that users consistently describe Monzo as "feeling like it was made by humans." This is a design decision that doesn't show up in screenshots. It shows up in experience.
 
-## The fintech Pulse comparison
+## The fintech sentiment comparison
 
 Monzo's +0.6 gap is unusual in its category. Here's how other fintech products compare:
 
-- [Mercury](/top-100/mercury): Screen 3.2, Pulse 3.2 (gap: 0.0). Honest. The business banking experience matches the interface exactly.
-- [Robinhood](/top-100/robinhood): Screen 3.1, Pulse 2.4 (gap: -0.7). The simplified investing interface oversells an experience users increasingly find patronizing. 5.3 million data points.
-- Stripe: Screen 4.0, Pulse 3.1 (gap: -0.9). Developer clarity on screen, but real-world integration complexity brings the lived experience down. 2,800+ data points.
+- [Mercury](/top-100/mercury): Screen 3.2, Sentiment 3.2 (gap: 0.0). Honest. The business banking experience matches the interface exactly.
+- [Robinhood](/top-100/robinhood): Screen 3.1, Sentiment 2.4 (gap: -0.7). The simplified investing interface oversells an experience users increasingly find patronizing. 5.3 million data points.
+- Stripe: Screen 4.0, Sentiment 3.1 (gap: -0.9). Developer clarity on screen, but real-world integration complexity brings the lived experience down. 2,800+ data points.
 
-Monzo is the only fintech product where Pulse exceeds Screen. In a category defined by trust, Monzo is the only one overdelivering.
+Monzo is the only fintech product where sentiment exceeds screen. In a category defined by trust, Monzo is the only one overdelivering.
 
 ## What this means for product teams
 
 Monzo's +0.6 gap contains a lesson: you don't need a beautiful interface to build a beloved product. You need an honest one.
 
-Every design decision Monzo made that drives its Pulse Score is invisible in a screenshot:
+Every design decision Monzo made that drives its Ladder Top 100 score is invisible in a screenshot:
 - Instant notifications (an infrastructure decision)
 - Plain-English copy (a content decision)
 - Real-time balance accuracy (a backend decision)
@@ -598,45 +598,45 @@ Every design decision Monzo made that drives its Pulse Score is invisible in a s
 
 None of these are "design" in the visual sense. All of them are design in the experience sense. The [Ladder framework](/framework) measures experience quality across five levels. Monzo proves that you can reach toward Level 4 without Level 4 visuals.
 
-If your Screen Score is higher than your Pulse Score, you're investing in the wrong layer. Polish the interface after you've earned trust.
+If your Screen Score is higher than your Ladder Top 100 score, you're investing in the wrong layer. Polish the interface after you've earned trust.
 
 [Score your interface](/score) to see where your Screen Score stands. Then [request a Pulse demo](/contact) to find out if your users agree.`,
   },
   {
     slug: "netflix-peaked",
     title: "Netflix Peaked",
-    subtitle: "120,000+ data points. A Screen Score of 3.4. A Pulse Score of 2.4. The platform that defined streaming is now a case study in stagnation.",
+    subtitle: "120,000+ data points. A Screen Score of 3.4. A Ladder Top 100 score of 2.4. The platform that defined streaming is now a case study in stagnation.",
     date: "2026-03-20",
     readTime: "5 min read",
-    category: "Pulse Teardown",
+    category: "Ladder Teardown",
     products: ["netflix", "spotify", "apple-music"],
     excerpt:
-      "Pulse analyzed 120,000+ Netflix reviews and found a 1.0-point gap between interface and reality. Content discovery peaked. The interface hasn't kept up. And users are noticing.",
+      "Ladder analyzed 120,000+ Netflix reviews and found a 1.0-point gap between interface and reality. Content discovery peaked. The interface hasn't kept up. And users are noticing.",
     content: `[Netflix](/top-100/netflix) defined streaming. The autoplay preview, the percentage match, the horizontal category rows, the "Because you watched..." recommendations. Every streaming service copied the playbook. Screen Score: 3.4, Comfortable. The interface still works.
 
-But [Pulse](/pulse) tells a different story. 120,000+ data points across 3,000+ online sources. Pulse Score: 2.4. Usable. A full point below the interface.
+But Ladder tells a different story. 120,000+ data points across 3,000+ online sources. Ladder Top 100 score: 2.4. Usable. A full point below the interface.
 
 ## What 120,000 data points reveal
 
 **Content discovery has regressed.**
 
-The recommendation engine was Netflix's signature innovation. Pulse found that user sentiment around discovery has shifted decisively negative. "I spend more time browsing than watching" is the single most repeated pattern across all sources. Users describe an experience where the catalog feels simultaneously vast and empty: too many options, none of them compelling. The "97% match" that once felt like magic now feels arbitrary.
+The recommendation engine was Netflix's signature innovation. Ladder found that user sentiment around discovery has shifted decisively negative. "I spend more time browsing than watching" is the single most repeated pattern across all sources. Users describe an experience where the catalog feels simultaneously vast and empty: too many options, none of them compelling. The "97% match" that once felt like magic now feels arbitrary.
 
 **The interface optimizes for Netflix, not the viewer.**
 
-Pulse identified a consistent frustration: autoplay previews, unskippable trailers for Netflix originals, and a browse experience that privileges what Netflix wants you to watch over what you're looking for. Users describe feeling marketed to inside a product they're already paying for. This is the same dynamic that drove [Pinterest's](/top-100/pinterest) -1.4 gap: the business model is visible in the experience, and users resent it.
+Ladder identified a consistent frustration: autoplay previews, unskippable trailers for Netflix originals, and a browse experience that privileges what Netflix wants you to watch over what you're looking for. Users describe feeling marketed to inside a product they're already paying for. This is the same dynamic that drove [Pinterest's](/top-100/pinterest) -1.4 gap: the business model is visible in the experience, and users resent it.
 
 **Quality perception is declining with the content.**
 
-Pulse can't separate the product from the content, and neither can users. As Netflix's catalog has shifted toward volume-over-quality original content, the overall experience perception drops. Users describe a platform that used to feel curated and now feels algorithmic. The interface hasn't changed much. The feeling has.
+Ladder can't separate the product from the content, and neither can users. As Netflix's catalog has shifted toward volume-over-quality original content, the overall experience perception drops. Users describe a platform that used to feel curated and now feels algorithmic. The interface hasn't changed much. The feeling has.
 
 ## The media category pattern
 
-Netflix isn't alone. Pulse found a consistent pattern across media products:
+Netflix isn't alone. Ladder found a consistent pattern across media products:
 
-- Netflix: Screen 3.4, Pulse 2.4 (gap: -1.0)
-- [Spotify](/top-100/spotify): Screen 3.5, Pulse 2.8 (gap: -0.7). 5 million data points. Discovery is strong but library management, podcasts-over-music prioritization, and UI clutter drag the experience down.
-- [Apple Music](/top-100/apple-music): Screen 3.6, Pulse 2.4 (gap: -1.2). 8,500+ data points. Beautiful but frustrating. Library management issues, inconsistent navigation, and discovery that trails Spotify.
+- Netflix: Screen 3.4, Sentiment 2.4 (gap: -1.0)
+- [Spotify](/top-100/spotify): Screen 3.5, Sentiment 2.8 (gap: -0.7). 5 million data points. Discovery is strong but library management, podcasts-over-music prioritization, and UI clutter drag the experience down.
+- [Apple Music](/top-100/apple-music): Screen 3.6, Sentiment 2.4 (gap: -1.2). 8,500+ data points. Beautiful but frustrating. Library management issues, inconsistent navigation, and discovery that trails Spotify.
 
 Every media product in the Top 100 has a negative gap. The pattern suggests that media interfaces tend to oversell the experience because the content itself is the variable. A music player can be perfectly designed, but if the recommendations are wrong, the experience fails.
 
@@ -646,114 +646,114 @@ A -1.0 gap on 120,000+ data points is not noise. It's signal at scale. Netflix's
 
 That last part is the risk. Netflix pioneered the category. Now, with Disney+, Max, Apple TV+, and Amazon Prime all competing, "would switch without hesitation" is exactly the sentiment that precedes churn.
 
-The Screen Score says the interface is fine. The Pulse Score says the relationship is eroding. One of those numbers should worry Netflix more than the other.
+The Screen Score says the interface is fine. The Ladder Top 100 score says the relationship is eroding. One of those numbers should worry Netflix more than the other.
 
 [See Netflix's full score on the Top 100](/top-100/netflix). Want to see what your users are really saying? [Request a Pulse demo.](/contact)`,
   },
   {
     slug: "what-25-million-reviews-teach-you",
     title: "What 25 Million Reviews Teach You That Screenshots Can't",
-    subtitle: "We analyzed the five products with the most user data in the world. At massive scale, Pulse reveals patterns invisible to any other method.",
+    subtitle: "We analyzed the five products with the most user data in the world. At massive scale, Ladder reveals patterns invisible to any other method.",
     date: "2026-03-20",
     readTime: "6 min read",
-    category: "Pulse Intelligence",
+    category: "Ladder Top 100 Analysis",
     excerpt:
-      "Discord has 6.6 million data points. Robinhood has 5.3 million. Spotify has 5 million. At this scale, Pulse doesn't just score sentiment. It maps the topology of human experience with software.",
+      "Discord has 6.6 million data points. Robinhood has 5.3 million. Spotify has 5 million. At this scale, Ladder doesn't just score sentiment. It maps the topology of human experience with software.",
     products: ["discord", "spotify", "robinhood", "twitch", "canva"],
-    content: `Most product analytics work with thousands of data points. User interviews might cover dozens. Surveys might reach hundreds. [Pulse](/pulse) works with millions.
+    content: `Most product analytics work with thousands of data points. User interviews might cover dozens. Surveys might reach hundreds. Ladder works with millions.
 
 Five products in the [Ladder Top 100](/top-100) have datasets exceeding one million real user signals each. Combined, they represent over 25 million data points across 3,000+ online sources.
 
-At this scale, Pulse doesn't just measure whether users are happy. It maps the terrain of how millions of people actually experience software.
+At this scale, Ladder doesn't just measure whether users are happy. It maps the terrain of how millions of people actually experience software.
 
 ## The five million-plus products
 
 **[Discord](/top-100/discord): 6.6 million data points**
-Screen 2.8 / Pulse 3.4 / Gap: +0.6
+Screen 2.8 / Sentiment 3.4 / Gap: +0.6
 
-The largest dataset in the Top 100 produces one of the most interesting signals. Discord's interface is widely criticized: settings complexity, channel overwhelm, permission confusion. But 6.6 million data points reveal that community attachment overrides interface frustration. Pulse found that Discord users segment into two populations: newcomers (who rate it poorly) and embedded community members (who rate it essential). The average masks a bimodal distribution. New user experience and power user experience are essentially different products.
+The largest dataset in the Top 100 produces one of the most interesting signals. Discord's interface is widely criticized: settings complexity, channel overwhelm, permission confusion. But 6.6 million data points reveal that community attachment overrides interface frustration. Ladder found that Discord users segment into two populations: newcomers (who rate it poorly) and embedded community members (who rate it essential). The average masks a bimodal distribution. New user experience and power user experience are essentially different products.
 
 **[Robinhood](/top-100/robinhood): 5.3 million data points**
-Screen 3.1 / Pulse 2.4 / Gap: -0.7
+Screen 3.1 / Sentiment 2.4 / Gap: -0.7
 
-Robinhood simplified stock trading for a generation. The interface is clean, approachable, and deliberately stripped of the complexity that traditional brokerages use. Screen Score: 3.1. But 5.3 million data points paint a more complicated picture. Pulse identified three dominant negative themes: limited customer support (overwhelmingly the top complaint), the "gamification" controversy (confetti on trades, simplified risk presentation), and platform outages during high-volatility events. The simplified interface that earns a 3.1 Screen Score is the same simplification that users describe as "patronizing" when real money is on the line.
+Robinhood simplified stock trading for a generation. The interface is clean, approachable, and deliberately stripped of the complexity that traditional brokerages use. Screen Score: 3.1. But 5.3 million data points paint a more complicated picture. Ladder identified three dominant negative themes: limited customer support (overwhelmingly the top complaint), the "gamification" controversy (confetti on trades, simplified risk presentation), and platform outages during high-volatility events. The simplified interface that earns a 3.1 Screen Score is the same simplification that users describe as "patronizing" when real money is on the line.
 
 **[Spotify](/top-100/spotify): 5 million data points**
-Screen 3.5 / Pulse 2.8 / Gap: -0.7
+Screen 3.5 / Sentiment 2.8 / Gap: -0.7
 
-Five million data points make Spotify one of the most thoroughly measured products on the planet. Pulse found that the discovery experience (Discover Weekly, Release Radar, Daily Mix) remains Spotify's strongest signal. But three themes drag the Pulse Score down: podcast integration that users didn't ask for, library management that's been neglected for years, and a free tier experience that's increasingly hostile (more ads, more interruptions, more nudges to upgrade). The premium experience scores higher than the free experience by a significant margin. Pulse reflects the blended reality.
+Five million data points make Spotify one of the most thoroughly measured products on the planet. Ladder found that the discovery experience (Discover Weekly, Release Radar, Daily Mix) remains Spotify's strongest signal. But three themes drag the Ladder Top 100 score down: podcast integration that users didn't ask for, library management that's been neglected for years, and a free tier experience that's increasingly hostile (more ads, more interruptions, more nudges to upgrade). The premium experience scores higher than the free experience by a significant margin. Ladder reflects the blended reality.
 
 **[Twitch](/top-100/twitch): 5.3 million data points**
-Screen 2.6 / Pulse 2.1 / Gap: -0.5
+Screen 2.6 / Sentiment 2.1 / Gap: -0.5
 
-The lowest Pulse Score among the million-plus products. 5.3 million data points reveal a platform where the viewer experience is adequate but the creator experience is punishing. Discoverability is broken (new streamers can't grow), monetization is opaque, and platform policies are inconsistently enforced. Pulse found that Twitch's community loyalty comes from individual streamers, not the platform itself. Users are loyal to creators, not to Twitch. That's a fragile foundation.
+The lowest Ladder Top 100 score among the million-plus products. 5.3 million data points reveal a platform where the viewer experience is adequate but the creator experience is punishing. Discoverability is broken (new streamers can't grow), monetization is opaque, and platform policies are inconsistently enforced. Ladder found that Twitch's community loyalty comes from individual streamers, not the platform itself. Users are loyal to creators, not to Twitch. That's a fragile foundation.
 
 **[Canva](/top-100/canva): 2.1 million data points**
-Screen 3.3 / Pulse 3.7 / Gap: +0.4
+Screen 3.3 / Sentiment 3.7 / Gap: +0.4
 
-The only million-plus product with a positive gap. 2.1 million data points reveal that Canva's user base rates the experience higher than the interface suggests. The template-first approach that professional designers critique is exactly what non-designers celebrate. "I made this myself" is the sentiment Pulse detects across hundreds of thousands of reviews. Canva's audience isn't designers. It's everyone else. And everyone else loves it.
+The only million-plus product with a positive gap. 2.1 million data points reveal that Canva's user base rates the experience higher than the interface suggests. The template-first approach that professional designers critique is exactly what non-designers celebrate. "I made this myself" is the sentiment Ladder detects across hundreds of thousands of reviews. Canva's audience isn't designers. It's everyone else. And everyone else loves it.
 
 ## What emerges at scale
 
-Across 25 million data points, Pulse surfaced patterns that no screenshot analysis, survey, or user interview could reveal:
+Across 25 million data points, Ladder surfaced patterns that no screenshot analysis, survey, or user interview could reveal:
 
 **1. Bimodal experiences are invisible to Screen Scores.**
-Discord and Spotify both have user populations with fundamentally different experiences. New vs. embedded. Free vs. premium. The Screen Score measures one interface. The Pulse Score measures two (or more) realities. When you see a gap, ask: whose experience is Pulse measuring that Screen Score isn't?
+Discord and Spotify both have user populations with fundamentally different experiences. New vs. embedded. Free vs. premium. The Screen Score measures one interface. The Ladder Top 100 score measures two (or more) realities. When you see a gap, ask: whose experience is Ladder measuring that Screen Score isn't?
 
 **2. Platform loyalty is borrowed, not owned.**
-Twitch users are loyal to streamers, not to Twitch. Discord users are loyal to communities, not to Discord. Pulse detects the difference. When loyalty is borrowed from content creators or community leaders, the platform is one migration away from irrelevance.
+Twitch users are loyal to streamers, not to Twitch. Discord users are loyal to communities, not to Discord. Ladder detects the difference. When loyalty is borrowed from content creators or community leaders, the platform is one migration away from irrelevance.
 
 **3. Simplification has a ceiling.**
-Robinhood's simplification earned it a clean Screen Score. But at scale, users begin to resent the same simplification they initially loved. Pulse tracked this sentiment shift over time: early reviews are enthusiastic, later reviews describe feeling "talked down to." The interface that attracted users is now repelling power users.
+Robinhood's simplification earned it a clean Screen Score. But at scale, users begin to resent the same simplification they initially loved. Ladder tracked this sentiment shift over time: early reviews are enthusiastic, later reviews describe feeling "talked down to." The interface that attracted users is now repelling power users.
 
 **4. Non-expert users rate differently.**
-Canva's positive gap exists because Pulse captures the voice of non-designers. Screen Score evaluates against professional design standards. Pulse evaluates against human satisfaction. When your audience isn't designers, those are two different things.
+Canva's positive gap exists because Ladder captures the voice of non-designers. Screen Score evaluates against professional design standards. Ladder evaluates against human satisfaction. When your audience isn't designers, those are two different things.
 
-## The case for Pulse at scale
+## The case for Ladder at scale
 
-At small sample sizes, Pulse confirms what you probably already know. At massive scale, it reveals what you can't see any other way. The patterns in 25 million data points are too complex for NPS, too nuanced for star ratings, and too distributed for user interviews.
+At small sample sizes, Ladder confirms what you probably already know. At massive scale, it reveals what you can't see any other way. The patterns in 25 million data points are too complex for NPS, too nuanced for star ratings, and too distributed for user interviews.
 
-A Screen Score tells you what the interface looks like today. A Pulse Score at scale tells you what millions of people actually experience, and where the experience is headed.
+A Screen Score tells you what the interface looks like today. A Ladder Top 100 score at scale tells you what millions of people actually experience, and where the experience is headed.
 
 [Explore the full Top 100](/top-100) or [request a Pulse demo](/contact) to see what your users are saying at scale.`,
   },
   {
     slug: "the-honest-products",
     title: "The Honest Products",
-    subtitle: "Six products where the Screen Score and Pulse Score are nearly identical. No gap. No overselling. What you see is what you get.",
+    subtitle: "Six products where the Screen Score and Ladder Top 100 score are nearly identical. No gap. No overselling. What you see is what you get.",
     date: "2026-03-20",
     readTime: "5 min read",
-    category: "Pulse Intelligence",
+    category: "Ladder Top 100 Analysis",
     excerpt:
       "Linear: -0.1. Superhuman: 0.0. Mercury: 0.0. Calendly: 0.0. GitHub: -0.1. Figma: -0.1. These products don't promise more than they deliver. That's rarer than it sounds.",
     products: ["linear", "superhuman", "mercury", "calendly", "github", "figma"],
-    content: `The average [Ladder Top 100](/top-100) product has a -0.6 gap between its Screen Score and its [Pulse Score](/pulse). The interface oversells the experience by more than half a point. For some products, that gap is devastating: [Airbnb](/top-100/airbnb) at -1.4, [Pinterest](/top-100/pinterest) at -1.4, [Notion](/top-100/notion) at -1.3.
+    content: `The average [Ladder Top 100](/top-100) product has a -0.6 gap between its Screen Score and its [Ladder Top 100 score](/pulse). The interface oversells the experience by more than half a point. For some products, that gap is devastating: [Airbnb](/top-100/airbnb) at -1.4, [Pinterest](/top-100/pinterest) at -1.4, [Notion](/top-100/notion) at -1.3.
 
 But six products in the Top 100 have gaps of 0.1 or less. Their interfaces are honest representations of what users actually experience. No overselling. No underselling. What you see is what you get.
 
 ## The zero-gap products
 
-**[Linear](/top-100/linear): Screen 4.3, Pulse 4.2 (gap: -0.1)**
-3,200+ data points. The #1 product on the Top 100, and the highest-scoring honest product. Linear's interface promises speed, clarity, and keyboard-first efficiency. Pulse confirms all three. Users describe exactly the experience the screenshots suggest. No surprises. No letdowns. The 0.1-point gap is statistical noise.
+**[Linear](/top-100/linear): Screen 4.3, Sentiment 4.2 (gap: -0.1)**
+3,200+ data points. The #1 product on the Top 100, and the highest-scoring honest product. Linear's interface promises speed, clarity, and keyboard-first efficiency. Ladder confirms all three. Users describe exactly the experience the screenshots suggest. No surprises. No letdowns. The 0.1-point gap is statistical noise.
 
-**[Superhuman](/top-100/superhuman): Screen 3.8, Pulse 3.8 (gap: 0.0)**
-900+ data points. Mathematically perfect honesty. The premium email client that charges $30/month looks like a $30/month product and feels like one. Pulse found no meaningful gap between the marketed experience and the lived one. Users who pay for Superhuman describe getting exactly what they expected. In a world of overpromise, that's remarkable.
+**[Superhuman](/top-100/superhuman): Screen 3.8, Sentiment 3.8 (gap: 0.0)**
+900+ data points. Mathematically perfect honesty. The premium email client that charges $30/month looks like a $30/month product and feels like one. Ladder found no meaningful gap between the marketed experience and the lived one. Users who pay for Superhuman describe getting exactly what they expected. In a world of overpromise, that's remarkable.
 
-**[Mercury](/top-100/mercury): Screen 3.2, Pulse 3.2 (gap: 0.0)**
-1,750+ data points. Another zero gap. Mercury's business banking interface is clean and consumer-grade. Pulse confirms: business owners describe an experience that matches the interface precisely. No hidden complexity, no features that work differently than they appear, no onboarding promises that evaporate after signup.
+**[Mercury](/top-100/mercury): Screen 3.2, Sentiment 3.2 (gap: 0.0)**
+1,750+ data points. Another zero gap. Mercury's business banking interface is clean and consumer-grade. Ladder confirms: business owners describe an experience that matches the interface precisely. No hidden complexity, no features that work differently than they appear, no onboarding promises that evaporate after signup.
 
-**[Calendly](/top-100/calendly): Screen 3.2, Pulse 3.2 (gap: 0.0)**
-3,500+ data points. The booking flow is flawless and Pulse agrees. Users describe the scheduling experience as exactly what it appears to be: simple, reliable, and invisible after setup. Pulse noted that sentiment around Calendly is notably *boring*, and that's the highest compliment for a utility product. It works. It's always worked. There's nothing more to say.
+**[Calendly](/top-100/calendly): Screen 3.2, Sentiment 3.2 (gap: 0.0)**
+3,500+ data points. The booking flow is flawless and Ladder agrees. Users describe the scheduling experience as exactly what it appears to be: simple, reliable, and invisible after setup. Ladder noted that sentiment around Calendly is notably *boring*, and that's the highest compliment for a utility product. It works. It's always worked. There's nothing more to say.
 
-**[GitHub](/top-100/github): Screen 3.5, Pulse 3.4 (gap: -0.1)**
-50,000+ data points. Dense but navigable on screen. Dense but navigable in reality. GitHub's information architecture carries the experience, and Pulse confirms that the architecture works as well in daily use as it appears in screenshots. The 0.1-point gap across 50,000 data points is essentially zero.
+**[GitHub](/top-100/github): Screen 3.5, Sentiment 3.4 (gap: -0.1)**
+50,000+ data points. Dense but navigable on screen. Dense but navigable in reality. GitHub's information architecture carries the experience, and Ladder confirms that the architecture works as well in daily use as it appears in screenshots. The 0.1-point gap across 50,000 data points is essentially zero.
 
-**[Figma](/top-100/figma): Screen 3.9, Pulse 3.8 (gap: -0.1)**
-2,600+ data points. Collaboration as a first-class design primitive on screen. Collaboration as a first-class design primitive in practice. Pulse found that Figma's real-time multiplayer experience is described with almost identical language to how it's marketed. The product delivers what the interface shows.
+**[Figma](/top-100/figma): Screen 3.9, Sentiment 3.8 (gap: -0.1)**
+2,600+ data points. Collaboration as a first-class design primitive on screen. Collaboration as a first-class design primitive in practice. Ladder found that Figma's real-time multiplayer experience is described with almost identical language to how it's marketed. The product delivers what the interface shows.
 
 ## What honest products have in common
 
-These six products span four categories (SaaS, Productivity, Fintech, Developer Tools), four price points (free to $30/month), and vastly different levels of complexity. But Pulse identified three patterns they all share:
+These six products span four categories (SaaS, Productivity, Fintech, Developer Tools), four price points (free to $30/month), and vastly different levels of complexity. But Ladder identified three patterns they all share:
 
 **1. No marketing layer inside the product.**
 
@@ -761,17 +761,17 @@ None of these products upsell aggressively inside the core experience. No pop-up
 
 **2. Scope matches ambition.**
 
-Every honest product does a defined thing well rather than doing many things adequately. Linear is project management. Superhuman is email. Mercury is banking. Calendly is scheduling. They aren't platforms trying to be everything. Pulse scores the *entire* experience. Products with narrow scope have less surface area for disappointment.
+Every honest product does a defined thing well rather than doing many things adequately. Linear is project management. Superhuman is email. Mercury is banking. Calendly is scheduling. They aren't platforms trying to be everything. Ladder scores the *entire* experience. Products with narrow scope have less surface area for disappointment.
 
 **3. The onboarding promise matches the long-term experience.**
 
-Pulse tracks sentiment over time. Products with large gaps often have strong early reviews that degrade as users go deeper. Honest products maintain consistent sentiment. The experience at month six matches the experience at day one. There's no "honeymoon cliff."
+Ladder tracks sentiment over time. Products with large gaps often have strong early reviews that degrade as users go deeper. Honest products maintain consistent sentiment. The experience at month six matches the experience at day one. There's no "honeymoon cliff."
 
 ## Why honesty compounds
 
-Products with near-zero gaps don't just maintain trust. They build it. Pulse found that honest products have higher rates of user advocacy: recommendations, referrals, and "you should try this" language. Users who get what they expected become the most reliable growth channel.
+Products with near-zero gaps don't just maintain trust. They build it. Ladder found that honest products have higher rates of user advocacy: recommendations, referrals, and "you should try this" language. Users who get what they expected become the most reliable growth channel.
 
-The lesson isn't that these products have perfect interfaces. Linear is a 4.3 and Calendly is a 3.2. They're at very different levels of the [Ladder framework](/framework). The lesson is that both score within 0.1 of their Pulse Score. Honesty isn't a function of quality. It's a function of alignment between promise and delivery.
+The lesson isn't that these products have perfect interfaces. Linear is a 4.3 and Calendly is a 3.2. They're at very different levels of the [Ladder framework](/framework). The lesson is that both score within 0.1 of their Ladder Top 100 score. Honesty isn't a function of quality. It's a function of alignment between promise and delivery.
 
 Build an interface that accurately represents the experience behind it. [Score your screen](/score) to see the promise. [Request a Pulse demo](/contact) to see the reality. If the numbers match, you're building something users can trust.`,
   },


### PR DESCRIPTION
## Summary
- Top 100 study uses public-signal analysis, not Pulse. Pulse is the enterprise VOC product that ingests a customer's own voice data. Blog posts conflated the two.
- Across 9 posts: replaced "Pulse Score" with "Ladder Top 100 score" / "Sentiment score" in Top 100 contexts; recategorized posts from "Pulse Intelligence/Teardown" to "Ladder Top 100 Analysis/Teardown".
- Kept "Ladder Pulse" only in VOC/enterprise contexts with demo CTAs. Clarified in the lead posts that Pulse is enterprise VOC while the Top 100 uses lighter public-signal analysis.

## Test plan
- [ ] /blog index renders all 9 posts with updated categories
- [ ] Each post body reads naturally (no orphaned "Pulse" references where it should be "Ladder")
- [ ] "Request a Pulse demo" CTA still present on enterprise-appropriate posts
- [ ] No broken internal links (/pulse, /top-100, /framework)

🤖 Generated with [Claude Code](https://claude.com/claude-code)