### PR TITLE
Dashboard: Figma installer + bare-token copy

### DIFF
--- a/src/components/FigmaPluginCard.tsx
+++ b/src/components/FigmaPluginCard.tsx
@@ -2,52 +2,92 @@
 
 const FIGMA_PLUGIN_URL = "https://www.figma.com/community/plugin/ladder";
 
+function NumberedStep({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex gap-4 mb-5 last:mb-0">
+      <span className="text-[10px] text-ladder-green font-mono tabular-nums shrink-0 mt-1">
+        {String(n).padStart(2, "0")}
+      </span>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-foreground font-sans font-semibold mb-2">
+          {title}
+        </p>
+        {children}
+      </div>
+    </div>
+  );
+}
+
 /**
- * Dashboard promo card for the Ladder for Figma plugin.
+ * Dashboard installer card for the Ladder for Figma plugin.
+ * Three steps mirror the Skill install flow — same token, different surface.
  * Sits alongside SkillTokenCard in the dashboard sidebar.
  */
 export function FigmaPluginCard() {
   return (
     <div className="border border-[#333] bg-[#1e1e1e] p-6">
-      <div className="flex items-center gap-2 mb-1">
-        <span className="text-[9px] text-ladder-green uppercase tracking-widest font-semibold">
-          New
-        </span>
-        <h3 className="text-sm text-foreground font-sans font-semibold">
-          Ladder for Figma
-        </h3>
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-[9px] text-ladder-green uppercase tracking-widest font-semibold">
+            New
+          </span>
+          <h3 className="text-sm text-foreground font-sans font-semibold">
+            Ladder for Figma
+          </h3>
+        </div>
+        <p className="text-xs text-muted font-sans leading-relaxed">
+          Score frames inside Figma without leaving the canvas. Same framework,
+          same calibration, same per-rung breakdown.
+        </p>
       </div>
-      <p className="text-xs text-muted font-sans leading-relaxed mb-5">
-        Score frames inside Figma without leaving the canvas. Same framework,
-        same calibration, same per-rung breakdown — embedded in the tool where
-        your design work actually happens.
-      </p>
 
-      <ul className="space-y-2 mb-6">
-        {[
-          "Score any frame, page, or component in place",
-          "Per-rung breakdown with ranked findings",
-          "Fix suggestions with score uplift estimates",
-          "Scores attributed to your Ladder account",
-        ].map((feature) => (
-          <li
-            key={feature}
-            className="flex items-start gap-2 text-[11px] text-body font-sans leading-relaxed"
-          >
-            <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
-            {feature}
-          </li>
-        ))}
-      </ul>
+      <NumberedStep n={1} title="Get your Ladder token">
+        <p className="text-[11px] text-muted font-sans leading-relaxed">
+          Use the <span className="text-foreground font-semibold">Ladder for Claude</span> card
+          below — generate a token, then click{" "}
+          <span className="text-foreground font-semibold">Copy raw token</span>.
+          The same token works for both surfaces.
+        </p>
+      </NumberedStep>
 
-      <a
-        href={FIGMA_PLUGIN_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="block text-center text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
-      >
-        Install for Figma
-      </a>
+      <NumberedStep n={2} title="Install the plugin">
+        <a
+          href={FIGMA_PLUGIN_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-block text-[11px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-4 py-2 font-semibold"
+        >
+          Open in Figma Community →
+        </a>
+        <p className="text-[10px] text-muted font-sans mt-3 leading-relaxed">
+          Click <span className="text-foreground">Open in…</span> in Figma Community to
+          install into your account. Available in any Figma file under{" "}
+          <code className="text-foreground">Plugins → Ladder for Figma</code>.
+        </p>
+      </NumberedStep>
+
+      <NumberedStep n={3} title="Paste your token">
+        <p className="text-[11px] text-muted font-sans leading-relaxed">
+          Open the plugin. Paste your Ladder token in the auth screen, click{" "}
+          <span className="text-foreground font-semibold">Continue</span>, and you&apos;re in.
+          Select any frame and hit <span className="text-foreground font-semibold">Score</span>.
+        </p>
+      </NumberedStep>
+
+      <div className="mt-6 pt-5 border-t border-[#333]">
+        <p className="text-[10px] text-muted font-sans leading-relaxed">
+          Scores from the plugin sync to your dashboard automatically. The free
+          5-score lifetime cap is shared across web, Skill, and Figma.
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/components/SkillTokenCard.tsx
+++ b/src/components/SkillTokenCard.tsx
@@ -83,6 +83,7 @@ export function SkillTokenCard() {
   const [working, setWorking] = useState(false);
   const [rawToken, setRawToken] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [bareCopied, setBareCopied] = useState(false);
   const [ccCopied, setCcCopied] = useState(false);
   const [showTroubleshooting, setShowTroubleshooting] = useState(false);
 
@@ -131,6 +132,13 @@ export function SkillTokenCard() {
     navigator.clipboard.writeText(installCommand(rawToken));
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
+  }
+
+  function copyBareToken() {
+    if (!rawToken) return;
+    navigator.clipboard.writeText(rawToken);
+    setBareCopied(true);
+    setTimeout(() => setBareCopied(false), 2000);
   }
 
   function claudeCodeInstall(version: string): string {
@@ -210,6 +218,17 @@ export function SkillTokenCard() {
             <p className="text-[10px] text-muted font-sans mt-3">
               Saves your token to <code className="text-foreground">~/.ladder/token</code>. macOS &amp; Linux.
             </p>
+            <div className="mt-3 pt-3 border-t border-ladder-green/20 flex items-center justify-between gap-2">
+              <p className="text-[10px] text-muted font-sans">
+                Using the Figma plugin instead?
+              </p>
+              <button
+                onClick={copyBareToken}
+                className="text-[10px] uppercase tracking-widest text-ladder-green border border-ladder-green/30 px-3 py-1.5 hover:bg-ladder-green/10 transition-colors font-semibold"
+              >
+                {bareCopied ? "Copied" : "Copy raw token"}
+              </button>
+            </div>
           </div>
         ) : meta?.hasToken ? (
           <div className="flex items-center justify-between gap-4">


### PR DESCRIPTION
## Summary
Phase 4 of the plugin Clerk migration. With the plugin's new token-paste auth gate (drawbackwards/ai-design-assistant#173), users need an easy way to grab their Ladder token from the dashboard.

## Changes
- **\`SkillTokenCard\`** — when a fresh token is shown post-generation, adds a small "Copy raw token" button next to the Terminal install command. Same underlying token, different copy format. The hint reads "Using the Figma plugin instead?"
- **\`FigmaPluginCard\`** — promoted from a promo card to a 3-step installer mirroring the Skill flow:
  1. Get your Ladder token (points to the SkillTokenCard's "Copy raw token")
  2. Install the plugin (Figma Community link)
  3. Paste your token in the plugin's auth screen

## Out of scope
- Refactoring SkillTokenCard into a generic LadderTokenCard with multiple install paths underneath — current shape works, refactor can come later.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Generate a fresh token → "Copy raw token" lands a clean \`ladder_skl_...\` on clipboard
- [ ] FigmaPluginCard renders 3 steps cleanly above the SkillTokenCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)