### PR TITLE
Stripe billing: self-serve Pro at $250/mo + lifetime free tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,53 @@ To learn more about Next.js, take a look at the following resources:
 
 You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
 
+## Stripe billing
+
+Self-serve Pro at $250/mo. Free tier is 5 lifetime scans, enforced via Clerk
+publicMetadata.tier and a Redis lifetime counter.
+
+### Required env vars
+
+```
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRO_PRICE_ID=price_...
+NEXT_PUBLIC_APP_URL=http://localhost:3000   # https://runladder.com in prod
+```
+
+### One-time Stripe Dashboard setup
+
+1. Create a product **Ladder Pro** with a recurring monthly price of **$250 USD**.
+   Copy the `price_...` ID into `STRIPE_PRO_PRICE_ID`.
+2. **Customer Portal:** Settings → Billing → Customer portal — enable cancellation
+   and plan switching. Save.
+3. **Webhook (production):** Developers → Webhooks → Add endpoint
+   - URL: `https://runladder.com/api/stripe/webhooks`
+   - Events: `checkout.session.completed`, `customer.subscription.created`,
+     `customer.subscription.updated`, `customer.subscription.deleted`
+   - Copy the signing secret into `STRIPE_WEBHOOK_SECRET`.
+
+### Local webhook forwarding
+
+```bash
+brew install stripe/stripe-cli/stripe   # one time
+stripe login
+stripe listen --forward-to localhost:3000/api/stripe/webhooks
+# Copy the printed `whsec_...` into your local STRIPE_WEBHOOK_SECRET
+```
+
+### Routes
+
+- `POST /api/stripe/checkout` — start a Checkout session for the signed-in user
+- `POST /api/stripe/webhooks` — Stripe → Clerk publicMetadata.tier sync
+- `POST /api/stripe/portal` — open the Customer Portal
+
+### Tier enforcement
+
+`getUserTier(userId)` reads `publicMetadata.tier` from Clerk; `isPaidTier()`
+bypasses the free lifetime cap. Both `/api/score` and `/api/skill/score` share
+the same `user:{id}:lifetime_scans_used` counter.
+
 ## Deploy on Vercel
 
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runladder",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runladder",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.79.0",
         "@clerk/nextjs": "^7.0.8",
@@ -16,7 +16,8 @@
         "puppeteer-core": "^24.39.1",
         "react": "19.2.3",
         "react-dom": "19.2.3",
-        "sharp": "^0.34.5"
+        "sharp": "^0.34.5",
+        "stripe": "^22.1.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6914,6 +6915,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "22.1.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-22.1.0.tgz",
+      "integrity": "sha512-w/xHyJGxXWnLPbNHG13sz/fae0MrFGC80Oz7YbICQymbfpqfEcsoG+6yG+9BWb81PWc4rrkeSO4wmTcmefmbLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/styled-jsx": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "puppeteer-core": "^24.39.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
-    "sharp": "^0.34.5"
+    "sharp": "^0.34.5",
+    "stripe": "^22.1.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
-import { FREE_MONTHLY_LIMIT } from "@/lib/plans";
+import { redis, lifetimeScansKey } from "@/lib/redis";
+import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
+import { getUserTier } from "@/lib/tier";
 
 export async function GET() {
   const { userId } = await auth();
@@ -10,17 +11,12 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const monthKey = new Date().toISOString().slice(0, 7);
-  const countKey = `user:${userId}:usage:${monthKey}`;
-
-  const [scores, usage] = await Promise.all([
-    // Get all scores, newest first (reverse sorted set by timestamp)
+  const [scores, used, tier] = await Promise.all([
     redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true }),
-    // Get current month usage
-    redis.get<number>(countKey),
+    redis.get<number>(lifetimeScansKey(userId)),
+    getUserTier(userId),
   ]);
 
-  // Parse score entries (stored as JSON strings in sorted set)
   const parsedScores = (scores as string[]).map((entry) => {
     if (typeof entry === "string") {
       try {
@@ -34,10 +30,12 @@ export async function GET() {
 
   return NextResponse.json({
     scores: parsedScores,
+    tier,
+    paid: isPaidTier(tier),
     usage: {
-      used: usage ?? 0,
-      limit: FREE_MONTHLY_LIMIT,
-      month: monthKey,
+      used: used ?? 0,
+      limit: FREE_LIFETIME_LIMIT,
+      lifetime: true,
     },
   });
 }

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -1,13 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
+import { redis, lifetimeScansKey } from "@/lib/redis";
 import {
   parseImageDataUrl,
   scoreImage,
   isScoringError,
 } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
-import { FREE_MONTHLY_LIMIT, ANON_LIMIT } from "@/lib/plans";
+import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
+import { getUserTier } from "@/lib/tier";
 
 export const maxDuration = 60;
 
@@ -29,20 +30,21 @@ export async function POST(req: NextRequest) {
       req.headers.get("x-real-ip") ||
       "unknown";
 
-    /* ── Rate limiting via Redis ── */
-    const monthKey = new Date().toISOString().slice(0, 7); // "2026-04"
-
+    /* ── Rate limiting ── */
     if (userId) {
-      const countKey = `user:${userId}:usage:${monthKey}`;
-      const count = (await redis.get<number>(countKey)) ?? 0;
-      if (count >= FREE_MONTHLY_LIMIT) {
-        return NextResponse.json(
-          {
-            error: `Free tier limit reached (${FREE_MONTHLY_LIMIT} scores/month). Upgrade for unlimited scoring.`,
-            upgrade: true,
-          },
-          { status: 429 }
-        );
+      const tier = await getUserTier(userId);
+      if (!isPaidTier(tier)) {
+        const usedKey = lifetimeScansKey(userId);
+        const used = (await redis.get<number>(usedKey)) ?? 0;
+        if (used >= FREE_LIFETIME_LIMIT) {
+          return NextResponse.json(
+            {
+              error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for unlimited scoring.`,
+              upgrade: true,
+            },
+            { status: 429 }
+          );
+        }
       }
     } else {
       const anonKey = `rate:anon:${ip}`;
@@ -50,7 +52,7 @@ export async function POST(req: NextRequest) {
       if (count >= ANON_LIMIT) {
         return NextResponse.json(
           {
-            error: `Sign up for free to get ${FREE_MONTHLY_LIMIT} scores per month.`,
+            error: `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
             signup: true,
           },
           { status: 429 }
@@ -99,20 +101,15 @@ export async function POST(req: NextRequest) {
         timestamp: Date.now(),
       };
 
-      const countKey = `user:${userId}:usage:${monthKey}`;
-
-      await Promise.all([
+      const ops: Promise<unknown>[] = [
         redis.zadd(`user:${userId}:scores`, {
           score: Date.now(),
           member: JSON.stringify(scoreEntry),
         }),
-        redis.incr(countKey),
-      ]);
-
-      const ttl = await redis.ttl(countKey);
-      if (ttl < 0) {
-        await redis.expire(countKey, 60 * 60 * 24 * 35);
-      }
+      ];
+      // Always count lifetime scans — even on paid tiers, for analytics + audit.
+      ops.push(redis.incr(lifetimeScansKey(userId)));
+      await Promise.all(ops);
     } else {
       const anonKey = `rate:anon:${ip}`;
       await redis.incr(anonKey);

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { redis } from "@/lib/redis";
+import { redis, lifetimeScansKey } from "@/lib/redis";
 import {
   parseImageDataUrl,
   scoreImage,
@@ -7,14 +7,15 @@ import {
 } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
 import { userIdFromBearer, touchSkillToken } from "@/lib/skill-auth";
-import { FREE_MONTHLY_LIMIT } from "@/lib/plans";
+import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
+import { getUserTier } from "@/lib/tier";
 
 export const maxDuration = 60;
 
 /**
  * Skill scoring endpoint — called by the Ladder Claude Skill and other
  * token-authenticated thin clients. Shares the scoring engine and
- * monthly usage pool with /api/score.
+ * lifetime usage pool with /api/score.
  *
  * Response shape intentionally mirrors /api/score but strips anything
  * that could expose internal scoring logic.
@@ -41,18 +42,20 @@ export async function POST(req: NextRequest) {
     const installedVersion =
       req.headers.get("x-ladder-skill-version")?.slice(0, 32) || undefined;
 
-    /* ── Rate limiting (shared pool with /api/score) ── */
-    const monthKey = new Date().toISOString().slice(0, 7);
-    const countKey = `user:${userId}:usage:${monthKey}`;
-    const count = (await redis.get<number>(countKey)) ?? 0;
-    if (count >= FREE_MONTHLY_LIMIT) {
-      return NextResponse.json(
-        {
-          error: `Free tier limit reached (${FREE_MONTHLY_LIMIT} scores/month). Upgrade at https://runladder.com/pricing for unlimited scoring.`,
-          upgrade: true,
-        },
-        { status: 429 }
-      );
+    /* ── Rate limiting (shared lifetime pool with /api/score) ── */
+    const tier = await getUserTier(userId);
+    const usedKey = lifetimeScansKey(userId);
+    if (!isPaidTier(tier)) {
+      const used = (await redis.get<number>(usedKey)) ?? 0;
+      if (used >= FREE_LIFETIME_LIMIT) {
+        return NextResponse.json(
+          {
+            error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade at https://runladder.com/pricing for unlimited scoring.`,
+            upgrade: true,
+          },
+          { status: 429 }
+        );
+      }
     }
 
     const body = await req.json();
@@ -103,14 +106,9 @@ export async function POST(req: NextRequest) {
         score: Date.now(),
         member: JSON.stringify(scoreEntry),
       }),
-      redis.incr(countKey),
+      redis.incr(usedKey),
       touchSkillToken(userId, installedVersion),
     ]);
-
-    const ttl = await redis.ttl(countKey);
-    if (ttl < 0) {
-      await redis.expire(countKey, 60 * 60 * 24 * 35);
-    }
 
     return NextResponse.json({
       score: result.score,

--- a/src/app/api/stripe/checkout/route.ts
+++ b/src/app/api/stripe/checkout/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import {
+  stripe,
+  assertStripeConfigured,
+  STRIPE_PRO_PRICE_ID,
+} from "@/lib/stripe";
+import { getStripeCustomerId, setUserSubscription } from "@/lib/tier";
+
+/**
+ * POST /api/stripe/checkout
+ * Creates a Stripe Checkout session for the signed-in user and the requested plan.
+ * Body: { plan: "pro" } — only "pro" is self-serve today.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    assertStripeConfigured();
+
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const body = (await req.json().catch(() => ({}))) as { plan?: string };
+    const plan = body.plan ?? "pro";
+
+    if (plan !== "pro") {
+      return NextResponse.json(
+        { error: "That plan isn't self-serve. Visit /contact for Team or Pulse." },
+        { status: 400 }
+      );
+    }
+
+    if (!STRIPE_PRO_PRICE_ID) {
+      return NextResponse.json(
+        { error: "STRIPE_PRO_PRICE_ID is not configured." },
+        { status: 500 }
+      );
+    }
+
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const email = user.primaryEmailAddress?.emailAddress;
+
+    /* ── Reuse or create the Stripe customer for this Clerk user ── */
+    let customerId = await getStripeCustomerId(userId);
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email,
+        name: [user.firstName, user.lastName].filter(Boolean).join(" ") || undefined,
+        metadata: { clerkUserId: userId },
+      });
+      customerId = customer.id;
+      // Stash the customer ID immediately so retries don't create duplicates.
+      await setUserSubscription(userId, {
+        tier: "free",
+        stripeCustomerId: customerId,
+      });
+    }
+
+    const origin =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      req.headers.get("origin") ||
+      `https://${req.headers.get("host")}`;
+
+    const session = await stripe.checkout.sessions.create({
+      mode: "subscription",
+      customer: customerId,
+      line_items: [{ price: STRIPE_PRO_PRICE_ID, quantity: 1 }],
+      client_reference_id: userId,
+      subscription_data: {
+        metadata: { clerkUserId: userId, tier: "pro" },
+      },
+      success_url: `${origin}/dashboard?upgraded=pro`,
+      cancel_url: `${origin}/pricing?canceled=1`,
+      allow_promotion_codes: true,
+      billing_address_collection: "auto",
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Checkout failed.";
+    console.error("[LADDER:ERROR] Stripe checkout:", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/stripe/portal/route.ts
+++ b/src/app/api/stripe/portal/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { stripe, assertStripeConfigured } from "@/lib/stripe";
+import { getStripeCustomerId } from "@/lib/tier";
+
+/**
+ * POST /api/stripe/portal
+ * Opens the Stripe Customer Portal for the signed-in user.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    assertStripeConfigured();
+
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: "Sign in required." }, { status: 401 });
+    }
+
+    const customerId = await getStripeCustomerId(userId);
+    if (!customerId) {
+      return NextResponse.json(
+        { error: "No subscription found." },
+        { status: 404 }
+      );
+    }
+
+    const origin =
+      process.env.NEXT_PUBLIC_APP_URL ||
+      req.headers.get("origin") ||
+      `https://${req.headers.get("host")}`;
+
+    const session = await stripe.billingPortal.sessions.create({
+      customer: customerId,
+      return_url: `${origin}/dashboard`,
+    });
+
+    return NextResponse.json({ url: session.url });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "Portal failed.";
+    console.error("[LADDER:ERROR] Stripe portal:", err);
+    return NextResponse.json({ error: msg }, { status: 500 });
+  }
+}

--- a/src/app/api/stripe/webhooks/route.ts
+++ b/src/app/api/stripe/webhooks/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import type Stripe from "stripe";
+import {
+  stripe,
+  assertStripeConfigured,
+  tierForPriceId,
+  isActiveSubscription,
+} from "@/lib/stripe";
+import { setUserSubscription, userIdForStripeCustomer } from "@/lib/tier";
+
+export const runtime = "nodejs";
+
+/**
+ * Stripe webhook receiver. Validates the signature, then mirrors subscription
+ * state into Clerk publicMetadata.tier so every surface (web, Skill, MCP, API)
+ * sees a consistent tier.
+ */
+export async function POST(req: NextRequest) {
+  try {
+    assertStripeConfigured();
+
+    const secret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!secret) {
+      return NextResponse.json(
+        { error: "STRIPE_WEBHOOK_SECRET is not configured." },
+        { status: 500 }
+      );
+    }
+
+    const sig = req.headers.get("stripe-signature");
+    if (!sig) {
+      return NextResponse.json({ error: "Missing signature." }, { status: 400 });
+    }
+
+    const raw = await req.text();
+    let event: Stripe.Event;
+    try {
+      event = stripe.webhooks.constructEvent(raw, sig, secret);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Bad signature";
+      console.error("[LADDER:STRIPE] Signature verification failed:", msg);
+      return NextResponse.json({ error: `Webhook error: ${msg}` }, { status: 400 });
+    }
+
+    switch (event.type) {
+      case "checkout.session.completed": {
+        const session = event.data.object as Stripe.Checkout.Session;
+        const userId =
+          session.client_reference_id ||
+          (session.metadata?.clerkUserId as string | undefined);
+        const customerId =
+          typeof session.customer === "string"
+            ? session.customer
+            : session.customer?.id;
+        if (userId && customerId) {
+          // Subscription event will follow with full state — record the customer now.
+          await setUserSubscription(userId, {
+            tier: "pro",
+            stripeCustomerId: customerId,
+          });
+        }
+        break;
+      }
+
+      case "customer.subscription.created":
+      case "customer.subscription.updated":
+      case "customer.subscription.deleted": {
+        const sub = event.data.object as Stripe.Subscription;
+        const customerId =
+          typeof sub.customer === "string" ? sub.customer : sub.customer.id;
+
+        const userId =
+          (sub.metadata?.clerkUserId as string | undefined) ||
+          (await userIdForStripeCustomer(customerId));
+
+        if (!userId) {
+          console.warn(
+            "[LADDER:STRIPE] No Clerk user found for customer",
+            customerId
+          );
+          break;
+        }
+
+        const priceId = sub.items.data[0]?.price?.id;
+        const active = isActiveSubscription(sub.status);
+        const tier = active ? tierForPriceId(priceId) : "free";
+
+        await setUserSubscription(userId, {
+          tier,
+          stripeCustomerId: customerId,
+          stripeSubscriptionId: sub.id,
+          currentPeriodEnd: sub.items.data[0]?.current_period_end ?? undefined,
+          cancelAtPeriodEnd: sub.cancel_at_period_end,
+        });
+        break;
+      }
+
+      default:
+        // No-op for events we don't care about.
+        break;
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (err) {
+    console.error("[LADDER:ERROR] Stripe webhook:", err);
+    return NextResponse.json({ error: "Webhook handler failed." }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,8 @@ import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
 import { SkillTokenCard } from "@/components/SkillTokenCard";
-import { FREE_MONTHLY_LIMIT } from "@/lib/plans";
+import { ManageSubscriptionButton } from "@/components/ManageSubscriptionButton";
+import { FREE_LIFETIME_LIMIT } from "@/lib/plans";
 
 type ScoreEntry = {
   id: string;
@@ -22,12 +23,14 @@ type ScoreEntry = {
 type UsageInfo = {
   used: number;
   limit: number;
-  month: string;
+  lifetime?: boolean;
 };
 
 type DashboardData = {
   scores: ScoreEntry[];
   usage: UsageInfo;
+  tier: "free" | "pro" | "team" | "pulse";
+  paid: boolean;
 };
 
 function timeAgo(ts: number): string {
@@ -43,7 +46,24 @@ function timeAgo(ts: number): string {
   return `${months}mo ago`;
 }
 
-function UpgradeStrip({ usage }: { usage: UsageInfo }) {
+function UpgradeStrip({ usage, paid }: { usage: UsageInfo; paid: boolean }) {
+  if (paid) {
+    return (
+      <div className="border-b border-ladder-green/20 bg-ladder-green/5">
+        <div className="max-w-6xl mx-auto px-6 py-2.5 flex items-center justify-center gap-4 flex-wrap">
+          <span className="text-[11px] text-muted font-sans">
+            <span className="text-ladder-green font-semibold uppercase tracking-widest text-[10px]">
+              Pro
+            </span>{" "}
+            — unlimited scoring across every Ladder surface.
+          </span>
+          <ManageSubscriptionButton className="text-[10px] uppercase tracking-widest font-semibold text-ladder-green hover:text-ladder-green/80 transition-colors">
+            Manage subscription →
+          </ManageSubscriptionButton>
+        </div>
+      </div>
+    );
+  }
   const remaining = Math.max(0, usage.limit - usage.used);
   const exhausted = remaining === 0;
   return (
@@ -59,16 +79,16 @@ function UpgradeStrip({ usage }: { usage: UsageInfo }) {
           {exhausted ? (
             <>
               <span className="text-ladder-red font-semibold">
-                0 scores left
+                0 free scores left.
               </span>{" "}
-              this month.
+              Upgrade to keep scoring.
             </>
           ) : (
             <>
               <span className="text-foreground font-semibold tabular-nums">
                 {remaining}
               </span>{" "}
-              of {usage.limit} free scores left this month
+              of {usage.limit} free scores left
             </>
           )}
         </span>
@@ -170,12 +190,13 @@ export default function DashboardPage() {
   if (!isSignedIn) return <RedirectToSignIn />;
 
   const scores = data?.scores ?? [];
-  const usage = data?.usage ?? { used: 0, limit: FREE_MONTHLY_LIMIT, month: "" };
+  const usage = data?.usage ?? { used: 0, limit: FREE_LIFETIME_LIMIT };
+  const paid = data?.paid ?? false;
   const firstName = user?.firstName || null;
 
   return (
     <div className="pt-20 font-mono">
-      <UpgradeStrip usage={usage} />
+      <UpgradeStrip usage={usage} paid={paid} />
       <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="mb-8">
           <h1 className="text-xl text-foreground font-sans">

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { LegalNotice } from "@/components/LegalNotice";
+import { SubscribeButton } from "@/components/SubscribeButton";
 
 export const metadata: Metadata = {
   title: "Pricing | Ladder",
@@ -17,7 +18,7 @@ const SCREEN_SCORE_TIERS = [
     limit: "5 scores to get started",
     features: [
       "Overall Ladder score + coaching",
-      "Score on web, Claude Skill, MCP, or Figma",
+      "Score on web, Claude Skill, or Figma",
       "Scores are public",
     ],
     cta: "Start free",
@@ -29,11 +30,9 @@ const SCREEN_SCORE_TIERS = [
     price: "$250",
     period: "/ mo",
     highlight: true,
-    limit: "Unlimited + 1,000 API / mo",
+    limit: "Unlimited scoring",
     features: [
-      "Unlimited scoring on web, Claude Skill, MCP, and Figma",
-      "1,000 API calls per month, overage at $0.50 per call",
-      "API keys for programmatic access",
+      "Unlimited scoring on web, Claude Skill, and Figma",
       "All scores are private",
       "UX copy suggestions",
       "Accessibility audit",
@@ -78,8 +77,7 @@ export default function PricingPage() {
           </h1>
           <p className="text-body max-w-lg mx-auto leading-relaxed">
             One subscription works across every Ladder surface: web,
-            Claude, MCP, Figma, and API. Start free, upgrade when you
-            need more.
+            Claude, and Figma. Start free, upgrade when you need more.
           </p>
         </div>
 
@@ -142,18 +140,27 @@ export default function PricingPage() {
                 ))}
               </ul>
 
-              <Link
-                href={tier.href}
-                className={`text-center text-sm font-semibold py-3 rounded-full transition-colors ${
-                  tier.highlight
-                    ? "bg-ladder-green text-background hover:bg-ladder-green/90"
-                    : tier.solidCta
-                    ? "bg-foreground text-background hover:bg-foreground/90"
-                    : "border border-border text-foreground hover:bg-card-hover"
-                }`}
-              >
-                {tier.cta}
-              </Link>
+              {tier.name === "Professional" ? (
+                <SubscribeButton
+                  plan="pro"
+                  className="w-full text-center text-sm font-semibold py-3 rounded-full transition-colors bg-ladder-green text-background hover:bg-ladder-green/90 disabled:opacity-60"
+                >
+                  {tier.cta}
+                </SubscribeButton>
+              ) : (
+                <Link
+                  href={tier.href}
+                  className={`text-center text-sm font-semibold py-3 rounded-full transition-colors ${
+                    tier.highlight
+                      ? "bg-ladder-green text-background hover:bg-ladder-green/90"
+                      : tier.solidCta
+                      ? "bg-foreground text-background hover:bg-foreground/90"
+                      : "border border-border text-foreground hover:bg-card-hover"
+                  }`}
+                >
+                  {tier.cta}
+                </Link>
+              )}
             </div>
           ))}
 
@@ -267,15 +274,11 @@ export default function PricingPage() {
               },
               {
                 q: "Does one subscription cover all surfaces?",
-                a: "Yes. Your Ladder account works on runladder.com, the Claude Skill, MCP, the Figma plugin, and the Ladder API. One subscription, one usage meter — your 5 free scores are shared across all surfaces.",
+                a: "Yes. Your Ladder account works on runladder.com, the Claude Skill, and the Figma plugin. One subscription, one usage meter — your 5 free scores are shared across every surface.",
               },
               {
                 q: "What counts as a score?",
                 a: "Each time you submit a screenshot, URL, or payload for Ladder analysis on any surface, that\u2019s one score. Viewing history, sharing results, or browsing the Top 100 doesn\u2019t count.",
-              },
-              {
-                q: "How does the API work?",
-                a: "API keys are included at Professional and above. Professional includes 1,000 API calls per month with overage at $0.50 per call. Team includes 25,000 pooled API calls per month with overage at $0.25 per call. Pulse includes 50,000 queries per month with overage at $0.15 per query. Generate keys from your dashboard once subscribed.",
               },
               {
                 q: "Can I cancel anytime?",

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -355,7 +355,7 @@ export default function ScorePage() {
       try { data = JSON.parse(text); } catch { throw new Error("Scoring service returned an unexpected response. Please try again."); }
       if (!res.ok) {
         if (data.signup) {
-          throw new Error("Sign up for free to get 15 scores per month. Log in at runladder.com/login");
+          throw new Error("Sign up for free to get 5 Ladder scores. Log in at runladder.com/login");
         }
         if (data.upgrade) {
           throw new Error("You've used all 15 free scores this month. Upgrade at runladder.com/pricing for unlimited scoring.");

--- a/src/components/ManageSubscriptionButton.tsx
+++ b/src/components/ManageSubscriptionButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+type Props = {
+  className?: string;
+  children: React.ReactNode;
+};
+
+/** Opens the Stripe Customer Portal for the signed-in user. */
+export function ManageSubscriptionButton({ className, children }: Props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/portal", { method: "POST" });
+      const data = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        throw new Error(data.error || "Couldn't open billing portal.");
+      }
+      window.location.href = data.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Portal failed.");
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={loading}
+        className={className}
+      >
+        {loading ? "Opening…" : children}
+      </button>
+      {error && (
+        <p className="text-xs text-ladder-red font-mono mt-2">{error}</p>
+      )}
+    </>
+  );
+}

--- a/src/components/SkillTokenCard.tsx
+++ b/src/components/SkillTokenCard.tsx
@@ -37,10 +37,10 @@ const TROUBLESHOOTING: { title: string; body: React.ReactNode }[] = [
     body: "Your token was revoked or never saved correctly. Click Rotate above, then re-run the install command in Terminal.",
   },
   {
-    title: "429 — monthly limit reached",
+    title: "429 — free tier limit reached",
     body: (
       <>
-        You&apos;ve used all 15 free scores this month.{" "}
+        You&apos;ve used all 5 free Ladder scores.{" "}
         <a
           href="/pricing"
           className="text-ladder-green hover:underline"

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth, SignInButton } from "@clerk/nextjs";
+
+type Props = {
+  plan: "pro";
+  className?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * Triggers Stripe Checkout for a given plan.
+ * Unauthed users get Clerk's modal sign-in overlaid on the page so they
+ * don't lose their place — after signing in they're still on /pricing
+ * and the next click goes straight to Stripe Checkout.
+ */
+export function SubscribeButton({ plan, className, children }: Props) {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handle() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/stripe/checkout", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ plan }),
+      });
+      const data = (await res.json()) as { url?: string; error?: string };
+      if (!res.ok || !data.url) {
+        throw new Error(data.error || "Couldn't start checkout. Try again.");
+      }
+      window.location.href = data.url;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Checkout failed.");
+      setLoading(false);
+    }
+  }
+
+  if (!isLoaded) {
+    return (
+      <button type="button" className={className} disabled>
+        {children}
+      </button>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <SignInButton
+        mode="modal"
+        forceRedirectUrl="/pricing"
+        signUpForceRedirectUrl="/pricing"
+      >
+        <button type="button" className={className}>
+          {children}
+        </button>
+      </SignInButton>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={handle}
+        disabled={loading}
+        className={className}
+      >
+        {loading ? "Starting checkout…" : children}
+      </button>
+      {error && (
+        <p className="text-xs text-ladder-red font-mono mt-2 text-center">{error}</p>
+      )}
+    </>
+  );
+}

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -1,10 +1,19 @@
 /**
- * Plan limits — single source of truth.
+ * Plan limits and tier definitions — single source of truth.
  * Keep in sync with the /pricing page and /framework copy.
  */
 
-/** Free-tier monthly score quota, shared across all surfaces (web, Skill, Figma, MCP). */
-export const FREE_MONTHLY_LIMIT = 15;
+export type Tier = "free" | "pro" | "team" | "pulse";
+
+/** Free-tier lifetime score quota. Shared across all surfaces (web, Skill, Figma, MCP, API). */
+export const FREE_LIFETIME_LIMIT = 5;
 
 /** Anonymous (unauthenticated) rate limit, per IP, per 24 hours. */
 export const ANON_LIMIT = 1;
+
+/** Tiers that bypass the free lifetime cap. */
+const PAID_TIERS: ReadonlySet<Tier> = new Set(["pro", "team", "pulse"]);
+
+export function isPaidTier(tier: Tier): boolean {
+  return PAID_TIERS.has(tier);
+}

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -7,8 +7,12 @@ export const redis = new Redis({
 
 /*
   Redis key schema:
-  - votes:{slug}              Hash { total: float, count: int }
-  - user:{userId}:scores      Sorted set (timestamp as score, JSON payload as member)
-  - user:{userId}:usage:{YYYY-MM}  Integer counter for monthly rate limiting
-  - rate:anon:{ip}            Integer counter with 24h TTL for anonymous rate limiting
+  - votes:{slug}                       Hash { total: float, count: int }
+  - user:{userId}:scores               Sorted set (timestamp as score, JSON payload as member)
+  - user:{userId}:lifetime_scans_used  Integer counter, never resets — drives the free-tier cap
+  - rate:anon:{ip}                     Integer counter with 24h TTL for anonymous rate limiting
 */
+
+export function lifetimeScansKey(userId: string): string {
+  return `user:${userId}:lifetime_scans_used`;
+}

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,41 @@
+import Stripe from "stripe";
+import type { Tier } from "@/lib/plans";
+
+const secret = process.env.STRIPE_SECRET_KEY;
+
+export const stripe: Stripe = secret
+  ? new Stripe(secret)
+  : (null as unknown as Stripe);
+
+export function assertStripeConfigured(): void {
+  if (!secret) {
+    throw new Error(
+      "Stripe is not configured. Set STRIPE_SECRET_KEY in the environment."
+    );
+  }
+}
+
+export const STRIPE_PRO_PRICE_ID = process.env.STRIPE_PRO_PRICE_ID || "";
+
+/**
+ * Map a Stripe price ID to a Ladder tier.
+ * Today only Pro is self-serve; Team and Pulse are sold via Drawbackwards.
+ */
+export function tierForPriceId(priceId: string | null | undefined): Tier {
+  if (!priceId) return "free";
+  if (priceId === STRIPE_PRO_PRICE_ID) return "pro";
+  return "free";
+}
+
+/** Statuses that should grant access to the paid tier. */
+const ACTIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
+  "active",
+  "trialing",
+  "past_due", // grace period — Stripe Smart Retries will recover or cancel
+]);
+
+export function isActiveSubscription(
+  status: Stripe.Subscription.Status
+): boolean {
+  return ACTIVE_SUBSCRIPTION_STATUSES.has(status);
+}

--- a/src/lib/tier.ts
+++ b/src/lib/tier.ts
@@ -1,0 +1,75 @@
+import { clerkClient } from "@clerk/nextjs/server";
+import type { Tier } from "@/lib/plans";
+
+/**
+ * Read the Ladder tier for a user from Clerk publicMetadata.
+ * Defaults to "free" when missing or invalid.
+ */
+export async function getUserTier(userId: string): Promise<Tier> {
+  try {
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    const raw = user.publicMetadata?.tier;
+    if (raw === "pro" || raw === "team" || raw === "pulse") return raw;
+    return "free";
+  } catch {
+    return "free";
+  }
+}
+
+type SubscriptionMeta = {
+  tier: Tier;
+  stripeCustomerId?: string;
+  stripeSubscriptionId?: string;
+  currentPeriodEnd?: number;
+  cancelAtPeriodEnd?: boolean;
+};
+
+/**
+ * Write subscription metadata back to Clerk.
+ * - tier and currentPeriodEnd land in publicMetadata (used by client UI).
+ * - Stripe IDs land in privateMetadata (server-only).
+ */
+export async function setUserSubscription(
+  userId: string,
+  meta: SubscriptionMeta
+): Promise<void> {
+  const client = await clerkClient();
+  const existing = await client.users.getUser(userId);
+
+  await client.users.updateUser(userId, {
+    publicMetadata: {
+      ...existing.publicMetadata,
+      tier: meta.tier,
+      currentPeriodEnd: meta.currentPeriodEnd,
+      cancelAtPeriodEnd: meta.cancelAtPeriodEnd,
+    },
+    privateMetadata: {
+      ...existing.privateMetadata,
+      stripeCustomerId: meta.stripeCustomerId,
+      stripeSubscriptionId: meta.stripeSubscriptionId,
+    },
+  });
+}
+
+/** Read the Stripe customer ID for a user (private metadata). */
+export async function getStripeCustomerId(
+  userId: string
+): Promise<string | null> {
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const id = user.privateMetadata?.stripeCustomerId;
+  return typeof id === "string" ? id : null;
+}
+
+/** Find a Clerk userId by Stripe customer ID. Used by webhooks. */
+export async function userIdForStripeCustomer(
+  customerId: string
+): Promise<string | null> {
+  const client = await clerkClient();
+  const list = await client.users.getUserList({ limit: 100 });
+  for (const u of list.data) {
+    if (u.privateMetadata?.stripeCustomerId === customerId) return u.id;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- Self-serve Pro subscription at \$250/mo via Stripe Checkout
- Stripe → Clerk \`publicMetadata.tier\` sync so every Ladder surface (web, Skill, MCP, Figma, API) reads one tier
- Free tier compressed from 15/month → 5 lifetime scans; paid tiers bypass the cap
- Customer Portal wired up for subscription management

## Surface map
- \`POST /api/stripe/checkout\` — create Checkout session for the signed-in user
- \`POST /api/stripe/webhooks\` — verify signature, mirror subscription state to Clerk
- \`POST /api/stripe/portal\` — open Stripe Customer Portal
- \`SubscribeButton\` — opens Clerk modal sign-in for unauthed users so they don't lose their place; signed-in click goes straight to Checkout
- \`ManageSubscriptionButton\` — Pro users on dashboard
- \`getUserTier\` / \`setUserSubscription\` — Clerk metadata helpers
- Free-tier counter moved from \`user:{id}:usage:{YYYY-MM}\` to \`user:{id}:lifetime_scans_used\`

## Required env vars (production / Vercel)
- \`STRIPE_SECRET_KEY\`
- \`STRIPE_WEBHOOK_SECRET\` (from the live-mode webhook, not the CLI)
- \`STRIPE_PRO_PRICE_ID\` (live-mode price)
- \`NEXT_PUBLIC_APP_URL\` = \`https://runladder.com\`

## Test plan
- [x] End-to-end checkout in test mode (card 4242 4242 4242 4242) — completes, redirects to dashboard, webhook fires \`checkout.session.completed\` + \`customer.subscription.created\`, Clerk \`publicMetadata.tier\` flips to \`pro\`
- [x] \`stripe listen\` shows all events 200 OK
- [x] Manage subscription button opens Stripe Customer Portal
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean (no new warnings)
- [ ] Live-mode end-to-end test after Vercel env vars are set

## Notes
The pricing page intentionally omits MCP and API references for now since neither is shipped at launch. A scheduled agent (https://claude.ai/code/routines/trig_01TpxdT6eGX82WsGUteK2aRN) will check in 4 weeks and re-sync if either ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)