### PR TITLE
Plugin: issue-token endpoint for email+password auth flow

### DIFF
--- a/src/app/api/plugin/issue-token/route.ts
+++ b/src/app/api/plugin/issue-token/route.ts
@@ -1,0 +1,60 @@
+import { NextRequest, NextResponse } from "next/server";
+import { rotateSkillToken } from "@/lib/skill-auth";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+/**
+ * Mint (or rotate) a Ladder personal token for a Clerk user.
+ *
+ * Called server-to-server by ai-design-assistant after it has verified an
+ * email + password against Clerk on the plugin's behalf. The plugin then
+ * stores the returned token and sends it as a Bearer on subsequent calls.
+ *
+ * Reuses the Skill token format (`ladder_skl_...`) since one token works
+ * across every authenticated surface (web, Skill, Figma).
+ *
+ * Auth model: shared service secret (X-Ladder-Service-Token header).
+ *
+ * Body: { userId: "<clerk_user_id>" }
+ * Returns: { token: "ladder_skl_..." }
+ */
+export async function POST(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Service not configured." },
+      { status: 503, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  try {
+    const body = (await req.json()) as { userId?: string };
+    const userId = body.userId?.trim();
+    if (!userId) {
+      return NextResponse.json(
+        { error: "Body must include a userId." },
+        { status: 400, headers: API_VERSION_HEADERS },
+      );
+    }
+
+    const token = await rotateSkillToken(userId);
+    return NextResponse.json(
+      { token },
+      { headers: API_VERSION_HEADERS },
+    );
+  } catch (err) {
+    console.error("[LADDER:ERROR] Plugin issue-token:", err);
+    return NextResponse.json(
+      { error: "Token issuance failed." },
+      { status: 500, headers: API_VERSION_HEADERS },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Service-to-service endpoint that mints a Ladder personal token (\`ladder_skl_...\`) for a given Clerk userId. Called by ai-design-assistant after it verifies email + password against Clerk on behalf of the Figma plugin.

Companion PR: drawbackwards/ai-design-assistant#175 (forthcoming) — adds /api/auth/signup and /api/auth/login on the plugin backend.

## Why
The plugin's previous auth was paste-a-token UX, which is too clunky for a Figma plugin. New flow:

1. User types email + password in plugin
2. Plugin → ai-design-assistant /api/auth/login
3. ai-design-assistant → Clerk Backend API (verifyPassword)
4. ai-design-assistant → runladder /api/plugin/issue-token (this PR) → returns ladder_skl_ token
5. Plugin stores token, uses as Bearer

User never sees or thinks about tokens.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Live test once ai-design-assistant deploys

🤖 Generated with [Claude Code](https://claude.com/claude-code)