### PR TITLE
Admin: Ladder Lift evaluation + report generation tool

### DIFF
--- a/src/app/admin/evaluations/[id]/page.tsx
+++ b/src/app/admin/evaluations/[id]/page.tsx
@@ -1,0 +1,496 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
+import type { Evaluation, AnnotationFinding, EvaluationScreen } from "@/lib/evaluation";
+import { AnnotatedScreen } from "@/components/admin/AnnotatedScreen";
+
+const SCORE_COLOR = (s: number | null) => {
+  if (s === null) return "text-muted";
+  if (s >= 4) return "text-ladder-green";
+  if (s >= 3) return "text-ladder-yellow";
+  if (s >= 2) return "text-ladder-orange";
+  return "text-ladder-red";
+};
+
+export default function EvaluationReviewPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+
+  const [evaluation, setEvaluation] = useState<Evaluation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [activeScreenIdx, setActiveScreenIdx] = useState(0);
+  const [dirty, setDirty] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/evaluations/${params.id}`);
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Fetch failed (${res.status})`);
+      }
+      const { evaluation: ev } = await res.json();
+      setEvaluation(ev);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (isSignedIn) load();
+  }, [isSignedIn, params.id]);
+
+  async function analyze(screenId?: string) {
+    if (!evaluation) return;
+    setAnalyzing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/evaluations/${params.id}/analyze`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(screenId ? { screenId } : {}),
+      });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j.error || "Analyze failed");
+      setEvaluation(j.evaluation);
+      setDirty(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Analysis failed");
+    } finally {
+      setAnalyzing(false);
+    }
+  }
+
+  async function save() {
+    if (!evaluation) return;
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/evaluations/${params.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          screens: evaluation.screens,
+          executiveSummary: evaluation.executiveSummary,
+          nextSteps: evaluation.nextSteps,
+          humanNotes: evaluation.humanNotes,
+          status: evaluation.status === "review" ? "review" : evaluation.status,
+        }),
+      });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j.error || "Save failed");
+      setEvaluation(j.evaluation);
+      setDirty(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function approve() {
+    if (!evaluation) return;
+    setSaving(true);
+    try {
+      const res = await fetch(`/api/admin/evaluations/${params.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "approved" }),
+      });
+      const j = await res.json();
+      if (!res.ok) throw new Error(j.error || "Approve failed");
+      setEvaluation(j.evaluation);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Approve failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function deleteEval() {
+    if (!confirm("Delete this evaluation? This cannot be undone.")) return;
+    await fetch(`/api/admin/evaluations/${params.id}`, { method: "DELETE" });
+    router.push("/admin/evaluations");
+  }
+
+  const updateFinding = useCallback(
+    (screenId: string, findingId: string, field: "humanNote" | "fix" | "issue", value: string) => {
+      setEvaluation((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          screens: prev.screens.map((s) =>
+            s.id !== screenId
+              ? s
+              : {
+                  ...s,
+                  findings: s.findings.map((f) =>
+                    f.id !== findingId ? f : { ...f, [field]: value },
+                  ),
+                },
+          ),
+        };
+      });
+      setDirty(true);
+    },
+    [],
+  );
+
+  const updateScreen = useCallback((screenId: string, field: keyof EvaluationScreen, value: string) => {
+    setEvaluation((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        screens: prev.screens.map((s) =>
+          s.id !== screenId ? s : { ...s, [field]: value },
+        ),
+      };
+    });
+    setDirty(true);
+  }, []);
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (loading) {
+    return (
+      <div className="pt-20 font-mono max-w-6xl mx-auto px-6 py-10">
+        <p className="text-muted font-sans">Loading…</p>
+      </div>
+    );
+  }
+
+  if (!evaluation) {
+    return (
+      <div className="pt-20 font-mono max-w-6xl mx-auto px-6 py-10">
+        <p className="text-red-400 font-sans">{error ?? "Evaluation not found."}</p>
+      </div>
+    );
+  }
+
+  const activeScreen: EvaluationScreen | undefined = evaluation.screens[activeScreenIdx];
+  const allAnalyzed = evaluation.screens.every((s) => s.analyzedAt);
+
+  return (
+    <div className="pt-20 font-mono min-h-screen">
+      <div className="max-w-[1200px] mx-auto px-6 py-10">
+        {/* Nav */}
+        <div className="mb-6 flex items-start justify-between">
+          <div>
+            <div className="text-[10px] uppercase tracking-widest text-muted mb-1 font-sans">
+              <Link href="/admin" className="hover:text-foreground transition-colors">Admin</Link>
+              <span className="mx-1.5">/</span>
+              <Link href="/admin/evaluations" className="hover:text-foreground transition-colors">Evaluations</Link>
+              <span className="mx-1.5">/</span>
+              <span className="text-foreground">{evaluation.clientName}</span>
+            </div>
+            <h1 className="text-xl text-foreground font-sans">
+              {evaluation.clientName}
+              <span className="text-muted mx-2">—</span>
+              {evaluation.projectName}
+            </h1>
+            <div className="flex items-center gap-4 mt-1">
+              {evaluation.overallScore !== null && (
+                <span className={`text-2xl font-semibold tabular-nums ${SCORE_COLOR(evaluation.overallScore)}`}>
+                  {evaluation.overallScore.toFixed(1)}
+                </span>
+              )}
+              <span className="text-[10px] uppercase tracking-widest text-muted">
+                {evaluation.mode === "sample" ? "Sample report" : "Full audit"}
+              </span>
+              <span className="text-[10px] uppercase tracking-widest text-muted">
+                {evaluation.status}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-3 flex-wrap justify-end">
+            {!allAnalyzed && (
+              <button
+                onClick={() => analyze()}
+                disabled={analyzing}
+                className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors disabled:opacity-40"
+              >
+                {analyzing ? "Analyzing…" : "Run analysis"}
+              </button>
+            )}
+            {dirty && (
+              <button
+                onClick={save}
+                disabled={saving}
+                className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+              >
+                {saving ? "Saving…" : "Save changes"}
+              </button>
+            )}
+            {allAnalyzed && evaluation.status !== "approved" && (
+              <button
+                onClick={approve}
+                disabled={saving}
+                className="text-xs font-semibold bg-foreground text-background px-4 py-1.5 rounded-sm hover:bg-foreground/90 transition-colors disabled:opacity-40"
+              >
+                Approve
+              </button>
+            )}
+            {evaluation.status === "approved" && (
+              <Link
+                href={`/admin/evaluations/${evaluation.id}/report`}
+                className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors"
+              >
+                Open report
+              </Link>
+            )}
+            <button
+              onClick={deleteEval}
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-red-400 transition-colors"
+            >
+              Delete
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-4 border border-red-500/40 bg-red-500/5 text-red-400 text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* Screen tabs */}
+        {evaluation.screens.length > 1 && (
+          <div className="flex gap-1 mb-6 border-b border-[#2a2a2a] pb-0">
+            {evaluation.screens.map((s, i) => (
+              <button
+                key={s.id}
+                onClick={() => setActiveScreenIdx(i)}
+                className={`px-3 py-2 text-[11px] font-sans border-b-2 transition-colors ${
+                  i === activeScreenIdx
+                    ? "border-ladder-green text-foreground"
+                    : "border-transparent text-muted hover:text-foreground"
+                }`}
+              >
+                {s.screenName || `Screen ${i + 1}`}
+                {s.score !== null && (
+                  <span className={`ml-1.5 tabular-nums ${SCORE_COLOR(s.score)}`}>
+                    {s.score.toFixed(1)}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {activeScreen && (
+          <div>
+            {/* Screen header */}
+            <div className="flex items-center gap-4 mb-4">
+              <input
+                type="text"
+                value={activeScreen.screenName}
+                onChange={(e) => updateScreen(activeScreen.id, "screenName", e.target.value)}
+                placeholder="Screen name…"
+                className="bg-transparent border-b border-[#333] text-sm text-foreground px-0 py-1 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans w-64"
+              />
+              {activeScreen.score !== null && (
+                <>
+                  <span className={`text-xl font-semibold tabular-nums ${SCORE_COLOR(activeScreen.score)}`}>
+                    {activeScreen.score.toFixed(1)}
+                  </span>
+                  <span className="text-xs text-muted font-sans">{activeScreen.label}</span>
+                </>
+              )}
+              {!activeScreen.analyzedAt && (
+                <button
+                  onClick={() => analyze(activeScreen.id)}
+                  disabled={analyzing}
+                  className="text-[10px] uppercase tracking-widest text-ladder-green hover:text-ladder-green/80 transition-colors disabled:opacity-40"
+                >
+                  {analyzing ? "Analyzing…" : "Analyze this screen"}
+                </button>
+              )}
+              {activeScreen.analyzedAt && (
+                <button
+                  onClick={() => analyze(activeScreen.id)}
+                  disabled={analyzing}
+                  className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
+                >
+                  {analyzing ? "Re-analyzing…" : "Re-analyze"}
+                </button>
+              )}
+            </div>
+
+            {activeScreen.summary && (
+              <p className="text-sm text-muted font-sans mb-6 italic">{activeScreen.summary}</p>
+            )}
+
+            {/* Annotated screen */}
+            {activeScreen.analyzedAt ? (
+              <div className="overflow-x-auto">
+                <AnnotatedScreen
+                  imageDataUrl={activeScreen.imageData}
+                  findings={activeScreen.findings}
+                  displayWidth={620}
+                  onFindingEdit={(findingId, field, value) =>
+                    updateFinding(activeScreen.id, findingId, field, value)
+                  }
+                />
+              </div>
+            ) : (
+              <div className="border border-dashed border-[#333] p-8 text-center">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={activeScreen.imageData}
+                  alt="Screen preview"
+                  className="max-w-full mx-auto mb-4 opacity-50"
+                  style={{ maxHeight: 400, objectFit: "contain" }}
+                />
+                <p className="text-muted font-sans text-sm">
+                  {analyzing ? "Analyzing…" : "Run analysis to generate annotations."}
+                </p>
+              </div>
+            )}
+
+            {/* Findings list below */}
+            {activeScreen.findings.length > 0 && (
+              <div className="mt-8">
+                <div className="text-[10px] uppercase tracking-widest text-muted mb-3">
+                  Findings ({activeScreen.findings.length})
+                </div>
+                <div className="space-y-3">
+                  {activeScreen.findings.map((f, i) => (
+                    <FindingRow
+                      key={f.id}
+                      index={i + 1}
+                      finding={f}
+                      onEdit={(field, value) => updateFinding(activeScreen.id, f.id, field, value)}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Executive summary + next steps */}
+        {allAnalyzed && (
+          <div className="mt-10 grid grid-cols-2 gap-6 border-t border-[#2a2a2a] pt-8">
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-2">
+                Executive summary
+              </label>
+              <textarea
+                value={evaluation.executiveSummary}
+                onChange={(e) => {
+                  setEvaluation((prev) => prev ? { ...prev, executiveSummary: e.target.value } : prev);
+                  setDirty(true);
+                }}
+                rows={5}
+                placeholder="Overall assessment for the report…"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground p-2.5 focus:outline-none focus:border-muted placeholder:text-[#555] resize-y font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-2">
+                What&apos;s next (report pitch)
+              </label>
+              <textarea
+                value={evaluation.nextSteps}
+                onChange={(e) => {
+                  setEvaluation((prev) => prev ? { ...prev, nextSteps: e.target.value } : prev);
+                  setDirty(true);
+                }}
+                rows={5}
+                placeholder="Pitch for the next engagement step…"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground p-2.5 focus:outline-none focus:border-muted placeholder:text-[#555] resize-y font-sans"
+              />
+            </div>
+            <div className="col-span-2">
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-2">
+                Internal notes (not in report)
+              </label>
+              <textarea
+                value={evaluation.humanNotes}
+                onChange={(e) => {
+                  setEvaluation((prev) => prev ? { ...prev, humanNotes: e.target.value } : prev);
+                  setDirty(true);
+                }}
+                rows={3}
+                placeholder="Sales context, call notes, anything internal…"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground p-2.5 focus:outline-none focus:border-muted placeholder:text-[#555] resize-y font-sans"
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function FindingRow({
+  index,
+  finding,
+  onEdit,
+}: {
+  index: number;
+  finding: AnnotationFinding;
+  onEdit: (field: "humanNote" | "fix" | "issue", value: string) => void;
+}) {
+  const SCOLOR = { high: "text-red-400", medium: "text-orange-400", low: "text-yellow-400" };
+  return (
+    <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+      <div className="flex items-start gap-3">
+        <span className="text-[10px] tabular-nums text-muted mt-0.5 w-4 flex-shrink-0">{index}</span>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <span className="text-xs font-semibold text-foreground">{finding.title}</span>
+            <span className={`text-[9px] uppercase tracking-widest ${SCOLOR[finding.severity]}`}>
+              {finding.severity}
+            </span>
+            <span className="text-[9px] uppercase tracking-widest text-[#555]">{finding.category}</span>
+          </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="text-[9px] uppercase tracking-widest text-muted block mb-1">Issue</label>
+              <textarea
+                value={finding.issue}
+                onChange={(e) => onEdit("issue", e.target.value)}
+                rows={2}
+                className="w-full bg-[#111] border border-[#2a2a2a] text-xs text-muted p-2 focus:outline-none focus:border-muted resize-none font-sans"
+              />
+            </div>
+            <div>
+              <label className="text-[9px] uppercase tracking-widest text-muted block mb-1">Fix</label>
+              <textarea
+                value={finding.fix}
+                onChange={(e) => onEdit("fix", e.target.value)}
+                rows={2}
+                className="w-full bg-[#111] border border-[#2a2a2a] text-xs text-muted p-2 focus:outline-none focus:border-muted resize-none font-sans"
+              />
+            </div>
+            <div className="col-span-2">
+              <label className="text-[9px] uppercase tracking-widest text-muted block mb-1">
+                Human note (optional)
+              </label>
+              <input
+                type="text"
+                value={finding.humanNote}
+                onChange={(e) => onEdit("humanNote", e.target.value)}
+                placeholder="Add context or emphasis…"
+                className="w-full bg-[#111] border border-[#2a2a2a] text-xs text-ladder-green px-2 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/evaluations/[id]/report/page.tsx
+++ b/src/app/admin/evaluations/[id]/report/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import type { Evaluation } from "@/lib/evaluation";
+import { AnnotatedScreen } from "@/components/admin/AnnotatedScreen";
+
+const SCORE_LABEL: Record<string, string> = {
+  Functional: "Functional",
+  Usable: "Usable",
+  Comfortable: "Comfortable",
+  Delightful: "Delightful",
+  Meaningful: "Meaningful",
+};
+
+const SCORE_COLOR = (s: number) => {
+  if (s >= 4) return "#22c55e";
+  if (s >= 3) return "#eab308";
+  if (s >= 2) return "#f97316";
+  return "#ef4444";
+};
+
+export default function ReportPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const params = useParams<{ id: string }>();
+  const [evaluation, setEvaluation] = useState<Evaluation | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    fetch(`/api/admin/evaluations/${params.id}`)
+      .then((r) => r.json())
+      .then(({ evaluation: ev, error: err }) => {
+        if (err) throw new Error(err);
+        setEvaluation(ev);
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [isSignedIn, params.id]);
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (loading) {
+    return <div className="p-10 text-muted font-sans">Loading…</div>;
+  }
+
+  if (!evaluation) {
+    return <div className="p-10 text-red-400 font-sans">{error ?? "Not found."}</div>;
+  }
+
+  const analyzedScreens = evaluation.screens.filter((s) => s.analyzedAt);
+
+  return (
+    <>
+      {/* Screen-only toolbar — hidden in print */}
+      <div className="print:hidden pt-20 pb-4 px-8 flex items-center justify-between border-b border-[#2a2a2a] bg-background sticky top-0 z-10">
+        <div className="text-[10px] uppercase tracking-widest text-muted font-mono">
+          <Link href={`/admin/evaluations/${evaluation.id}`} className="hover:text-foreground transition-colors">
+            ← Back to review
+          </Link>
+        </div>
+        <button
+          onClick={() => window.print()}
+          className="text-xs font-semibold bg-ladder-green text-background px-5 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors font-sans"
+        >
+          Print / Export PDF
+        </button>
+      </div>
+
+      {/* Report body */}
+      <div className="report-body bg-white text-[#111] font-sans" style={{ minHeight: "100vh" }}>
+        {/* Cover / header */}
+        <div
+          className="report-header"
+          style={{
+            background: "#0e0e0e",
+            color: "#fff",
+            padding: "48px 56px 40px",
+            pageBreakAfter: "avoid",
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start" }}>
+            {/* Left: branding */}
+            <div>
+              <div style={{ fontSize: 11, letterSpacing: "0.12em", textTransform: "uppercase", color: "#6AC89B", marginBottom: 16, fontFamily: "monospace" }}>
+                Ladder Evaluation
+              </div>
+              <div style={{ fontSize: 28, fontWeight: 700, lineHeight: 1.1, marginBottom: 6 }}>
+                {evaluation.clientName}
+              </div>
+              <div style={{ fontSize: 16, color: "#888", fontWeight: 400 }}>
+                {evaluation.projectName}
+              </div>
+            </div>
+
+            {/* Right: score */}
+            {evaluation.overallScore !== null && (
+              <div style={{ textAlign: "right" }}>
+                <div
+                  style={{
+                    fontSize: 56,
+                    fontWeight: 700,
+                    lineHeight: 1,
+                    color: SCORE_COLOR(evaluation.overallScore),
+                    fontFamily: "monospace",
+                  }}
+                >
+                  {evaluation.overallScore.toFixed(1)}
+                </div>
+                <div style={{ fontSize: 13, color: "#888", marginTop: 4, textTransform: "uppercase", letterSpacing: "0.1em" }}>
+                  {analyzedScreens[0]?.label ?? ""}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Ladder level bar */}
+          <div style={{ display: "flex", gap: 4, marginTop: 32 }}>
+            {(["Functional", "Usable", "Comfortable", "Delightful", "Meaningful"] as const).map((level, i) => {
+              const score = evaluation.overallScore ?? 0;
+              const levelMin = i + 1;
+              const active = score >= levelMin && score < levelMin + 1;
+              const passed = score >= levelMin + 1;
+              return (
+                <div
+                  key={level}
+                  style={{
+                    flex: 1,
+                    height: 4,
+                    background: passed ? "#6AC89B" : active ? SCORE_COLOR(score) : "#333",
+                    borderRadius: 2,
+                  }}
+                />
+              );
+            })}
+          </div>
+          <div style={{ display: "flex", gap: 4, marginTop: 6 }}>
+            {["Functional", "Usable", "Comfortable", "Delightful", "Meaningful"].map((level) => (
+              <div key={level} style={{ flex: 1, fontSize: 9, color: "#555", textTransform: "uppercase", letterSpacing: "0.08em" }}>
+                {level}
+              </div>
+            ))}
+          </div>
+
+          {/* Summary */}
+          {evaluation.executiveSummary && (
+            <div style={{ marginTop: 28, paddingTop: 24, borderTop: "1px solid #222" }}>
+              <p style={{ fontSize: 14, color: "#ccc", lineHeight: 1.6, maxWidth: 680 }}>
+                {evaluation.executiveSummary}
+              </p>
+            </div>
+          )}
+
+          {/* Drawbackwards credit */}
+          <div style={{ marginTop: 24, fontSize: 10, color: "#444", letterSpacing: "0.08em", textTransform: "uppercase" }}>
+            Prepared by Drawbackwards · runladder.com
+          </div>
+        </div>
+
+        {/* Screens */}
+        {analyzedScreens.map((screen, screenIdx) => (
+          <div
+            key={screen.id}
+            style={{
+              padding: "48px 0",
+              pageBreakBefore: screenIdx > 0 ? "always" : "auto",
+              pageBreakInside: "avoid",
+            }}
+          >
+            {/* Screen label */}
+            <div style={{ padding: "0 56px", marginBottom: 24 }}>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 16, marginBottom: 8 }}>
+                <span style={{ fontSize: 18, fontWeight: 600, color: "#111" }}>
+                  {screen.screenName || `Screen ${screenIdx + 1}`}
+                </span>
+                {screen.score !== null && (
+                  <>
+                    <span
+                      style={{
+                        fontSize: 24,
+                        fontWeight: 700,
+                        fontFamily: "monospace",
+                        color: SCORE_COLOR(screen.score),
+                      }}
+                    >
+                      {screen.score.toFixed(1)}
+                    </span>
+                    <span style={{ fontSize: 12, color: "#888", textTransform: "uppercase", letterSpacing: "0.1em" }}>
+                      {SCORE_LABEL[screen.label ?? ""] ?? screen.label}
+                    </span>
+                  </>
+                )}
+              </div>
+              {screen.summary && (
+                <p style={{ fontSize: 13, color: "#555", lineHeight: 1.6 }}>{screen.summary}</p>
+              )}
+            </div>
+
+            {/* Annotated screen — slightly narrower image for report */}
+            <div style={{ overflowX: "auto" }}>
+              <AnnotatedScreen
+                imageDataUrl={screen.imageData}
+                findings={screen.findings}
+                displayWidth={580}
+                readOnly
+              />
+            </div>
+
+            {/* Findings detail list */}
+            {screen.findings.length > 0 && (
+              <div style={{ padding: "32px 56px 0" }}>
+                <div style={{ borderTop: "1px solid #e5e7eb", paddingTop: 24 }}>
+                  <div style={{ fontSize: 10, letterSpacing: "0.1em", textTransform: "uppercase", color: "#888", marginBottom: 16 }}>
+                    Findings
+                  </div>
+                  <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+                    {screen.findings.map((f, i) => (
+                      <div key={f.id} style={{ display: "flex", gap: 16, alignItems: "flex-start" }}>
+                        <div
+                          style={{
+                            width: 20,
+                            height: 20,
+                            borderRadius: "50%",
+                            background:
+                              f.severity === "high" ? "#ef4444" : f.severity === "medium" ? "#f97316" : "#eab308",
+                            color: "#fff",
+                            fontSize: 10,
+                            fontWeight: 700,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            flexShrink: 0,
+                            marginTop: 2,
+                          }}
+                        >
+                          {i + 1}
+                        </div>
+                        <div>
+                          <div style={{ fontSize: 13, fontWeight: 600, color: "#111", marginBottom: 3 }}>
+                            {f.title}
+                          </div>
+                          <p style={{ fontSize: 12, color: "#555", lineHeight: 1.6, margin: "0 0 4px" }}>
+                            {f.issue}
+                          </p>
+                          <p style={{ fontSize: 12, color: "#6AC89B", lineHeight: 1.5, margin: 0 }}>
+                            → {f.fix}
+                          </p>
+                          {f.humanNote && (
+                            <p style={{ fontSize: 12, color: "#888", lineHeight: 1.5, marginTop: 4, fontStyle: "italic" }}>
+                              {f.humanNote}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+
+        {/* What's next */}
+        {evaluation.nextSteps && (
+          <div
+            style={{
+              background: "#0e0e0e",
+              color: "#fff",
+              padding: "40px 56px",
+              pageBreakBefore: "always",
+            }}
+          >
+            <div style={{ fontSize: 10, letterSpacing: "0.12em", textTransform: "uppercase", color: "#6AC89B", marginBottom: 16, fontFamily: "monospace" }}>
+              What&apos;s next
+            </div>
+            <p style={{ fontSize: 15, color: "#ccc", lineHeight: 1.7, maxWidth: 640 }}>
+              {evaluation.nextSteps}
+            </p>
+            <div style={{ marginTop: 32, paddingTop: 24, borderTop: "1px solid #222", fontSize: 11, color: "#444" }}>
+              Drawbackwards · drawbackwards.com · runladder.com
+            </div>
+          </div>
+        )}
+      </div>
+
+      <style>{`
+        @media print {
+          .print\\:hidden { display: none !important; }
+          body { background: white; }
+          .report-body { margin: 0; }
+          @page {
+            margin: 0;
+            size: letter;
+          }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/src/app/admin/evaluations/new/page.tsx
+++ b/src/app/admin/evaluations/new/page.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+type UploadedImage = {
+  name: string;
+  dataUrl: string;
+  preview: string;
+};
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export default function NewEvaluationPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const router = useRouter();
+
+  const [clientName, setClientName] = useState("");
+  const [projectName, setProjectName] = useState("");
+  const [mode, setMode] = useState<"sample" | "audit">("sample");
+  const [images, setImages] = useState<UploadedImage[]>([]);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFiles(files: FileList | null) {
+    if (!files?.length) return;
+    const newImages: UploadedImage[] = [];
+    for (const file of Array.from(files)) {
+      if (!file.type.startsWith("image/")) continue;
+      const dataUrl = await readFileAsDataUrl(file);
+      newImages.push({ name: file.name, dataUrl, preview: dataUrl });
+    }
+    setImages((prev) => [...prev, ...newImages]);
+  }
+
+  function removeImage(idx: number) {
+    setImages((prev) => prev.filter((_, i) => i !== idx));
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!clientName.trim()) return setError("Client name required");
+    if (!projectName.trim()) return setError("Project name required");
+    if (!images.length) return setError("At least one screen required");
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/evaluations", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          clientName: clientName.trim(),
+          projectName: projectName.trim(),
+          mode,
+          images: images.map((img) => img.dataUrl),
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Create failed (${res.status})`);
+      router.push(`/admin/evaluations/${json.evaluation.id}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create");
+      setSubmitting(false);
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-3xl mx-auto px-6 py-10">
+        {/* Nav */}
+        <div className="mb-8">
+          <div className="text-[10px] uppercase tracking-widest text-muted mb-1 font-sans">
+            <Link href="/admin" className="hover:text-foreground transition-colors">Admin</Link>
+            <span className="mx-1.5">/</span>
+            <Link href="/admin/evaluations" className="hover:text-foreground transition-colors">Evaluations</Link>
+            <span className="mx-1.5">/</span>
+            <span className="text-foreground">New</span>
+          </div>
+          <h1 className="text-xl text-foreground font-sans">New evaluation</h1>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-red-500/40 bg-red-500/5 text-red-400 text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={submit} className="space-y-6">
+          {/* Client + project */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1.5">
+                Client name
+              </label>
+              <input
+                type="text"
+                value={clientName}
+                onChange={(e) => setClientName(e.target.value)}
+                placeholder="Acme Corp"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1.5">
+                Project / screen
+              </label>
+              <input
+                type="text"
+                value={projectName}
+                onChange={(e) => setProjectName(e.target.value)}
+                placeholder="Onboarding flow"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+          </div>
+
+          {/* Mode */}
+          <div>
+            <label className="block text-[10px] uppercase tracking-widest text-muted mb-2">
+              Report type
+            </label>
+            <div className="flex gap-3">
+              {(["sample", "audit"] as const).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => setMode(m)}
+                  className={`px-4 py-2 text-xs font-semibold border transition-colors ${
+                    mode === m
+                      ? "border-ladder-green bg-ladder-green/10 text-ladder-green"
+                      : "border-[#333] text-muted hover:border-muted hover:text-foreground"
+                  }`}
+                >
+                  {m === "sample" ? "Sample report" : "Full audit"}
+                </button>
+              ))}
+            </div>
+            <p className="text-[11px] text-muted font-sans mt-1.5">
+              {mode === "sample"
+                ? "3–5 findings. Free post-call deliverable + pitch for what's next."
+                : "4–8 findings per screen. Full paid audit deliverable."}
+            </p>
+          </div>
+
+          {/* Image upload */}
+          <div>
+            <label className="block text-[10px] uppercase tracking-widest text-muted mb-2">
+              Screens ({images.length})
+            </label>
+            <div
+              onDrop={handleDrop}
+              onDragOver={(e) => e.preventDefault()}
+              onClick={() => fileInputRef.current?.click()}
+              className="border border-dashed border-[#444] bg-[#111] p-8 text-center cursor-pointer hover:border-muted transition-colors"
+            >
+              <p className="text-sm text-muted font-sans">
+                Drop screenshots here or click to upload
+              </p>
+              <p className="text-[11px] text-[#555] font-sans mt-1">
+                PNG, JPG, WebP — multiple files supported
+              </p>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                className="hidden"
+                onChange={(e) => handleFiles(e.target.files)}
+              />
+            </div>
+
+            {images.length > 0 && (
+              <div className="mt-3 grid grid-cols-3 gap-3">
+                {images.map((img, i) => (
+                  <div key={i} className="relative group">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={img.preview}
+                      alt={img.name}
+                      className="w-full aspect-video object-cover border border-[#333]"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeImage(i)}
+                      className="absolute top-1 right-1 w-5 h-5 bg-background/80 text-foreground text-[10px] flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-500/20 hover:text-red-400"
+                    >
+                      ×
+                    </button>
+                    <p className="text-[10px] text-muted mt-1 truncate font-sans">{img.name}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center gap-4 pt-2">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="text-sm font-semibold bg-ladder-green text-background px-6 py-2 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+            >
+              {submitting ? "Creating…" : "Create evaluation"}
+            </button>
+            <Link
+              href="/admin/evaluations"
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/evaluations/page.tsx
+++ b/src/app/admin/evaluations/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
+import type { Evaluation } from "@/lib/evaluation";
+
+function fmtDate(iso: string) {
+  return new Date(iso).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  draft: "text-muted",
+  analyzing: "text-ladder-yellow",
+  review: "text-ladder-green",
+  approved: "text-foreground",
+};
+
+const MODE_LABEL: Record<string, string> = {
+  sample: "Sample",
+  audit: "Audit",
+};
+
+export default function EvaluationsPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [evaluations, setEvaluations] = useState<Evaluation[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/evaluations");
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Fetch failed (${res.status})`);
+      }
+      const { evaluations: list } = await res.json();
+      setEvaluations(list);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (isSignedIn) load();
+  }, [isSignedIn]);
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        {/* Nav */}
+        <div className="mb-8 flex items-baseline justify-between">
+          <div>
+            <div className="text-[10px] uppercase tracking-widest text-muted mb-1 font-sans">
+              <Link href="/admin" className="hover:text-foreground transition-colors">Admin</Link>
+              <span className="mx-1.5">/</span>
+              <span className="text-foreground">Evaluations</span>
+            </div>
+            <h1 className="text-xl text-foreground font-sans">Evaluations</h1>
+          </div>
+          <Link
+            href="/admin/evaluations/new"
+            className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors"
+          >
+            New evaluation
+          </Link>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-red-500/40 bg-red-500/5 text-red-400 text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        <div className="border border-[#333] bg-[#1e1e1e]">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                <th className="text-left p-3">Client</th>
+                <th className="text-left p-3">Project</th>
+                <th className="text-left p-3">Mode</th>
+                <th className="text-left p-3">Status</th>
+                <th className="text-left p-3">Screens</th>
+                <th className="text-left p-3">Score</th>
+                <th className="text-left p-3">Created</th>
+                <th className="text-right p-3"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={8} className="p-6 text-center text-muted font-sans">
+                    Loading…
+                  </td>
+                </tr>
+              ) : evaluations.length === 0 ? (
+                <tr>
+                  <td colSpan={8} className="p-6 text-center text-muted font-sans">
+                    No evaluations yet.{" "}
+                    <Link href="/admin/evaluations/new" className="text-ladder-green hover:underline">
+                      Create the first one.
+                    </Link>
+                  </td>
+                </tr>
+              ) : (
+                evaluations.map((ev) => (
+                  <tr
+                    key={ev.id}
+                    className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                  >
+                    <td className="p-3 text-foreground">{ev.clientName}</td>
+                    <td className="p-3 text-muted">{ev.projectName}</td>
+                    <td className="p-3 text-muted uppercase tracking-widest text-[10px]">
+                      {MODE_LABEL[ev.mode]}
+                    </td>
+                    <td className={`p-3 uppercase tracking-widest text-[10px] ${STATUS_COLOR[ev.status] ?? "text-muted"}`}>
+                      {ev.status}
+                    </td>
+                    <td className="p-3 text-muted tabular-nums">{ev.screens.length}</td>
+                    <td className="p-3 tabular-nums">
+                      {ev.overallScore !== null ? (
+                        <span className="text-foreground font-semibold">
+                          {ev.overallScore.toFixed(1)}
+                        </span>
+                      ) : (
+                        <span className="text-muted">—</span>
+                      )}
+                    </td>
+                    <td className="p-3 text-muted">{fmtDate(ev.createdAt)}</td>
+                    <td className="p-3 text-right">
+                      <Link
+                        href={`/admin/evaluations/${ev.id}`}
+                        className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors mr-3"
+                      >
+                        Review
+                      </Link>
+                      <Link
+                        href={`/admin/evaluations/${ev.id}/report`}
+                        className="text-[10px] uppercase tracking-widest text-ladder-green hover:text-ladder-green/80 transition-colors"
+                      >
+                        Report
+                      </Link>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useEffect, useState } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
 
 type InviteRecord = {
   code: string;
@@ -359,13 +360,21 @@ export default function AdminPage() {
               Plugin beta — invite codes and users
             </p>
           </div>
-          <button
-            onClick={refresh}
-            className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
-            disabled={loading}
-          >
-            {loading ? "Loading…" : "Refresh"}
-          </button>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/admin/evaluations"
+              className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
+            >
+              Evaluations
+            </Link>
+            <button
+              onClick={refresh}
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+              disabled={loading}
+            >
+              {loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
         </div>
 
         {error && (

--- a/src/app/api/admin/evaluations/[id]/analyze/route.ts
+++ b/src/app/api/admin/evaluations/[id]/analyze/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminEmail } from "@/lib/admin";
+import { getEvaluation, updateEvaluation } from "@/lib/evaluation";
+import type { EvaluationScreen, AnnotationFinding } from "@/lib/evaluation";
+import { analyzeScreenForReport } from "@/lib/annotation-analysis";
+import { parseImageDataUrl } from "@/lib/scoring";
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { id } = await params;
+  const evaluation = await getEvaluation(id);
+  if (!evaluation) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  let body: { screenId?: string } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  // Analyze either a single screen or all screens
+  const screensToAnalyze = body.screenId
+    ? evaluation.screens.filter((s) => s.id === body.screenId)
+    : evaluation.screens;
+
+  if (!screensToAnalyze.length) {
+    return NextResponse.json({ error: "No matching screens" }, { status: 400 });
+  }
+
+  // Mark as analyzing
+  await updateEvaluation(id, { status: "analyzing" });
+
+  const updatedScreens: EvaluationScreen[] = [...evaluation.screens];
+
+  for (const screen of screensToAnalyze) {
+    const parsed = parseImageDataUrl(screen.imageData);
+    if (!parsed) continue;
+
+    const result = await analyzeScreenForReport(parsed, evaluation.mode);
+    const idx = updatedScreens.findIndex((s) => s.id === screen.id);
+    if (idx === -1) continue;
+
+    if ("error" in result) {
+      // Leave screen as-is, continue with others
+      continue;
+    }
+
+    updatedScreens[idx] = {
+      ...updatedScreens[idx],
+      screenName: result.screenName,
+      score: result.score,
+      label: result.label,
+      summary: result.summary,
+      findings: result.findings.map((f) => ({
+        id: f.id,
+        title: f.title,
+        issue: f.issue,
+        fix: f.fix,
+        severity: f.severity,
+        xPercent: f.xPercent,
+        yPercent: f.yPercent,
+        category: f.category,
+        humanNote: "",
+      } satisfies AnnotationFinding)),
+      analyzedAt: new Date().toISOString(),
+    };
+  }
+
+  // Compute overall score as average of analyzed screens
+  const scoredScreens = updatedScreens.filter((s) => s.score !== null);
+  const overallScore =
+    scoredScreens.length > 0
+      ? Math.round((scoredScreens.reduce((sum, s) => sum + (s.score ?? 0), 0) / scoredScreens.length) * 10) / 10
+      : null;
+
+  const updated = await updateEvaluation(id, {
+    screens: updatedScreens,
+    overallScore,
+    status: "review",
+  });
+
+  return NextResponse.json({ evaluation: updated });
+}

--- a/src/app/api/admin/evaluations/[id]/route.ts
+++ b/src/app/api/admin/evaluations/[id]/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminEmail } from "@/lib/admin";
+import { getEvaluation, updateEvaluation, deleteEvaluation } from "@/lib/evaluation";
+import type { Evaluation } from "@/lib/evaluation";
+
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { id } = await params;
+  const evaluation = await getEvaluation(id);
+  if (!evaluation) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  return NextResponse.json({ evaluation });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { id } = await params;
+  let body: Partial<Omit<Evaluation, "id" | "createdAt">> = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const updated = await updateEvaluation(id, body);
+  if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  return NextResponse.json({ evaluation: updated });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { id } = await params;
+  const existing = await getEvaluation(id);
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  await deleteEvaluation(id);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/evaluations/route.ts
+++ b/src/app/api/admin/evaluations/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAdminEmail } from "@/lib/admin";
+import { listEvaluations, createEvaluation } from "@/lib/evaluation";
+import type { EvaluationMode } from "@/lib/evaluation";
+import { parseImageDataUrl } from "@/lib/scoring";
+
+export async function GET() {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const evaluations = await listEvaluations();
+  return NextResponse.json({ evaluations });
+}
+
+export async function POST(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  let body: {
+    clientName?: string;
+    projectName?: string;
+    mode?: EvaluationMode;
+    images?: string[];
+  } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!body.clientName?.trim()) {
+    return NextResponse.json({ error: "clientName required" }, { status: 400 });
+  }
+  if (!body.projectName?.trim()) {
+    return NextResponse.json({ error: "projectName required" }, { status: 400 });
+  }
+  if (!body.images?.length) {
+    return NextResponse.json({ error: "At least one image required" }, { status: 400 });
+  }
+  if (body.mode !== "sample" && body.mode !== "audit") {
+    return NextResponse.json({ error: "mode must be 'sample' or 'audit'" }, { status: 400 });
+  }
+
+  const screens = body.images.map((img) => {
+    const parsed = parseImageDataUrl(img);
+    if (!parsed) throw new Error("Invalid image data URL");
+    return { imageData: img };
+  });
+
+  const evaluation = await createEvaluation({
+    clientName: body.clientName.trim(),
+    projectName: body.projectName.trim(),
+    mode: body.mode,
+    screens,
+  });
+
+  return NextResponse.json({ evaluation }, { status: 201 });
+}

--- a/src/components/admin/AnnotatedScreen.tsx
+++ b/src/components/admin/AnnotatedScreen.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useRef, useState, useEffect, useCallback } from "react";
+import type { AnnotationFinding } from "@/lib/evaluation";
+
+type Props = {
+  imageDataUrl: string;
+  findings: AnnotationFinding[];
+  displayWidth?: number;
+  onFindingEdit?: (id: string, field: "humanNote" | "fix" | "issue", value: string) => void;
+  readOnly?: boolean;
+};
+
+const MARGIN_W = 220;
+const STEM = 14;
+const MIN_SLOT = 76;
+
+type AnnotationLayout = {
+  id: string;
+  finding: AnnotationFinding;
+  pinX: number;
+  pinY: number;
+  elbowY: number;
+  exitX: number;
+  textY: number;
+  side: "left" | "right";
+};
+
+function computeLayout(
+  findings: AnnotationFinding[],
+  imgW: number,
+  imgH: number,
+): AnnotationLayout[] {
+  const layouts = findings.map((f) => {
+    const pinX = f.xPercent * imgW;
+    const pinY = f.yPercent * imgH;
+    const side: "left" | "right" = f.xPercent < 0.5 ? "left" : "right";
+    // Exit point: 8px outside the image edge
+    const exitX = side === "left" ? -8 : imgW + 8;
+    const dx = Math.abs(pinX - exitX);
+    // Go up from lower half, down from upper half
+    const goUp = f.yPercent >= 0.5;
+    const elbowY = goUp ? pinY - STEM : pinY + STEM;
+    const naturalTextY = goUp ? elbowY - dx : elbowY + dx;
+    return { id: f.id, finding: f, pinX, pinY, elbowY, exitX, textY: naturalTextY, side };
+  });
+
+  // Resolve collisions per side
+  for (const side of ["left", "right"] as const) {
+    const sideItems = layouts
+      .filter((l) => l.side === side)
+      .sort((a, b) => a.textY - b.textY);
+    for (let i = 1; i < sideItems.length; i++) {
+      if (sideItems[i].textY < sideItems[i - 1].textY + MIN_SLOT) {
+        sideItems[i].textY = sideItems[i - 1].textY + MIN_SLOT;
+      }
+    }
+  }
+
+  return layouts;
+}
+
+const SEVERITY_COLOR = {
+  high: "#ef4444",
+  medium: "#f97316",
+  low: "#eab308",
+} as const;
+
+export function AnnotatedScreen({
+  imageDataUrl,
+  findings,
+  displayWidth = 620,
+  onFindingEdit,
+  readOnly = false,
+}: Props) {
+  const imgRef = useRef<HTMLImageElement>(null);
+  const [imgH, setImgH] = useState<number | null>(null);
+
+  const measureImage = useCallback(() => {
+    const img = imgRef.current;
+    if (!img || !img.naturalWidth) return;
+    const h = Math.round(displayWidth * (img.naturalHeight / img.naturalWidth));
+    setImgH(h);
+  }, [displayWidth]);
+
+  useEffect(() => {
+    const img = imgRef.current;
+    if (!img) return;
+    if (img.complete && img.naturalWidth) {
+      measureImage();
+    }
+  }, [measureImage]);
+
+  const layout = imgH ? computeLayout(findings, displayWidth, imgH) : [];
+  const totalWidth = MARGIN_W + displayWidth + MARGIN_W;
+
+  return (
+    <div style={{ width: totalWidth, position: "relative" }}>
+      <div style={{ display: "flex", alignItems: "flex-start" }}>
+        {/* Left margin */}
+        <div style={{ width: MARGIN_W, flexShrink: 0, position: "relative", height: imgH ?? "auto" }}>
+          {layout
+            .filter((a) => a.side === "left")
+            .map((a) => (
+              <AnnotationTextBlock
+                key={a.id}
+                annotation={a}
+                side="left"
+                onEdit={onFindingEdit}
+                readOnly={readOnly}
+              />
+            ))}
+        </div>
+
+        {/* Image + SVG pin overlay */}
+        <div style={{ width: displayWidth, flexShrink: 0, position: "relative" }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            ref={imgRef}
+            src={imageDataUrl}
+            alt="Screen"
+            onLoad={measureImage}
+            style={{ width: "100%", display: "block" }}
+          />
+          {imgH && (
+            <svg
+              style={{
+                position: "absolute",
+                top: 0,
+                left: 0,
+                width: displayWidth,
+                height: imgH,
+                overflow: "visible",
+                pointerEvents: "none",
+              }}
+              viewBox={`0 0 ${displayWidth} ${imgH}`}
+            >
+              {layout.map((a) => {
+                const color = SEVERITY_COLOR[a.finding.severity] ?? "#ef4444";
+                const points = `${a.pinX},${a.pinY} ${a.pinX},${a.elbowY} ${a.exitX},${a.textY}`;
+                return (
+                  <g key={a.id}>
+                    {/* Pin dot */}
+                    <circle cx={a.pinX} cy={a.pinY} r={5} fill={color} opacity={0.9} />
+                    <circle cx={a.pinX} cy={a.pinY} r={3} fill={color} />
+                    {/* Vertical stem + 45° diagonal */}
+                    <polyline
+                      points={points}
+                      stroke={color}
+                      strokeWidth={1}
+                      fill="none"
+                      opacity={0.7}
+                    />
+                    {/* Short horizontal tick at text end */}
+                    <line
+                      x1={a.exitX}
+                      y1={a.textY}
+                      x2={a.side === "left" ? a.exitX - 12 : a.exitX + 12}
+                      y2={a.textY}
+                      stroke={color}
+                      strokeWidth={1}
+                      opacity={0.7}
+                    />
+                  </g>
+                );
+              })}
+            </svg>
+          )}
+        </div>
+
+        {/* Right margin */}
+        <div style={{ width: MARGIN_W, flexShrink: 0, position: "relative", height: imgH ?? "auto" }}>
+          {layout
+            .filter((a) => a.side === "right")
+            .map((a) => (
+              <AnnotationTextBlock
+                key={a.id}
+                annotation={a}
+                side="right"
+                onEdit={onFindingEdit}
+                readOnly={readOnly}
+              />
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AnnotationTextBlock({
+  annotation: a,
+  side,
+  onEdit,
+  readOnly,
+}: {
+  annotation: AnnotationLayout;
+  side: "left" | "right";
+  onEdit?: (id: string, field: "humanNote" | "fix" | "issue", value: string) => void;
+  readOnly?: boolean;
+}) {
+  const color = SEVERITY_COLOR[a.finding.severity] ?? "#ef4444";
+  const offset = a.textY - 10;
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: offset,
+        ...(side === "left"
+          ? { right: 16, textAlign: "right" }
+          : { left: 16, textAlign: "left" }),
+        width: MARGIN_W - 28,
+      }}
+    >
+      <div
+        style={{ color, fontSize: 10, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.08em", marginBottom: 2 }}
+      >
+        {a.finding.title}
+      </div>
+      {readOnly ? (
+        <>
+          <p style={{ fontSize: 11, color: "#aaa", margin: "2px 0", lineHeight: 1.4 }}>
+            {a.finding.issue}
+          </p>
+          <p style={{ fontSize: 11, color: "#666", margin: "2px 0", lineHeight: 1.4 }}>
+            → {a.finding.fix}
+          </p>
+          {a.finding.humanNote && (
+            <p style={{ fontSize: 11, color: "#6AC89B", margin: "4px 0 0", lineHeight: 1.4 }}>
+              {a.finding.humanNote}
+            </p>
+          )}
+        </>
+      ) : (
+        <div className="space-y-1">
+          <textarea
+            value={a.finding.issue}
+            onChange={(e) => onEdit?.(a.id, "issue", e.target.value)}
+            rows={2}
+            style={{ fontSize: 11, width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #333", color: "#aaa", resize: "vertical", outline: "none", padding: "2px 0", lineHeight: 1.4 }}
+          />
+          <textarea
+            value={a.finding.fix}
+            onChange={(e) => onEdit?.(a.id, "fix", e.target.value)}
+            rows={2}
+            style={{ fontSize: 11, width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #333", color: "#666", resize: "vertical", outline: "none", padding: "2px 0", lineHeight: 1.4 }}
+            placeholder="Fix direction…"
+          />
+          <textarea
+            value={a.finding.humanNote}
+            onChange={(e) => onEdit?.(a.id, "humanNote", e.target.value)}
+            rows={1}
+            style={{ fontSize: 11, width: "100%", background: "transparent", border: "none", borderBottom: "1px solid #333", color: "#6AC89B", resize: "vertical", outline: "none", padding: "2px 0", lineHeight: 1.4 }}
+            placeholder="Add note…"
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/annotation-analysis.ts
+++ b/src/lib/annotation-analysis.ts
@@ -1,0 +1,139 @@
+/**
+ * Annotation analysis — PROTECTED IP.
+ *
+ * Generates Ladder-scored findings with precise screen coordinates for
+ * the Drawbackwards evaluation report tool. Separate from the main
+ * scoring engine so the report pipeline can iterate independently.
+ *
+ * MUST stay server-side. Never import from client components.
+ * Never log prompt text or echo findings in error messages.
+ */
+import Anthropic from "@anthropic-ai/sdk";
+import type { MediaType } from "./scoring";
+
+export type AnnotationResult = {
+  screenName: string;
+  score: number;
+  label: string;
+  summary: string;
+  findings: Array<{
+    id: string;
+    title: string;
+    issue: string;
+    fix: string;
+    severity: "high" | "medium" | "low";
+    xPercent: number;
+    yPercent: number;
+    category: string;
+  }>;
+};
+
+const SAMPLE_FINDING_COUNT = "3 to 5";
+const AUDIT_FINDING_COUNT = "4 to 8";
+
+function buildAnalysisPrompt(mode: "sample" | "audit"): string {
+  const count = mode === "sample" ? SAMPLE_FINDING_COUNT : AUDIT_FINDING_COUNT;
+  return `You are a principal product designer with 20 years of experience at companies like Apple, Airbnb, and Stripe. You are conducting a Drawbackwards design audit.
+
+Evaluate this UI screen and identify the ${count} most important UX issues. For each finding, pinpoint the exact location of the problem on screen using x/y percentages (0.0 = left/top edge, 1.0 = right/bottom edge). Point to the specific UI element causing the issue — a button, text field, icon, heading — not a general region.
+
+Score against the Ladder framework:
+- Functional (1.0–1.99): User fights the product
+- Usable (2.0–2.99): Tasks complete with effort
+- Comfortable (3.0–3.99): No thinking required
+- Delightful (4.0–4.99): Anticipates needs
+- Meaningful (5.0): Irreplaceable
+
+Return ONLY valid JSON, no markdown:
+{
+  "screenName": "Product — Screen Type",
+  "score": 2.4,
+  "label": "Usable",
+  "summary": "One honest sentence describing the user experience from the user's perspective",
+  "findings": [
+    {
+      "id": "f1",
+      "title": "Short title, max 5 words",
+      "issue": "The specific problem this creates for the user",
+      "fix": "Concrete, actionable fix with specific guidance",
+      "severity": "high",
+      "xPercent": 0.45,
+      "yPercent": 0.23,
+      "category": "hierarchy"
+    }
+  ]
+}
+
+Rules:
+- xPercent and yPercent point to the CENTER of the problematic element
+- severity: high = blocks task or causes abandonment, medium = causes confusion or extra steps, low = polish opportunity
+- category must be one of: hierarchy, spacing, copy, a11y, navigation, visual, interaction, feedback
+- Order findings by severity (high first), then by uplift potential
+- screenName format: "Product Name — Screen Type" using an em dash
+- Be direct and specific — vague findings are worthless`;
+}
+
+const client = new Anthropic();
+
+export async function analyzeScreenForReport(
+  { mediaType, base64Data }: { mediaType: MediaType; base64Data: string },
+  mode: "sample" | "audit" = "sample",
+): Promise<AnnotationResult | { error: string }> {
+  if (base64Data.length > 7_000_000) {
+    return { error: "Image too large. Please use an image under 5MB." };
+  }
+
+  try {
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-20250514",
+      max_tokens: 3000,
+      system: buildAnalysisPrompt(mode),
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: mediaType, data: base64Data },
+            },
+            {
+              type: "text",
+              text: "Analyze this screen. Be honest and specific.",
+            },
+          ],
+        },
+      ],
+    });
+
+    const textBlock = response.content.find((b) => b.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      return { error: "No response from analysis engine" };
+    }
+
+    const clean = textBlock.text.replace(/```json|```/g, "").trim();
+    let result: AnnotationResult;
+    try {
+      result = JSON.parse(clean);
+    } catch {
+      return { error: "Failed to parse analysis response" };
+    }
+
+    if (!result.screenName || typeof result.score !== "number" || !Array.isArray(result.findings)) {
+      return { error: "Invalid analysis response shape" };
+    }
+
+    // Clamp coordinates to valid range and ensure IDs
+    result.findings = result.findings.map((f, i) => ({
+      ...f,
+      id: f.id || `f${i + 1}`,
+      xPercent: Math.max(0, Math.min(1, f.xPercent ?? 0.5)),
+      yPercent: Math.max(0, Math.min(1, f.yPercent ?? 0.5)),
+    }));
+
+    return result;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Unknown error";
+    console.error("[ANNOTATION:ERROR]", msg);
+    return { error: "Analysis failed" };
+  }
+}

--- a/src/lib/evaluation.ts
+++ b/src/lib/evaluation.ts
@@ -1,0 +1,116 @@
+import { redis } from "./redis";
+
+export type EvaluationMode = "sample" | "audit";
+export type EvaluationStatus = "draft" | "analyzing" | "review" | "approved";
+
+export type AnnotationFinding = {
+  id: string;
+  title: string;
+  issue: string;
+  fix: string;
+  severity: "high" | "medium" | "low";
+  xPercent: number;
+  yPercent: number;
+  category: string;
+  humanNote: string;
+};
+
+export type EvaluationScreen = {
+  id: string;
+  imageData: string;
+  screenName: string;
+  score: number | null;
+  label: string | null;
+  summary: string | null;
+  findings: AnnotationFinding[];
+  analyzedAt: string | null;
+};
+
+export type Evaluation = {
+  id: string;
+  clientName: string;
+  projectName: string;
+  mode: EvaluationMode;
+  status: EvaluationStatus;
+  screens: EvaluationScreen[];
+  overallScore: number | null;
+  executiveSummary: string;
+  nextSteps: string;
+  humanNotes: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const evalKey = (id: string) => `admin:evaluation:${id}`;
+const EVAL_INDEX = "admin:evaluations";
+
+export async function listEvaluations(): Promise<Evaluation[]> {
+  const ids = await redis.lrange(EVAL_INDEX, 0, -1);
+  if (!ids.length) return [];
+  const items = await Promise.all(ids.map((id) => redis.get<Evaluation>(evalKey(id))));
+  return items
+    .filter((e): e is Evaluation => e !== null)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+}
+
+export async function getEvaluation(id: string): Promise<Evaluation | null> {
+  return redis.get<Evaluation>(evalKey(id));
+}
+
+export async function createEvaluation(data: {
+  clientName: string;
+  projectName: string;
+  mode: EvaluationMode;
+  screens: Array<{ imageData: string }>;
+}): Promise<Evaluation> {
+  const id = crypto.randomUUID();
+  const now = new Date().toISOString();
+  const evaluation: Evaluation = {
+    id,
+    clientName: data.clientName,
+    projectName: data.projectName,
+    mode: data.mode,
+    status: "draft",
+    screens: data.screens.map((s, i) => ({
+      id: `screen-${i}`,
+      imageData: s.imageData,
+      screenName: "",
+      score: null,
+      label: null,
+      summary: null,
+      findings: [],
+      analyzedAt: null,
+    })),
+    overallScore: null,
+    executiveSummary: "",
+    nextSteps: "",
+    humanNotes: "",
+    createdAt: now,
+    updatedAt: now,
+  };
+  await redis.set(evalKey(id), evaluation);
+  await redis.lpush(EVAL_INDEX, id);
+  return evaluation;
+}
+
+export async function updateEvaluation(
+  id: string,
+  patch: Partial<Omit<Evaluation, "id" | "createdAt">>,
+): Promise<Evaluation | null> {
+  const existing = await getEvaluation(id);
+  if (!existing) return null;
+  const updated: Evaluation = {
+    ...existing,
+    ...patch,
+    id,
+    createdAt: existing.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+  await redis.set(evalKey(id), updated);
+  return updated;
+}
+
+export async function deleteEvaluation(id: string): Promise<void> {
+  await redis.del(evalKey(id));
+  await redis.lrem(EVAL_INDEX, 0, id);
+}


### PR DESCRIPTION
## Summary

- Adds the full Drawbackwards client evaluation workflow to `admin.runladder.com`
- Two output modes: **Sample report** (free post-call deliverable + pitch) and **Full audit** (paid $5–15K deliverable)
- Annotation system: Claude Vision analyzes screens and returns x/y coordinates for each finding; rendered as pin dots → vertical stem → 45° leader lines into left/right margins
- Human review layer for editing findings, adding notes, exec summary, and pitch copy
- Print-optimized report page — Cmd+P exports to branded PDF

## Routes added

- `GET/POST /api/admin/evaluations` — list + create
- `GET/PATCH/DELETE /api/admin/evaluations/[id]` — single evaluation
- `POST /api/admin/evaluations/[id]/analyze` — trigger Claude analysis
- `/admin/evaluations` — evaluation list
- `/admin/evaluations/new` — upload screens + create
- `/admin/evaluations/[id]` — review workspace with annotated screen editor
- `/admin/evaluations/[id]/report` — print-ready branded report

## Test plan

- [ ] Sign in as admin, click Evaluations button on `/admin`
- [ ] Create a new evaluation with one or more screenshots
- [ ] Run analysis and confirm annotations appear with leader lines
- [ ] Edit findings, add human notes, write exec summary and next steps
- [ ] Open report page, verify layout, print to PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)