### PR TITLE
Plugin persist-score: debug log + admin reader

### DIFF
--- a/src/app/api/admin/persist-log/route.ts
+++ b/src/app/api/admin/persist-log/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from "next/server";
+import { redis } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+/**
+ * Returns the last 50 plugin persist-score attempts for diagnostic use.
+ * Read-only; gated by the same shared service secret as the persist endpoint
+ * itself so nothing else can hit it.
+ */
+export async function GET(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected || serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const raw = await redis.lrange("debug:plugin-persist-log", 0, 49);
+  const entries = (raw as string[])
+    .map((s) => {
+      if (typeof s !== "string") return s;
+      try {
+        return JSON.parse(s);
+      } catch {
+        return { raw: s };
+      }
+    })
+    .filter(Boolean);
+
+  return NextResponse.json(
+    { count: entries.length, entries },
+    { headers: API_VERSION_HEADERS },
+  );
+}

--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -79,6 +79,27 @@ export async function POST(req: NextRequest) {
       redis.incr(lifetimeScansKey(userId)),
     ]);
 
+    // Diagnostic log: keep the last 50 persist attempts for 24h so we can
+    // verify cross-repo calls land without trawling Vercel logs by hand.
+    try {
+      await redis.lpush(
+        "debug:plugin-persist-log",
+        JSON.stringify({
+          ts: Date.now(),
+          userId,
+          scoreId: entry.id,
+          score: entry.score,
+          screenName: entry.screenName,
+          source: entry.source,
+          ok: true,
+        }),
+      );
+      await redis.ltrim("debug:plugin-persist-log", 0, 49);
+      await redis.expire("debug:plugin-persist-log", 60 * 60 * 24);
+    } catch {
+      // Logging is best-effort.
+    }
+
     return NextResponse.json(
       { ok: true },
       { headers: API_VERSION_HEADERS },


### PR DESCRIPTION
Adds a small diagnostic log so we can verify Figma → dashboard score sync without manually checking Vercel logs. Service-token gated.