### PR TITLE
Score uplift, per-user stats, leaderboard groundwork

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { redis, lifetimeScansKey } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription } from "@/lib/tier";
+import { getUserStats } from "@/lib/scores";
 
 export async function GET() {
   const { userId } = await auth();
@@ -11,10 +12,11 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const [scores, used, sub] = await Promise.all([
+  const [scores, used, sub, stats] = await Promise.all([
     redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true }),
     redis.get<number>(lifetimeScansKey(userId)),
     getUserSubscription(userId),
+    getUserStats(userId),
   ]);
 
   const parsedScores = (scores as string[]).map((entry) => {
@@ -30,6 +32,7 @@ export async function GET() {
 
   return NextResponse.json({
     scores: parsedScores,
+    stats,
     tier: sub.tier,
     paid: isPaidTier(sub.tier),
     comp: sub.comp

--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -1,25 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { redis, lifetimeScansKey } from "@/lib/redis";
+import { redis } from "@/lib/redis";
 import { parseImageDataUrl } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
+import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
 
-type ScoreEntry = {
-  id: string;
-  score: number;
-  label: string;
-  screenName?: string;
-  summary?: string;
-  next?: string;
-  findings?: unknown[];
-  rungs?: unknown;
-  source: string;
-  thumbnail?: string;
-  isPublic?: boolean;
-  timestamp: number;
-};
+type ScoreEntry = ScoreEntryInput;
 
 /**
  * Persist a Ladder score to a user's runladder.com history.
@@ -74,7 +62,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    const entry: ScoreEntry = {
+    const stored = await persistScoreEntry(userId, {
       id: score.id,
       score: score.score,
       label: score.label,
@@ -87,15 +75,7 @@ export async function POST(req: NextRequest) {
       thumbnail,
       isPublic: !!score.isPublic,
       timestamp: score.timestamp || Date.now(),
-    };
-
-    await Promise.all([
-      redis.zadd(`user:${userId}:scores`, {
-        score: entry.timestamp,
-        member: JSON.stringify(entry),
-      }),
-      redis.incr(lifetimeScansKey(userId)),
-    ]);
+    });
 
     // Diagnostic log: keep the last 50 persist attempts for 24h so we can
     // verify cross-repo calls land without trawling Vercel logs by hand.
@@ -105,10 +85,12 @@ export async function POST(req: NextRequest) {
         JSON.stringify({
           ts: Date.now(),
           userId,
-          scoreId: entry.id,
-          score: entry.score,
-          screenName: entry.screenName,
-          source: entry.source,
+          scoreId: stored.id,
+          score: stored.score,
+          uplift: stored.uplift,
+          previousScore: stored.previousScore,
+          screenName: stored.screenName,
+          source: stored.source,
           ok: true,
         }),
       );

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -9,6 +9,7 @@ import {
 import { makeThumbnail } from "@/lib/thumbnail";
 import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
+import { persistScoreEntry } from "@/lib/scores";
 
 export const maxDuration = 60;
 
@@ -86,7 +87,7 @@ export async function POST(req: NextRequest) {
         parsed.mediaType,
       );
 
-      const scoreEntry = {
+      await persistScoreEntry(userId, {
         id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         score: result.score,
         label: result.label,
@@ -99,17 +100,7 @@ export async function POST(req: NextRequest) {
         thumbnail,
         isPublic: !!isPublic,
         timestamp: Date.now(),
-      };
-
-      const ops: Promise<unknown>[] = [
-        redis.zadd(`user:${userId}:scores`, {
-          score: Date.now(),
-          member: JSON.stringify(scoreEntry),
-        }),
-      ];
-      // Always count lifetime scans — even on paid tiers, for analytics + audit.
-      ops.push(redis.incr(lifetimeScansKey(userId)));
-      await Promise.all(ops);
+      });
     } else {
       const anonKey = `rate:anon:${ip}`;
       await redis.incr(anonKey);

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -9,6 +9,7 @@ import { makeThumbnail } from "@/lib/thumbnail";
 import { userIdFromBearer, touchSkillToken } from "@/lib/skill-auth";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
+import { persistScoreEntry } from "@/lib/scores";
 
 export const maxDuration = 60;
 
@@ -86,7 +87,7 @@ export async function POST(req: NextRequest) {
       parsed.mediaType,
     );
 
-    const scoreEntry = {
+    const scoreEntry = await persistScoreEntry(userId, {
       id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       score: result.score,
       label: result.label,
@@ -99,16 +100,8 @@ export async function POST(req: NextRequest) {
       thumbnail,
       isPublic: false,
       timestamp: Date.now(),
-    };
-
-    await Promise.all([
-      redis.zadd(`user:${userId}:scores`, {
-        score: Date.now(),
-        member: JSON.stringify(scoreEntry),
-      }),
-      redis.incr(usedKey),
-      touchSkillToken(userId, installedVersion),
-    ]);
+    });
+    await touchSkillToken(userId, installedVersion);
 
     return NextResponse.json({
       score: result.score,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -19,6 +19,17 @@ type ScoreEntry = {
   thumbnail?: string;
   isPublic?: boolean;
   timestamp: number;
+  // Uplift tracking — present when this isn't the first scan of the screen.
+  screenKey?: string;
+  previousScore?: number | null;
+  uplift?: number | null;
+};
+
+type UserStats = {
+  totalScans: number;
+  avgScore: number | null;
+  bestScore: number | null;
+  lastScoreAt: number | null;
 };
 
 type UsageInfo = {
@@ -34,6 +45,7 @@ type CompMeta = {
 
 type DashboardData = {
   scores: ScoreEntry[];
+  stats: UserStats;
   usage: UsageInfo;
   tier: "free" | "pro" | "team" | "pulse";
   paid: boolean;
@@ -148,6 +160,73 @@ function UpgradeStrip({
   );
 }
 
+function StatsSummaryCard({ stats }: { stats: UserStats }) {
+  if (!stats || stats.totalScans === 0) return null;
+  const avg = stats.avgScore;
+  const best = stats.bestScore;
+
+  return (
+    <div className="grid grid-cols-3 gap-2 mb-6">
+      <div className="border border-[#333] bg-[#1e1e1e] p-4">
+        <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+          Total scans
+        </p>
+        <p className="text-2xl font-bold text-foreground tabular-nums">
+          {stats.totalScans}
+        </p>
+      </div>
+      <div className="border border-[#333] bg-[#1e1e1e] p-4">
+        <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+          Average
+        </p>
+        <p
+          className="text-2xl font-bold tabular-nums"
+          style={{ color: avg !== null ? getScoreColor(avg) : "#444" }}
+        >
+          {avg !== null ? avg.toFixed(1) : "—"}
+        </p>
+      </div>
+      <div className="border border-[#333] bg-[#1e1e1e] p-4">
+        <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+          Best
+        </p>
+        <p
+          className="text-2xl font-bold tabular-nums"
+          style={{ color: best !== null ? getScoreColor(best) : "#444" }}
+        >
+          {best !== null ? best.toFixed(1) : "—"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function UpliftBadge({ uplift }: { uplift: number }) {
+  if (uplift === 0) {
+    return (
+      <span
+        className="text-[10px] font-mono font-semibold text-muted tabular-nums"
+        title="Same score as last scan of this screen"
+      >
+        ±0.0
+      </span>
+    );
+  }
+  const positive = uplift > 0;
+  const sign = positive ? "↑" : "↓";
+  const display = `${sign}${Math.abs(uplift).toFixed(1)}`;
+  return (
+    <span
+      className={`text-[10px] font-mono font-semibold tabular-nums ${
+        positive ? "text-ladder-green" : "text-ladder-red"
+      }`}
+      title={`Change from previous scan of this screen`}
+    >
+      {display}
+    </span>
+  );
+}
+
 function ScoreCTACard() {
   return (
     <Link
@@ -235,6 +314,12 @@ export default function DashboardPage() {
   if (!isSignedIn) return <RedirectToSignIn />;
 
   const scores = data?.scores ?? [];
+  const stats = data?.stats ?? {
+    totalScans: 0,
+    avgScore: null,
+    bestScore: null,
+    lastScoreAt: null,
+  };
   const usage = data?.usage ?? { used: 0, limit: FREE_LIFETIME_LIMIT };
   const paid = data?.paid ?? false;
   const tier = data?.tier ?? "free";
@@ -253,6 +338,7 @@ export default function DashboardPage() {
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-8 items-start">
           <main>
+            <StatsSummaryCard stats={stats} />
             <div className="flex items-center justify-between mb-6">
               <span className="text-[10px] text-muted uppercase tracking-widest">
                 Score history
@@ -318,6 +404,11 @@ export default function DashboardPage() {
                           >
                             {entry.label}
                           </span>
+                          {typeof entry.uplift === "number" && (
+                            <span className="block mt-1">
+                              <UpliftBadge uplift={entry.uplift} />
+                            </span>
+                          )}
                         </div>
 
                         <div className="flex-1 min-w-0">

--- a/src/lib/scores.ts
+++ b/src/lib/scores.ts
@@ -1,0 +1,198 @@
+import { redis, lifetimeScansKey } from "@/lib/redis";
+
+/**
+ * Single source of truth for persisting a Ladder score to a user's
+ * runladder.com history. Used by every surface — web (/api/score),
+ * Skill (/api/skill/score), and Figma plugin (/api/plugin/persist-score)
+ * — so dashboard rows look the same regardless of where the score came
+ * from, and per-user stats stay consistent.
+ *
+ * Side effects per call:
+ *   - user:{userId}:scores         zset add (timestamp -> JSON entry)
+ *   - user:{userId}:lifetime_scans_used  incr
+ *   - user:{userId}:lastscore:{screenKey}  set (last-score lookup for uplift)
+ *   - user:{userId}:stats           hash update (totalScans, sumScores, bestScore, lastScoreAt)
+ *   - leaderboard:global:avg / :scans  zadd (powers future leaderboard surfaces)
+ */
+
+export type ScoreEntryInput = {
+  id: string;
+  score: number;
+  label: string;
+  screenName?: string;
+  summary?: string;
+  next?: string;
+  findings?: unknown[];
+  rungs?: unknown;
+  source: string;
+  thumbnail?: string;
+  isPublic?: boolean;
+  timestamp: number;
+};
+
+export type StoredScoreEntry = ScoreEntryInput & {
+  /** Canonical identifier for "the same screen, scored across time". */
+  screenKey: string;
+  /** Score from the most recent prior scan of the same screen, or null if first time. */
+  previousScore: number | null;
+  /** entry.score - previousScore, rounded to 1 decimal. Null on first scan. */
+  uplift: number | null;
+};
+
+export type UserStats = {
+  totalScans: number;
+  avgScore: number | null;
+  bestScore: number | null;
+  lastScoreAt: number | null;
+};
+
+const SCORE_HISTORY_KEY = (userId: string) => `user:${userId}:scores`;
+const LASTSCORE_KEY = (userId: string, screenKey: string) =>
+  `user:${userId}:lastscore:${screenKey}`;
+const STATS_KEY = (userId: string) => `user:${userId}:stats`;
+const LEADERBOARD_AVG = "leaderboard:global:avg";
+const LEADERBOARD_SCANS = "leaderboard:global:scans";
+
+/**
+ * Canonical "this is the same screen across scans" key.
+ *
+ * We prefix with source so a Figma frame named "Login" and a web URL
+ * "/login" track separately even if their normalized names collide —
+ * different journeys, different deltas.
+ */
+export function screenKeyFor(source: string, screenName: string | undefined): string {
+  const src = (source || "unknown").toLowerCase().trim();
+  // Strip the "(Figma)" / "(Skill)" surface suffix if a caller already added one,
+  // since the source prefix already encodes that.
+  const cleaned = (screenName || "untitled")
+    .replace(/\s*\((figma|skill|web|claude|pulse)\)\s*$/i, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9.\-_/:]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 120);
+  return `${src}::${cleaned || "untitled"}`;
+}
+
+/**
+ * Persist a single score entry. Returns the enriched entry that ended up
+ * in the user's history (with uplift + previousScore filled in).
+ */
+export async function persistScoreEntry(
+  userId: string,
+  input: ScoreEntryInput,
+): Promise<StoredScoreEntry> {
+  const screenKey = screenKeyFor(input.source, input.screenName);
+
+  // Look up the previous score for the same screen (if any) before writing.
+  const prev = await redis.get<{ score: number; ts: number; id: string }>(
+    LASTSCORE_KEY(userId, screenKey),
+  );
+  const previousScore =
+    prev && typeof prev.score === "number" ? prev.score : null;
+  const uplift =
+    previousScore !== null
+      ? Math.round((input.score - previousScore) * 10) / 10
+      : null;
+
+  const entry: StoredScoreEntry = {
+    ...input,
+    screenKey,
+    previousScore,
+    uplift,
+  };
+
+  // Aggregate stats. We update via HINCRBY/HSET so concurrent scores don't
+  // clobber each other. avgScore is derived (sumScores / totalScans).
+  const ops: Promise<unknown>[] = [
+    redis.zadd(SCORE_HISTORY_KEY(userId), {
+      score: entry.timestamp,
+      member: JSON.stringify(entry),
+    }),
+    redis.incr(lifetimeScansKey(userId)),
+    redis.set(LASTSCORE_KEY(userId, screenKey), {
+      score: entry.score,
+      ts: entry.timestamp,
+      id: entry.id,
+    }),
+    redis.hincrby(STATS_KEY(userId), "totalScans", 1),
+    // Multiply by 10 + integer-store so we can recover via integer math without floats.
+    redis.hincrby(STATS_KEY(userId), "sumScoresX10", Math.round(entry.score * 10)),
+    redis.hset(STATS_KEY(userId), { lastScoreAt: entry.timestamp }),
+  ];
+  await Promise.all(ops);
+
+  // Update bestScore only if the new score beats the current best.
+  const currentBestRaw = await redis.hget<number | string>(
+    STATS_KEY(userId),
+    "bestScore",
+  );
+  const currentBest =
+    typeof currentBestRaw === "number"
+      ? currentBestRaw
+      : parseFloat(String(currentBestRaw ?? "0"));
+  if (!Number.isFinite(currentBest) || entry.score > currentBest) {
+    await redis.hset(STATS_KEY(userId), { bestScore: entry.score });
+  }
+
+  // Materialize the leaderboard zsets for fast read later. Best-effort.
+  try {
+    const stats = await getUserStats(userId);
+    if (stats.avgScore !== null) {
+      await redis.zadd(LEADERBOARD_AVG, {
+        score: stats.avgScore,
+        member: userId,
+      });
+    }
+    await redis.zadd(LEADERBOARD_SCANS, {
+      score: stats.totalScans,
+      member: userId,
+    });
+  } catch {
+    // never fail a persist over leaderboard maintenance
+  }
+
+  return entry;
+}
+
+/** Read the user's aggregate stats for dashboard display. */
+export async function getUserStats(userId: string): Promise<UserStats> {
+  const hash = await redis.hgetall<Record<string, string | number>>(
+    STATS_KEY(userId),
+  );
+  if (!hash) {
+    return {
+      totalScans: 0,
+      avgScore: null,
+      bestScore: null,
+      lastScoreAt: null,
+    };
+  }
+  const totalScans = toInt(hash.totalScans) ?? 0;
+  const sumScoresX10 = toInt(hash.sumScoresX10) ?? 0;
+  const bestScore = toNum(hash.bestScore);
+  const lastScoreAt = toInt(hash.lastScoreAt);
+  const avgScore =
+    totalScans > 0
+      ? Math.round((sumScoresX10 / totalScans) * 10) / 100 // /10 to undo, then 1-decimal
+      : null;
+  return {
+    totalScans,
+    avgScore,
+    bestScore,
+    lastScoreAt,
+  };
+}
+
+function toInt(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : parseInt(String(v), 10);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = typeof v === "number" ? v : parseFloat(String(v));
+  return Number.isFinite(n) ? n : null;
+}


### PR DESCRIPTION
## Summary
Tracks scoring as a journey, not a one-shot. Same screen scored twice → dashboard shows the delta. Aggregate per-user stats land for future grading / graphs / team reports / leaderboards.

## Changes

### Backend
- **\`src/lib/scores.ts\`** (new) — single source of truth for persisting a score:
  - canonical \`screenKey\` (\`source::normalized-name\`) for "same screen across scans"
  - looks up previous score for that screen, computes \`uplift\` (rounded to 1 decimal)
  - writes user:{id}:scores zset, user:{id}:lastscore:{screenKey}, user:{id}:stats hash
  - materializes leaderboard:global:avg and leaderboard:global:scans zsets
- **All three persist paths** (web / Skill / Figma plugin) now route through \`persistScoreEntry\`.
- **\`/api/dashboard\`** returns \`stats\` (totalScans, avgScore, bestScore, lastScoreAt) alongside scores.

### UI
- New 3-up summary card on the dashboard (Total scans / Average / Best).
- Score row shows an \`UpliftBadge\` (↑+0.4 green / ↓-0.2 red / ±0.0 muted) under the label when \`entry.uplift\` is present.
- First scan of any screen has no uplift — badge just hides.

## Backwards compatibility
- Old score entries don't have \`uplift\`/\`previousScore\` — UI handles their absence by not rendering the badge.
- \`screenKey\` is computed at write time, so old entries don't have one and won't match new scans of the "same" screen until they're scored again.

## Out of scope (future PRs)
- Team leaderboard / manager dashboard surfaces.
- Public global leaderboard page.
- Trend graphs (data is there, UI to come).
- Drill-down view: click a score → see all prior scores of that screen.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Dashboard page compiles, renders without error
- [ ] Score the same screen twice from web — second score shows uplift badge
- [ ] Score from Figma plugin twice on the same frame — same uplift behavior
- [ ] Stats card populates with real numbers as you scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)