### PR TITLE
Launch copy: web + Figma + Skill live; drop MCP/API mentions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,7 +13,7 @@ Not a promise of order or priority — this is a capture list so nothing falls o
 - **Lifecycle stages** — `new → active → engaged → at-risk → churned`. Auto-computed from activity signals.
 - **CSV export** — users, invite codes, activity windows
 - **Bulk actions** on selected users (email, re-tier, tag)
-- **Custom limits per user** — override the default monthly cap without promoting tier
+- **Custom limits per user** — override the default lifetime cap without promoting tier
 - **Flags** — admin-only booleans on a user (OG beta, reviewer, internal, do-not-contact)
 - **Admin activity log** — who (which admin) edited what, when. Accountability for multi-admin teams.
 
@@ -22,7 +22,7 @@ Not a promise of order or priority — this is a capture list so nothing falls o
 - **Score trend sparkline** per user in the drawer (score over last 30d)
 - **Mode usage breakdown** per user (pie or bar: improve / audit / a11y / copy / compare / generate)
 - **Team-level aggregation** that isn't just `/dashboard/team` (admin-side roll-up across all teams)
-- **Usage forecast** — project monthly usage based on current pace
+- **Usage forecast** — project usage based on current pace
 - **Cohort view** — new users by week, retention by cohort
 
 ## Admin — auth & infra
@@ -34,10 +34,15 @@ Not a promise of order or priority — this is a capture list so nothing falls o
 
 ## Billing & Stripe
 
-- **Stripe sync in admin** — show subscription state, next billing date, invoice history per user
-- **Manual upgrade/downgrade** that writes to Stripe (not just the local tier field)
-- **Dunning visibility** — failed-payment users surfaced in admin
-- **Seat management for Teams tier** (when Teams becomes a real product)
+Core self-serve Pro shipped 2026-05-02. Remaining work is admin tooling, lifecycle handling, and Teams-tier groundwork.
+
+- **Stripe state in admin** — show subscription status, next billing date, invoice history, and `cancel_at_period_end` per user
+- **Manual upgrade/downgrade from admin** that writes to Stripe (not just the local tier field)
+- **Dunning visibility** — failed-payment users surfaced in admin with `past_due` / `unpaid` reasons
+- **Seat management for Teams tier** — landing page, contact-to-quote → Stripe Checkout flow, seat add/remove via Customer Portal (gated on Teams becoming a real product)
+- **Re-add API allotments to Pro pricing page + Stripe description** when the public Ladder API ships (currently dropped — scheduled agent fires 2026-06-01 to check)
+- **MCP surface restoration** — same as above when MCP ships
+- **Subscription pause** — Stripe portal config option, surfaced in dashboard
 
 ## Scoring engine
 
@@ -60,14 +65,14 @@ Not a promise of order or priority — this is a capture list so nothing falls o
 - **Public roadmap page** at `/roadmap` — curated subset of this file (customer-facing only)
 - **`/status` page** with API uptime + recent deploy times
 - **API docs site** for the forthcoming public Ladder API
-- **Pricing page reality check** — sync copy with actual Stripe plans after Stripe sync lands
 
 ## Ops
 
 - **Error aggregation** beyond per-user — surface global error rate, top error types, deploy correlation
 - **Vercel deploy promotion workflow** — staging → prod with a confirmation step (today: push to main = prod)
-- **Scheduled runladder-framework sync health check** — alert if `/api/framework` 5xx rate crosses threshold
+- **Scheduled framework sync health check** — alert if `/api/framework` 5xx rate crosses threshold
+- **Production webhook health check** — scheduled sweep of Stripe Dashboard webhook deliveries; alert on failure spikes or orphaned customers without a Clerk tier
 
 ---
 
-*Last touch-up: 2026-04-19 after the light-CRM v1 ship.*
+*Last touch-up: 2026-05-02 after Stripe self-serve Pro shipped.*

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 
 const INTERESTS = [
   "Organization plan for my team",
-  "Enterprise & API access",
+  "Enterprise deployment",
   "Ladder Pulse deployment",
   "Drawbackwards Consulting",
   "Partnership or integration",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
 import { SkillTokenCard } from "@/components/SkillTokenCard";
+import { FigmaPluginCard } from "@/components/FigmaPluginCard";
 import { ManageSubscriptionButton } from "@/components/ManageSubscriptionButton";
 import { FREE_LIFETIME_LIMIT } from "@/lib/plans";
 
@@ -321,7 +322,8 @@ export default function DashboardPage() {
             </div>
           </main>
 
-          <aside>
+          <aside className="space-y-4">
+            <FigmaPluginCard />
             <SkillTokenCard />
           </aside>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -53,10 +53,16 @@ const PRODUCTS = [
     cta: "Learn about Pulse",
   },
   {
+    name: "Ladder for Figma",
+    desc: "Score frames inside Figma without leaving the canvas. Same framework, same calibration — embedded in the tool where your design work actually happens.",
+    href: "/products",
+    cta: "Install for Figma",
+  },
+  {
     name: "Ladder for Claude",
     desc: "Building with AI? Get a quality check mid-conversation. Know if what Claude generated is a 2.1 or a 3.8 before you ship it.",
-    href: "/products",
-    cta: "Coming soon",
+    href: "/dashboard",
+    cta: "Get the Skill",
   },
   {
     name: "Drawbackwards Consulting",
@@ -355,9 +361,9 @@ export default function Home() {
               <span className="text-ladder-green">Everywhere.</span>
             </h2>
             <p className="text-body max-w-lg mx-auto leading-relaxed">
-              Score in your browser, in Claude, or from customer feedback.
-              Every score feeds the same account, the same
-              history, the same dashboard.
+              Score in your browser, inside Figma, inside Claude, or
+              from customer feedback. Every score feeds the same account,
+              the same history, the same dashboard.
             </p>
           </div>
 

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -43,6 +43,22 @@ const SURFACES = [
     available: true,
   },
   {
+    name: "Ladder for Figma",
+    badge: "Figma Plugin",
+    tagline: "Score frames without leaving the canvas.",
+    description:
+      "Design work happens in Figma. Now scoring does too. Run Ladder on any frame to get the same per-rung breakdown, ranked findings, and fix instructions you'd get on the web — without exporting a screenshot or switching tabs.",
+    features: [
+      "Score any frame, page, or component in place",
+      "Per-rung breakdown with ranked findings",
+      "Fix suggestions with score uplift estimates",
+      "Scores attributed to your Ladder account",
+    ],
+    cta: "Install for Figma",
+    href: "https://www.figma.com/community/plugin/ladder",
+    available: true,
+  },
+  {
     name: "Ladder for Claude",
     badge: "AI Skill",
     tagline: "Quality check mid-conversation.",
@@ -52,11 +68,11 @@ const SURFACES = [
       "Score screenshots inside any Claude conversation",
       "Same Ladder framework as every other surface",
       "Scores attributed to your Ladder account",
-      "Works with Claude.ai and the Claude API",
+      "Works with Claude.ai and Claude Code",
     ],
-    cta: "Coming soon",
-    href: "#",
-    available: false,
+    cta: "Get the Skill",
+    href: "/dashboard",
+    available: true,
   },
   {
     name: "Drawbackwards Consulting",
@@ -91,9 +107,9 @@ export default function ProductsPage() {
             <span className="text-ladder-green">Every surface.</span>
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto leading-relaxed">
-            Score in your browser, from customer feedback, or through
-            Claude. Every score feeds the same account, the same history, the
-            same truth.
+            Score in your browser, inside Figma, inside Claude, or from
+            customer feedback. Every score feeds the same account, the
+            same history, the same truth.
           </p>
         </div>
       </section>
@@ -114,15 +130,21 @@ export default function ProductsPage() {
               </div>
               <div className="flex items-center gap-3">
                 <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
+                <span>Ladder for Figma</span>
+                <span className="flex-1 border-b border-dashed border-border" />
+                <span className="text-muted text-xs">canvas</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
+                <span>Ladder for Claude</span>
+                <span className="flex-1 border-b border-dashed border-border" />
+                <span className="text-muted text-xs">AI</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="w-2 h-2 rounded-full bg-ladder-green flex-shrink-0" />
                 <span>Ladder Pulse</span>
                 <span className="flex-1 border-b border-dashed border-border" />
                 <span className="text-muted text-xs">feedback</span>
-              </div>
-              <div className="flex items-center gap-3">
-                <span className="w-2 h-2 rounded-full bg-[#555] flex-shrink-0" />
-                <span className="text-muted">Ladder for Claude</span>
-                <span className="flex-1 border-b border-dashed border-border" />
-                <span className="text-muted text-xs">coming soon</span>
               </div>
             </div>
             <div className="mt-8 pt-6 border-t border-border text-center">

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -906,9 +906,13 @@ export default function ScorePage() {
                         {f}
                       </li>
                     ))}
-                    <li className="flex items-start gap-2 text-xs text-muted font-sans">
-                      <span className="text-[#555] mt-0.5 flex-shrink-0">+</span>
-                      Ladder for Figma — coming soon for Pro members
+                    <li className="flex items-start gap-2 text-xs text-body font-sans">
+                      <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+                      Ladder for Figma — score frames in the canvas
+                    </li>
+                    <li className="flex items-start gap-2 text-xs text-body font-sans">
+                      <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+                      Ladder for Claude — score in any AI conversation
                     </li>
                   </ul>
                   <Link

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -389,9 +389,8 @@ export default function TeamsPage() {
                   Enterprise
                 </h3>
                 <p className="text-sm text-body max-w-lg leading-relaxed">
-                  25+ designers, SSO, API access, multi-team dashboards,
-                  dedicated CSM, and custom integrations. Priced for your
-                  scale.
+                  25+ designers, SSO, multi-team dashboards, dedicated CSM,
+                  and custom integrations. Priced for your scale.
                 </p>
               </div>
               <Link

--- a/src/components/FigmaPluginCard.tsx
+++ b/src/components/FigmaPluginCard.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+const FIGMA_PLUGIN_URL = "https://www.figma.com/community/plugin/ladder";
+
+/**
+ * Dashboard promo card for the Ladder for Figma plugin.
+ * Sits alongside SkillTokenCard in the dashboard sidebar.
+ */
+export function FigmaPluginCard() {
+  return (
+    <div className="border border-[#333] bg-[#1e1e1e] p-6">
+      <div className="flex items-center gap-2 mb-1">
+        <span className="text-[9px] text-ladder-green uppercase tracking-widest font-semibold">
+          New
+        </span>
+        <h3 className="text-sm text-foreground font-sans font-semibold">
+          Ladder for Figma
+        </h3>
+      </div>
+      <p className="text-xs text-muted font-sans leading-relaxed mb-5">
+        Score frames inside Figma without leaving the canvas. Same framework,
+        same calibration, same per-rung breakdown — embedded in the tool where
+        your design work actually happens.
+      </p>
+
+      <ul className="space-y-2 mb-6">
+        {[
+          "Score any frame, page, or component in place",
+          "Per-rung breakdown with ranked findings",
+          "Fix suggestions with score uplift estimates",
+          "Scores attributed to your Ladder account",
+        ].map((feature) => (
+          <li
+            key={feature}
+            className="flex items-start gap-2 text-[11px] text-body font-sans leading-relaxed"
+          >
+            <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+            {feature}
+          </li>
+        ))}
+      </ul>
+
+      <a
+        href={FIGMA_PLUGIN_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block text-center text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
+      >
+        Install for Figma
+      </a>
+    </div>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,6 +22,7 @@ export function Footer() {
               Surfaces
             </h4>
             <ul className="space-y-3 text-sm text-body">
+              <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Figma</Link></li>
               <li><Link href="/products" className="hover:text-foreground transition-colors">Ladder for Claude</Link></li>
               <li><Link href="/pulse" className="hover:text-foreground transition-colors">Ladder Pulse</Link></li>
             </ul>


### PR DESCRIPTION
## Summary
- Public launch is web + Figma + Skill. MCP and public API are deferred.
- Site copy reflects the three live surfaces; "coming soon" framing removed where it referenced shipped products.
- New \`FigmaPluginCard\` promotes the Figma plugin on the dashboard sidebar (sits above the Skill card).

## Changes
- **Homepage** — adds Ladder for Figma to PRODUCTS list; flips Ladder for Claude from "Coming soon" → "Get the Skill"; updates platform tagline to mention Figma
- **Products page** — adds Figma surface card; flips Claude from \`available: false\` → \`true\`; "How it connects" diagram now lists all three live surfaces
- **Footer** — Surfaces column now lists Ladder for Figma alongside Claude and Pulse
- **Teams page** — drops "API access" from Enterprise tier description
- **Contact form** — replaces "Enterprise & API access" interest with "Enterprise deployment"
- **Score page** — Pro upsell list now lists Figma and Claude as live Pro surfaces
- **Dashboard** — new \`FigmaPluginCard\` component above SkillTokenCard
- **ROADMAP.md** — marks Stripe self-serve shipped; resolves "Pricing page reality check" item

## Out of scope
- Privacy/Terms/Legal pages keep forward-looking MCP/API references (those describe what services may exist later, fine to leave)
- Figma plugin URL in code (\`https://www.figma.com/community/plugin/ladder\`) is the expected target after Figma Community submission — confirm before merging if the slug differs

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Server-rendered HTML verified: homepage / products / contact / teams all show new copy, no orphaned "API access" or "Coming soon" on shipped surfaces
- [ ] Visual check on dashboard with Figma + Skill cards stacked
- [ ] Confirm Figma Community plugin URL once submission is complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)