### PR TITLE
Branded /login + /sign-up

### DIFF
--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -1,40 +1,34 @@
-import { SignIn } from "@clerk/nextjs";
+import { SignUp } from "@clerk/nextjs";
 import Link from "next/link";
 import type { Metadata } from "next";
 import { AuthShell } from "@/components/AuthShell";
 import { authAppearance } from "@/lib/clerkAuthAppearance";
 
 export const metadata: Metadata = {
-  title: "Log in | Ladder",
-  description: "Sign in to your Ladder account.",
+  title: "Sign up | Ladder",
+  description: "Create your Ladder account and start scoring.",
 };
 
-export default function LoginPage() {
+export default function SignUpPage() {
   return (
     <AuthShell
-      title="Welcome back"
-      subtitle={
-        <>
-          Sign in to your Ladder account
-          <br />
-          to keep scoring.
-        </>
-      }
+      title="Start scoring"
+      subtitle="Create a free account to score any screen against the Ladder framework."
       footer={
         <>
-          New here?{" "}
+          Already have an account?{" "}
           <Link
-            href="/sign-up"
+            href="/login"
             className="text-ladder-green hover:text-ladder-green/80 font-medium"
           >
-            Create an account
+            Log in
           </Link>
         </>
       }
     >
-      <SignIn
+      <SignUp
         routing="hash"
-        signUpUrl="/sign-up"
+        signInUrl="/login"
         fallbackRedirectUrl="/score"
         appearance={authAppearance}
       />

--- a/src/components/AuthShell.tsx
+++ b/src/components/AuthShell.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link";
+import { LadderLogo } from "./LadderLogo";
+
+export function AuthShell({
+  title,
+  subtitle,
+  children,
+  footer,
+}: {
+  title: string;
+  subtitle: React.ReactNode;
+  children: React.ReactNode;
+  footer: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center px-6 pt-28 pb-16 relative overflow-hidden">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            "radial-gradient(ellipse at 50% 0%, rgba(106, 200, 155, 0.06) 0%, transparent 55%)",
+        }}
+      />
+      <div className="relative w-full max-w-[26rem] flex flex-col items-center">
+        <Link href="/" aria-label="Ladder home" className="mb-10">
+          <LadderLogo height={26} className="text-white" />
+        </Link>
+        <h1 className="text-3xl font-semibold text-foreground tracking-tight text-center mb-3">
+          {title}
+        </h1>
+        <p className="text-body text-base text-center mb-10 max-w-[22rem]">
+          {subtitle}
+        </p>
+        <div className="w-full">{children}</div>
+        <div className="text-muted text-sm text-center mt-8">{footer}</div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -1,6 +1,4 @@
-import type { Appearance } from "@clerk/types";
-
-export const authAppearance: Appearance = {
+export const authAppearance = {
   variables: {
     colorPrimary: "#6AC89B",
     colorTextOnPrimaryBackground: "#1a1a1a",

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -1,0 +1,60 @@
+import type { Appearance } from "@clerk/types";
+
+export const authAppearance: Appearance = {
+  variables: {
+    colorPrimary: "#6AC89B",
+    colorTextOnPrimaryBackground: "#1a1a1a",
+    colorBackground: "transparent",
+    colorInputBackground: "#2a2a2a",
+    colorInputText: "#ffffff",
+    colorText: "#ffffff",
+    colorTextSecondary: "#B8B8B8",
+    colorNeutral: "#ffffff",
+    colorDanger: "#ef4444",
+    borderRadius: "0.75rem",
+    fontFamily: "var(--font-inter), Inter, sans-serif",
+    fontSize: "0.875rem",
+  },
+  elements: {
+    rootBox: "!w-full !max-w-none",
+    cardBox: "!w-full !max-w-none !shadow-none !border-0",
+    card: "!bg-transparent !border-0 !shadow-none !p-0 !w-full",
+    header: "!hidden",
+    headerTitle: "!hidden",
+    headerSubtitle: "!hidden",
+    main: "!gap-4",
+    socialButtons: "!gap-2",
+    socialButtonsBlockButton:
+      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !py-3 !shadow-none",
+    socialButtonsBlockButtonText: "!text-foreground !font-medium !text-sm",
+    socialButtonsProviderIcon: "!w-4 !h-4",
+    dividerLine: "!bg-border",
+    dividerText: "!text-muted !text-xs !uppercase !tracking-wider",
+    formFieldLabel:
+      "!text-body !text-xs !uppercase !tracking-wider !mb-2 !font-medium",
+    formFieldInput:
+      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green !ring-0 !px-4 !py-3 !text-sm placeholder:!text-muted",
+    formButtonPrimary:
+      "!bg-ladder-green hover:!bg-[#5ab88b] !text-black !font-semibold !rounded-full !normal-case !text-sm !py-3 !shadow-none !border-0 [&_*]:!text-black",
+    formFieldAction: "!text-ladder-green hover:!text-[#5ab88b] !text-xs",
+    formFieldInputShowPasswordButton: "!text-muted hover:!text-foreground",
+    formResendCodeLink: "!text-ladder-green hover:!text-[#5ab88b]",
+    identityPreview:
+      "!bg-card !border !border-border !rounded-lg !text-foreground",
+    identityPreviewText: "!text-foreground !text-sm",
+    identityPreviewEditButton: "!text-ladder-green hover:!text-[#5ab88b]",
+    otpCodeFieldInput:
+      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green",
+    alternativeMethodsBlockButton:
+      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !text-sm !py-3",
+    alternativeMethodsBlockButtonText: "!text-foreground !font-medium",
+    alternativeMethodsBlockButtonArrow: "!text-foreground",
+    backLink: "!text-ladder-green hover:!text-[#5ab88b]",
+    footer: "!hidden",
+    footerAction: "!hidden",
+    footerActionText: "!hidden",
+    footerActionLink: "!hidden",
+    badge:
+      "!bg-ladder-green/10 !text-ladder-green !border !border-ladder-green/20",
+  },
+};


### PR DESCRIPTION
## Summary
- Replace bare Clerk SignIn widget on /login with a branded shell (Ladder logo, headline, subhead, footer link)
- Add matching /sign-up route so the Nav's "Sign up to score" CTA no longer 404s
- Shared `AuthShell` component for layout; shared `authAppearance` config to theme Clerk surfaces in Ladder's palette (dark, transparent card, green pill primary with pure-black text, Inter type)

## Test plan
- [ ] Visit /login on Vercel preview — confirm Ladder logo, "Welcome back" headline, two-line subhead, themed Continue button
- [ ] Visit /sign-up on preview — confirm matching "Start scoring" headline + working email/Google flow
- [ ] Click "Sign up to score" in Nav — confirm it lands on /sign-up
- [ ] Check mobile (375px) — confirm form sizes correctly
- [ ] Once Clerk Dashboard email-link/email-code toggles propagate to Production, verify magic-link and OTP alternative methods appear after entering an email

🤖 Generated with [Claude Code](https://claude.com/claude-code)