### PR TITLE
Plugin auth + score persistence endpoints (Phase 1 of plugin Clerk migration)

### DIFF
--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { redis, lifetimeScansKey } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+type ScoreEntry = {
+  id: string;
+  score: number;
+  label: string;
+  screenName?: string;
+  summary?: string;
+  next?: string;
+  findings?: unknown[];
+  rungs?: unknown;
+  source: string;
+  thumbnail?: string;
+  isPublic?: boolean;
+  timestamp: number;
+};
+
+/**
+ * Persist a Ladder score to a user's runladder.com history.
+ * Called server-to-server by ai-design-assistant after a Figma plugin scan,
+ * so Figma scores show up alongside web/Skill scores in the user's dashboard.
+ *
+ * Auth model: shared service secret (X-Ladder-Service-Token header).
+ *
+ * Body: { userId: string, score: ScoreEntry }
+ * Returns: { ok: true }
+ */
+export async function POST(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Service not configured." },
+      { status: 503, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  try {
+    const body = (await req.json()) as { userId?: string; score?: ScoreEntry };
+    const { userId, score } = body;
+
+    if (!userId || !score?.id || typeof score.score !== "number") {
+      return NextResponse.json(
+        { error: "Body must include userId and a valid score entry." },
+        { status: 400, headers: API_VERSION_HEADERS },
+      );
+    }
+
+    const entry: ScoreEntry = {
+      id: score.id,
+      score: score.score,
+      label: score.label,
+      screenName: score.screenName,
+      summary: score.summary,
+      next: score.next,
+      findings: score.findings,
+      rungs: score.rungs,
+      source: score.source || "figma",
+      thumbnail: score.thumbnail,
+      isPublic: !!score.isPublic,
+      timestamp: score.timestamp || Date.now(),
+    };
+
+    await Promise.all([
+      redis.zadd(`user:${userId}:scores`, {
+        score: entry.timestamp,
+        member: JSON.stringify(entry),
+      }),
+      redis.incr(lifetimeScansKey(userId)),
+    ]);
+
+    return NextResponse.json(
+      { ok: true },
+      { headers: API_VERSION_HEADERS },
+    );
+  } catch (err) {
+    console.error("[LADDER:ERROR] Plugin persist-score:", err);
+    return NextResponse.json(
+      { error: "Persist failed." },
+      { status: 500, headers: API_VERSION_HEADERS },
+    );
+  }
+}

--- a/src/app/api/plugin/verify-token/route.ts
+++ b/src/app/api/plugin/verify-token/route.ts
@@ -1,0 +1,86 @@
+import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { userIdFromBearer } from "@/lib/skill-auth";
+import { FREE_LIFETIME_LIMIT, isPaidTier, type Tier } from "@/lib/plans";
+import { redis, lifetimeScansKey } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+/**
+ * Plugin token verification — server-to-server, called by the
+ * ai-design-assistant backend to resolve a user's Ladder personal token
+ * (the same token used by the Claude Skill) into a Clerk userId + tier.
+ *
+ * Auth model: shared service secret (X-Ladder-Service-Token header).
+ *
+ * Body: { token: "ladder_skl_..." }
+ * Returns: { userId, tier, paid } on 200, 401 if the token is unknown.
+ */
+export async function POST(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Service not configured." },
+      { status: 503, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  try {
+    const body = (await req.json()) as { token?: string };
+    const token = body.token?.trim();
+    if (!token) {
+      return NextResponse.json(
+        { error: "Missing token in body." },
+        { status: 400, headers: API_VERSION_HEADERS },
+      );
+    }
+
+    const userId = await userIdFromBearer(token);
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Token not recognized." },
+        { status: 401, headers: API_VERSION_HEADERS },
+      );
+    }
+
+    const [clerk, used] = await Promise.all([
+      clerkClient(),
+      redis.get<number>(lifetimeScansKey(userId)),
+    ]);
+    const user = await clerk.users.getUser(userId);
+    const rawTier = user.publicMetadata?.tier;
+    const tier: Tier =
+      rawTier === "pro" || rawTier === "team" || rawTier === "pulse"
+        ? rawTier
+        : "free";
+    const paid = isPaidTier(tier);
+    return NextResponse.json(
+      {
+        userId,
+        tier,
+        paid,
+        email: user.primaryEmailAddress?.emailAddress ?? null,
+        firstName: user.firstName ?? null,
+        usage: {
+          used: used ?? 0,
+          limit: paid ? null : FREE_LIFETIME_LIMIT,
+        },
+      },
+      { headers: API_VERSION_HEADERS },
+    );
+  } catch (err) {
+    console.error("[LADDER:ERROR] Plugin verify-token:", err);
+    return NextResponse.json(
+      { error: "Verification failed." },
+      { status: 500, headers: API_VERSION_HEADERS },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Adds two service-token-authenticated endpoints used by the Figma plugin backend (\`ai-design-assistant\`) so plugin scores land in the runladder dashboard alongside web + Skill scores.

Phase 1 of moving the plugin off its own magic-link auth + Redis user store and onto Clerk as the single user system. Companion PR in \`ai-design-assistant\`: #173 (forthcoming).

## Endpoints
- \`POST /api/plugin/verify-token\` — resolves a \`ladder_skl_...\` Bearer token (same token the Skill uses) into \`{ userId, tier, paid, email, firstName, usage }\`. Caller (ai-design-assistant) caches results for 60s.
- \`POST /api/plugin/persist-score\` — writes a Figma score into \`user:{userId}:scores\` and increments \`lifetime_scans_used\`. Single source of truth for free-tier enforcement.

Both gate on \`LADDER_SERVICE_TOKEN\`.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] curl smoke: 401 without service token, 401 with service token + bogus bearer, would 200 with a real bearer
- [ ] End-to-end after ai-design-assistant migration lands

## Out of scope
- Phases 2–5 ship in the ai-design-assistant repo + a follow-up runladder PR for the dashboard install card

🤖 Generated with [Claude Code](https://claude.com/claude-code)