### PR TITLE
Admin: learning loop for evaluation annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ next-env.d.ts
 
 # local data
 .data/
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/src/app/admin/evaluations/[id]/page.tsx
+++ b/src/app/admin/evaluations/[id]/page.tsx
@@ -146,6 +146,29 @@ export default function EvaluationReviewPage() {
     [],
   );
 
+  const updatePinPosition = useCallback(
+    (screenId: string, findingId: string, xPct: number, yPct: number) => {
+      setEvaluation((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          screens: prev.screens.map((s) =>
+            s.id !== screenId
+              ? s
+              : {
+                  ...s,
+                  findings: s.findings.map((f) =>
+                    f.id !== findingId ? f : { ...f, xPercent: xPct, yPercent: yPct },
+                  ),
+                },
+          ),
+        };
+      });
+      setDirty(true);
+    },
+    [],
+  );
+
   const updateScreen = useCallback((screenId: string, field: keyof EvaluationScreen, value: string) => {
     setEvaluation((prev) => {
       if (!prev) return prev;
@@ -341,6 +364,9 @@ export default function EvaluationReviewPage() {
                   displayWidth={620}
                   onFindingEdit={(findingId, field, value) =>
                     updateFinding(activeScreen.id, findingId, field, value)
+                  }
+                  onPinMove={(findingId, xPct, yPct) =>
+                    updatePinPosition(activeScreen.id, findingId, xPct, yPct)
                   }
                 />
               </div>

--- a/src/app/admin/evaluations/[id]/page.tsx
+++ b/src/app/admin/evaluations/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
@@ -27,6 +27,8 @@ export default function EvaluationReviewPage() {
   const [saving, setSaving] = useState(false);
   const [activeScreenIdx, setActiveScreenIdx] = useState(0);
   const [dirty, setDirty] = useState(false);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
+  const autoSaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   async function load() {
     setLoading(true);
@@ -71,32 +73,48 @@ export default function EvaluationReviewPage() {
     }
   }
 
-  async function save() {
-    if (!evaluation) return;
+  async function doSave(ev: typeof evaluation, silent = false) {
+    if (!ev) return;
     setSaving(true);
-    setError(null);
+    if (!silent) setError(null);
     try {
       const res = await fetch(`/api/admin/evaluations/${params.id}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          screens: evaluation.screens,
-          executiveSummary: evaluation.executiveSummary,
-          nextSteps: evaluation.nextSteps,
-          humanNotes: evaluation.humanNotes,
-          status: evaluation.status === "review" ? "review" : evaluation.status,
+          screens: ev.screens,
+          auditorName: ev.auditorName,
+          executiveSummary: ev.executiveSummary,
+          nextSteps: ev.nextSteps,
+          humanNotes: ev.humanNotes,
+          status: ev.status,
         }),
       });
       const j = await res.json();
       if (!res.ok) throw new Error(j.error || "Save failed");
       setEvaluation(j.evaluation);
       setDirty(false);
+      setLastSavedAt(new Date());
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Save failed");
+      if (!silent) setError(e instanceof Error ? e.message : "Save failed");
     } finally {
       setSaving(false);
     }
   }
+
+  function save() {
+    return doSave(evaluation);
+  }
+
+  // Auto-save 3s after the last change
+  useEffect(() => {
+    if (!dirty || !evaluation) return;
+    if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
+    autoSaveTimer.current = setTimeout(() => doSave(evaluation, true), 3000);
+    return () => {
+      if (autoSaveTimer.current) clearTimeout(autoSaveTimer.current);
+    };
+  }, [dirty, evaluation]); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function approve() {
     if (!evaluation) return;
@@ -222,7 +240,7 @@ export default function EvaluationReviewPage() {
               <span className="text-muted mx-2">—</span>
               {evaluation.projectName}
             </h1>
-            <div className="flex items-center gap-4 mt-1">
+            <div className="flex items-center gap-4 mt-1 flex-wrap">
               {evaluation.overallScore !== null && (
                 <span className={`text-2xl font-semibold tabular-nums ${SCORE_COLOR(evaluation.overallScore)}`}>
                   {evaluation.overallScore.toFixed(1)}
@@ -234,6 +252,27 @@ export default function EvaluationReviewPage() {
               <span className="text-[10px] uppercase tracking-widest text-muted">
                 {evaluation.status}
               </span>
+              {saving && (
+                <span className="text-[10px] text-muted font-sans">Saving…</span>
+              )}
+              {!saving && lastSavedAt && (
+                <span className="text-[10px] text-muted font-sans">
+                  Saved {lastSavedAt.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2 mt-2">
+              <span className="text-[10px] uppercase tracking-widest text-muted font-sans">Auditor:</span>
+              <input
+                type="text"
+                value={evaluation.auditorName ?? ""}
+                onChange={(e) => {
+                  setEvaluation((prev) => prev ? { ...prev, auditorName: e.target.value } : prev);
+                  setDirty(true);
+                }}
+                placeholder="Your name"
+                className="bg-transparent border-b border-[#333] text-xs text-muted px-0 py-0.5 focus:outline-none focus:border-muted placeholder:text-[#444] font-sans w-40"
+              />
             </div>
           </div>
 

--- a/src/app/admin/evaluations/[id]/report/page.tsx
+++ b/src/app/admin/evaluations/[id]/report/page.tsx
@@ -157,7 +157,9 @@ export default function ReportPage() {
 
           {/* Drawbackwards credit */}
           <div style={{ marginTop: 24, fontSize: 10, color: "#444", letterSpacing: "0.08em", textTransform: "uppercase" }}>
-            Prepared by Drawbackwards · runladder.com
+            {evaluation.auditorName
+              ? `Prepared by ${evaluation.auditorName} · Drawbackwards · runladder.com`
+              : "Prepared by Drawbackwards · runladder.com"}
           </div>
         </div>
 

--- a/src/app/admin/evaluations/new/page.tsx
+++ b/src/app/admin/evaluations/new/page.tsx
@@ -26,6 +26,7 @@ export default function NewEvaluationPage() {
 
   const [clientName, setClientName] = useState("");
   const [projectName, setProjectName] = useState("");
+  const [auditorName, setAuditorName] = useState("");
   const [mode, setMode] = useState<"sample" | "audit">("sample");
   const [images, setImages] = useState<UploadedImage[]>([]);
   const [submitting, setSubmitting] = useState(false);
@@ -68,6 +69,7 @@ export default function NewEvaluationPage() {
         body: JSON.stringify({
           clientName: clientName.trim(),
           projectName: projectName.trim(),
+          auditorName: auditorName.trim(),
           mode,
           images: images.map((img) => img.dataUrl),
         }),
@@ -106,7 +108,7 @@ export default function NewEvaluationPage() {
         )}
 
         <form onSubmit={submit} className="space-y-6">
-          {/* Client + project */}
+          {/* Client + project + auditor */}
           <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-[10px] uppercase tracking-widest text-muted mb-1.5">
@@ -129,6 +131,18 @@ export default function NewEvaluationPage() {
                 value={projectName}
                 onChange={(e) => setProjectName(e.target.value)}
                 placeholder="Onboarding flow"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1.5">
+                Human auditor
+              </label>
+              <input
+                type="text"
+                value={auditorName}
+                onChange={(e) => setAuditorName(e.target.value)}
+                placeholder="Your name"
                 className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
               />
             </div>

--- a/src/app/api/admin/evaluations/[id]/route.ts
+++ b/src/app/api/admin/evaluations/[id]/route.ts
@@ -1,7 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getAdminEmail } from "@/lib/admin";
 import { getEvaluation, updateEvaluation, deleteEvaluation } from "@/lib/evaluation";
-import type { Evaluation } from "@/lib/evaluation";
+import type { Evaluation, EvaluationScreen } from "@/lib/evaluation";
+import { appendLearningEvents } from "@/lib/evaluation-learning";
+import type { LearningEvent } from "@/lib/evaluation-learning";
 
 export async function GET(
   _req: NextRequest,
@@ -32,7 +34,70 @@ export async function PATCH(
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const updated = await updateEvaluation(id, body);
+  // Diff findings before saving to capture learning signals
+  const existing = await getEvaluation(id);
+  if (!existing) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+  const learningEvents: LearningEvent[] = [];
+  const now = Date.now();
+
+  if (body.screens) {
+    for (const incoming of body.screens as EvaluationScreen[]) {
+      const prior = existing.screens.find((s) => s.id === incoming.id);
+      if (!prior) continue;
+
+      for (const incomingFinding of incoming.findings) {
+        const priorFinding = prior.findings.find((f) => f.id === incomingFinding.id);
+        if (!priorFinding) continue;
+
+        // Pin position correction
+        const dX = Math.abs(incomingFinding.xPercent - priorFinding.xPercent);
+        const dY = Math.abs(incomingFinding.yPercent - priorFinding.yPercent);
+        if (dX > 0.005 || dY > 0.005) {
+          learningEvents.push({
+            type: "pin_moved",
+            ts: now,
+            evaluationId: id,
+            screenId: incoming.id,
+            findingId: incomingFinding.id,
+            title: incomingFinding.title,
+            category: incomingFinding.category,
+            severity: incomingFinding.severity,
+            origX: priorFinding.xPercent,
+            origY: priorFinding.yPercent,
+            corrX: incomingFinding.xPercent,
+            corrY: incomingFinding.yPercent,
+          });
+        }
+
+        // Text field edits
+        for (const field of ["issue", "fix"] as const) {
+          const before = priorFinding[field] ?? "";
+          const after = incomingFinding[field] ?? "";
+          if (after !== before && after.length >= 15) {
+            learningEvents.push({
+              type: "insight_edited",
+              ts: now,
+              evaluationId: id,
+              screenId: incoming.id,
+              findingId: incomingFinding.id,
+              title: incomingFinding.title,
+              category: incomingFinding.category,
+              severity: incomingFinding.severity,
+              field,
+              before,
+              after,
+            });
+          }
+        }
+      }
+    }
+  }
+
+  const [updated] = await Promise.all([
+    updateEvaluation(id, body),
+    learningEvents.length ? appendLearningEvents(learningEvents) : Promise.resolve(),
+  ]);
   if (!updated) return NextResponse.json({ error: "Not found" }, { status: 404 });
 
   return NextResponse.json({ evaluation: updated });

--- a/src/app/api/admin/evaluations/route.ts
+++ b/src/app/api/admin/evaluations/route.ts
@@ -19,6 +19,7 @@ export async function POST(req: NextRequest) {
   let body: {
     clientName?: string;
     projectName?: string;
+    auditorName?: string;
     mode?: EvaluationMode;
     images?: string[];
   } = {};
@@ -50,6 +51,7 @@ export async function POST(req: NextRequest) {
   const evaluation = await createEvaluation({
     clientName: body.clientName.trim(),
     projectName: body.projectName.trim(),
+    auditorName: body.auditorName?.trim(),
     mode: body.mode,
     screens,
   });

--- a/src/components/admin/AnnotatedScreen.tsx
+++ b/src/components/admin/AnnotatedScreen.tsx
@@ -8,6 +8,7 @@ type Props = {
   findings: AnnotationFinding[];
   displayWidth?: number;
   onFindingEdit?: (id: string, field: "humanNote" | "fix" | "issue", value: string) => void;
+  onPinMove?: (id: string, xPct: number, yPct: number) => void;
   readOnly?: boolean;
 };
 
@@ -89,6 +90,7 @@ export function AnnotatedScreen({
   findings,
   displayWidth = 620,
   onFindingEdit,
+  onPinMove,
   readOnly = false,
 }: Props) {
   const imgRef = useRef<HTMLImageElement>(null);
@@ -102,7 +104,13 @@ export function AnnotatedScreen({
   // Per-finding text-block Y overrides (dragging the label)
   const [textYOverrides, setTextYOverrides] = useState<Record<string, number>>({});
 
-  const pinDragging = useRef<{ id: string } | null>(null);
+  const pinDragging = useRef<{
+    id: string;
+    startXPct: number;
+    startYPct: number;
+    currentXPct: number;
+    currentYPct: number;
+  } | null>(null);
   const textDragging = useRef<{ id: string; startMouseY: number; startTextY: number } | null>(null);
 
   // Reset all manual positions when findings are replaced by a new analysis run
@@ -132,6 +140,8 @@ export function AnnotatedScreen({
         const rect = svgRef.current.getBoundingClientRect();
         const xPct = Math.max(0.02, Math.min(0.98, (e.clientX - rect.left) / rect.width));
         const yPct = Math.max(0.02, Math.min(0.98, (e.clientY - rect.top) / rect.height));
+        pinDragging.current.currentXPct = xPct;
+        pinDragging.current.currentYPct = yPct;
         setPinOverrides((prev) => ({ ...prev, [pinDragging.current!.id]: { xPct, yPct } }));
       }
       if (textDragging.current) {
@@ -143,6 +153,13 @@ export function AnnotatedScreen({
       }
     }
     function onUp() {
+      if (pinDragging.current && onPinMove) {
+        const { id, startXPct, startYPct, currentXPct, currentYPct } = pinDragging.current;
+        const moved =
+          Math.abs(currentXPct - startXPct) > 0.005 ||
+          Math.abs(currentYPct - startYPct) > 0.005;
+        if (moved) onPinMove(id, currentXPct, currentYPct);
+      }
       pinDragging.current = null;
       textDragging.current = null;
     }
@@ -152,18 +169,20 @@ export function AnnotatedScreen({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [imgH]);
+  }, [imgH, onPinMove]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function startPinDrag(id: string, e: React.MouseEvent) {
     e.preventDefault();
     e.stopPropagation();
-    // Lock the side at drag start so label doesn't jump margins
     const current = findings.find((f) => f.id === id);
-    if (current && !sideOverrides[id]) {
-      const xPct = pinOverrides[id]?.xPct ?? current.xPercent;
+    if (!current) return;
+    const xPct = pinOverrides[id]?.xPct ?? current.xPercent;
+    const yPct = pinOverrides[id]?.yPct ?? current.yPercent;
+    // Lock the side at drag start so label doesn't jump margins
+    if (!sideOverrides[id]) {
       setSideOverrides((prev) => ({ ...prev, [id]: xPct < 0.5 ? "left" : "right" }));
     }
-    pinDragging.current = { id };
+    pinDragging.current = { id, startXPct: xPct, startYPct: yPct, currentXPct: xPct, currentYPct: yPct };
   }
 
   function startTextDrag(id: string, currentTextY: number, e: React.MouseEvent) {

--- a/src/components/admin/AnnotatedScreen.tsx
+++ b/src/components/admin/AnnotatedScreen.tsx
@@ -112,6 +112,10 @@ export function AnnotatedScreen({
     currentYPct: number;
   } | null>(null);
   const textDragging = useRef<{ id: string; startMouseY: number; startTextY: number } | null>(null);
+  // Keep onPinMove in a ref so the effect closure always calls the latest version
+  // without needing it as a dep (avoids re-registering listeners on every parent render)
+  const onPinMoveRef = useRef(onPinMove);
+  useEffect(() => { onPinMoveRef.current = onPinMove; });
 
   // Reset all manual positions when findings are replaced by a new analysis run
   const findingsKey = findings.map((f) => f.id).join(",");
@@ -153,12 +157,12 @@ export function AnnotatedScreen({
       }
     }
     function onUp() {
-      if (pinDragging.current && onPinMove) {
+      if (pinDragging.current) {
         const { id, startXPct, startYPct, currentXPct, currentYPct } = pinDragging.current;
         const moved =
           Math.abs(currentXPct - startXPct) > 0.005 ||
           Math.abs(currentYPct - startYPct) > 0.005;
-        if (moved) onPinMove(id, currentXPct, currentYPct);
+        if (moved) onPinMoveRef.current?.(id, currentXPct, currentYPct);
       }
       pinDragging.current = null;
       textDragging.current = null;
@@ -169,7 +173,7 @@ export function AnnotatedScreen({
       window.removeEventListener("mousemove", onMove);
       window.removeEventListener("mouseup", onUp);
     };
-  }, [imgH, onPinMove]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [imgH]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function startPinDrag(id: string, e: React.MouseEvent) {
     e.preventDefault();

--- a/src/lib/annotation-analysis.ts
+++ b/src/lib/annotation-analysis.ts
@@ -10,6 +10,8 @@
  */
 import Anthropic from "@anthropic-ai/sdk";
 import type { MediaType } from "./scoring";
+import { getLearningContext } from "./evaluation-learning";
+import type { LearningContext } from "./evaluation-learning";
 
 export type AnnotationResult = {
   screenName: string;
@@ -31,8 +33,31 @@ export type AnnotationResult = {
 const SAMPLE_FINDING_COUNT = "3 to 5";
 const AUDIT_FINDING_COUNT = "4 to 8";
 
-function buildAnalysisPrompt(mode: "sample" | "audit"): string {
+function buildAnalysisPrompt(mode: "sample" | "audit", ctx?: LearningContext): string {
   const count = mode === "sample" ? SAMPLE_FINDING_COUNT : AUDIT_FINDING_COUNT;
+
+  let calibrationSection = "";
+  if (ctx && ctx.pinCalibration.length > 0) {
+    const hints = ctx.pinCalibration
+      .map(
+        (c) =>
+          `  - ${c.category}: shift x by ${c.avgDeltaX > 0 ? "+" : ""}${c.avgDeltaX.toFixed(3)}, y by ${c.avgDeltaY > 0 ? "+" : ""}${c.avgDeltaY.toFixed(3)} (from ${c.count} corrections)`,
+      )
+      .join("\n");
+    calibrationSection = `\n\nCoordinate calibration (apply these learned offsets to xPercent/yPercent for these categories):\n${hints}`;
+  }
+
+  let exemplarsSection = "";
+  if (ctx && ctx.exemplaryFindings.length > 0) {
+    const examples = ctx.exemplaryFindings
+      .map(
+        (f) =>
+          `  - [${f.category}/${f.severity}] "${f.title}"\n    issue: "${f.issue}"${f.fix ? `\n    fix: "${f.fix}"` : ""}`,
+      )
+      .join("\n");
+    exemplarsSection = `\n\nHuman-validated finding examples (match this quality of specificity and directness):\n${examples}`;
+  }
+
   return `You are a principal product designer with 20 years of experience at companies like Apple, Airbnb, and Stripe. You are conducting a Drawbackwards design audit.
 
 Evaluate this UI screen and identify the ${count} most important UX issues. For each finding, pinpoint the exact location of the problem on screen using x/y percentages (0.0 = left/top edge, 1.0 = right/bottom edge). Point to the specific UI element causing the issue — a button, text field, icon, heading — not a general region.
@@ -70,7 +95,7 @@ Rules:
 - category must be one of: hierarchy, spacing, copy, a11y, navigation, visual, interaction, feedback
 - Order findings by severity (high first), then by uplift potential
 - screenName format: "Product Name — Screen Type" using an em dash
-- Be direct and specific — vague findings are worthless`;
+- Be direct and specific — vague findings are worthless${calibrationSection}${exemplarsSection}`;
 }
 
 const client = new Anthropic();
@@ -83,11 +108,19 @@ export async function analyzeScreenForReport(
     return { error: "Image too large. Please use an image under 5MB." };
   }
 
+  // Load accumulated human corrections to calibrate coordinate estimates and set quality bar
+  let learningCtx: LearningContext | undefined;
+  try {
+    learningCtx = await getLearningContext();
+  } catch {
+    // Non-fatal — proceed with base prompt if learning context unavailable
+  }
+
   try {
     const response = await client.messages.create({
       model: "claude-sonnet-4-20250514",
       max_tokens: 3000,
-      system: buildAnalysisPrompt(mode),
+      system: buildAnalysisPrompt(mode, learningCtx),
       messages: [
         {
           role: "user",

--- a/src/lib/evaluation-learning.ts
+++ b/src/lib/evaluation-learning.ts
@@ -1,0 +1,163 @@
+/**
+ * Evaluation learning system — PROTECTED IP.
+ *
+ * Captures human corrections to AI-generated annotations and builds
+ * calibration data that feeds back into future analysis prompts.
+ *
+ * Three signal types:
+ *   pin_moved       — human corrected where an annotation pin points
+ *   insight_edited  — human rewrote the issue description or fix direction
+ *
+ * MUST stay server-side. Never import from client components.
+ */
+import { redis } from "./redis";
+
+const EVENTS_KEY = "admin:learning:events";
+const MAX_EVENTS = 2000;
+
+export type PinMovedEvent = {
+  type: "pin_moved";
+  ts: number;
+  evaluationId: string;
+  screenId: string;
+  findingId: string;
+  title: string;
+  category: string;
+  severity: string;
+  origX: number;
+  origY: number;
+  corrX: number;
+  corrY: number;
+};
+
+export type InsightEditedEvent = {
+  type: "insight_edited";
+  ts: number;
+  evaluationId: string;
+  screenId: string;
+  findingId: string;
+  title: string;
+  category: string;
+  severity: string;
+  field: "issue" | "fix";
+  before: string;
+  after: string;
+};
+
+export type LearningEvent = PinMovedEvent | InsightEditedEvent;
+
+export type PinCalibration = {
+  category: string;
+  count: number;
+  avgDeltaX: number;
+  avgDeltaY: number;
+};
+
+export type ExemplaryFinding = {
+  category: string;
+  severity: string;
+  title: string;
+  issue: string;
+  fix: string;
+};
+
+export type LearningContext = {
+  pinCalibration: PinCalibration[];
+  exemplaryFindings: ExemplaryFinding[];
+  totalEvents: number;
+};
+
+export async function appendLearningEvent(event: LearningEvent): Promise<void> {
+  await redis.lpush(EVENTS_KEY, JSON.stringify(event));
+  await redis.ltrim(EVENTS_KEY, 0, MAX_EVENTS - 1);
+}
+
+export async function appendLearningEvents(events: LearningEvent[]): Promise<void> {
+  if (!events.length) return;
+  for (const event of events) {
+    await redis.lpush(EVENTS_KEY, JSON.stringify(event));
+  }
+  await redis.ltrim(EVENTS_KEY, 0, MAX_EVENTS - 1);
+}
+
+export async function getLearningEvents(limit = 500): Promise<LearningEvent[]> {
+  const raw = await redis.lrange<string>(EVENTS_KEY, 0, limit - 1);
+  return raw
+    .map((r) => {
+      try {
+        const parsed = typeof r === "string" ? JSON.parse(r) : r;
+        return parsed as LearningEvent;
+      } catch {
+        return null;
+      }
+    })
+    .filter((e): e is LearningEvent => e !== null);
+}
+
+export async function getLearningContext(): Promise<LearningContext> {
+  const events = await getLearningEvents(500);
+
+  // Pin calibration: average correction delta per category
+  const pinByCategory: Record<string, { sumDX: number; sumDY: number; count: number }> = {};
+  for (const ev of events) {
+    if (ev.type !== "pin_moved") continue;
+    const c = ev.category || "other";
+    if (!pinByCategory[c]) pinByCategory[c] = { sumDX: 0, sumDY: 0, count: 0 };
+    pinByCategory[c].sumDX += ev.corrX - ev.origX;
+    pinByCategory[c].sumDY += ev.corrY - ev.origY;
+    pinByCategory[c].count++;
+  }
+  const pinCalibration: PinCalibration[] = Object.entries(pinByCategory)
+    .filter(([, v]) => v.count >= 3)
+    .map(([category, v]) => ({
+      category,
+      count: v.count,
+      avgDeltaX: Math.round((v.sumDX / v.count) * 1000) / 1000,
+      avgDeltaY: Math.round((v.sumDY / v.count) * 1000) / 1000,
+    }));
+
+  // Exemplary findings: group insight edits by finding, keep pairs where both issue+fix were refined
+  const findingMap: Record<
+    string,
+    { title: string; category: string; severity: string; issue?: string; fix?: string; ts: number }
+  > = {};
+  for (const ev of events) {
+    if (ev.type !== "insight_edited") continue;
+    if (ev.after.length < 20) continue;
+    const key = `${ev.evaluationId}:${ev.findingId}`;
+    if (!findingMap[key]) {
+      findingMap[key] = {
+        title: ev.title,
+        category: ev.category,
+        severity: ev.severity,
+        ts: ev.ts,
+      };
+    }
+    // Always take latest edit for each field
+    if (ev.ts >= findingMap[key].ts) {
+      findingMap[key].ts = ev.ts;
+    }
+    findingMap[key][ev.field] = ev.after;
+  }
+
+  // Prefer findings where both issue and fix were edited (highest quality signal)
+  const full = Object.values(findingMap).filter((f) => f.issue && f.fix);
+  const partial = Object.values(findingMap).filter((f) => f.issue || f.fix);
+  const pool = [...full, ...partial].slice(0, 6);
+
+  const exemplaryFindings: ExemplaryFinding[] = pool
+    .filter((f) => (f.issue || f.fix))
+    .map((f) => ({
+      category: f.category,
+      severity: f.severity,
+      title: f.title,
+      issue: f.issue ?? "",
+      fix: f.fix ?? "",
+    }));
+
+  return {
+    pinCalibration,
+    exemplaryFindings,
+    totalEvents: events.length,
+  };
+}

--- a/src/lib/evaluation.ts
+++ b/src/lib/evaluation.ts
@@ -34,6 +34,7 @@ export type Evaluation = {
   status: EvaluationStatus;
   screens: EvaluationScreen[];
   overallScore: number | null;
+  auditorName: string;
   executiveSummary: string;
   nextSteps: string;
   humanNotes: string;
@@ -61,6 +62,7 @@ export async function createEvaluation(data: {
   clientName: string;
   projectName: string;
   mode: EvaluationMode;
+  auditorName?: string;
   screens: Array<{ imageData: string }>;
 }): Promise<Evaluation> {
   const id = crypto.randomUUID();
@@ -82,6 +84,7 @@ export async function createEvaluation(data: {
       analyzedAt: null,
     })),
     overallScore: null,
+    auditorName: data.auditorName ?? "",
     executiveSummary: "",
     nextSteps: "",
     humanNotes: "",


### PR DESCRIPTION
## Summary
- **Pin calibration** — when an editor drags an annotation dot to a better spot, `AnnotatedScreen` fires `onPinMove` → review page updates `xPercent`/`yPercent` in state → PATCH handler diffs against the stored evaluation and emits `pin_moved` events to Redis
- **Insight quality signal** — when `issue` or `fix` text is edited and saved, PATCH diffs the text and emits `insight_edited` events
- **Feedback loop** — `analyzeScreenForReport` now loads the last 500 events at analysis time, computes per-category average coordinate offsets and surfaces human-validated finding examples, then injects both into the system prompt as calibration hints and few-shot exemplars

## New files
- `src/lib/evaluation-learning.ts` — `LearningEvent` types, Redis append/read (capped at 2000), `getLearningContext()` which computes calibration and exemplary findings

## Changed files
- `AnnotatedScreen.tsx` — added `onPinMove` prop, tracks start/end coords in drag ref, fires callback on mouseUp when pin actually moved
- `evaluations/[id]/page.tsx` — added `updatePinPosition` callback, wires `onPinMove` to `AnnotatedScreen`
- `evaluations/[id]/route.ts` — PATCH now diffs findings before saving, emits learning events in parallel with the update
- `annotation-analysis.ts` — loads `LearningContext` before each analysis run, passes to `buildAnalysisPrompt` which injects coordinate offsets and exemplar findings when available

## Test plan
- [ ] Open an analyzed evaluation, drag a pin to a new location, click Save — verify no errors
- [ ] Edit issue/fix text on a finding, Save — verify no errors
- [ ] Re-analyze — pin positions should trend closer to where the human moved them after enough corrections accumulate
- [ ] TypeScript: `tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)