### PR TITLE
Auth pages: forceRedirectUrl to fix Clerk redirect loop

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -35,7 +35,7 @@ export default function LoginPage() {
       <SignIn
         routing="hash"
         signUpUrl="/sign-up"
-        fallbackRedirectUrl="/score"
+        forceRedirectUrl="/score"
         appearance={authAppearance}
       />
     </AuthShell>

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -29,7 +29,7 @@ export default function SignUpPage() {
       <SignUp
         routing="hash"
         signInUrl="/login"
-        fallbackRedirectUrl="/score"
+        forceRedirectUrl="/score"
         appearance={authAppearance}
       />
     </AuthShell>


### PR DESCRIPTION
## Summary
Switches \`<SignIn>\` and \`<SignUp>\` from \`fallbackRedirectUrl=\"/score\"\` to \`forceRedirectUrl=\"/score\"\`.

## Why
Reported in production: visiting \`/login\` directly worked, but signing in could land on a corrupted URL like:

\`\`\`
/login#/factor-one?redirect_url=…%2Flogin%23%2Ffactor-one%3Fredirect_url%3D…%2F
\`\`\`

with the \`redirect_url\` nested into itself. The form then renders blank because Clerk is trying to honor a malformed redirect target. \`fallbackRedirectUrl\` only applies if no \`redirect_url\` param is present, so Clerk's own self-appended param (which can chain onto itself across refreshes / factor-one transitions) wins.

\`forceRedirectUrl\` ignores the URL param and always sends authenticated users to \`/score\`. No reason to honor an external \`redirect_url\` for our flow — there's only one place we ever want sign-in to land.

## Test plan
- [ ] Hit https://runladder.com/login normally → sign in → lands on /score
- [ ] Hit https://runladder.com/login?redirect_url=https://evil.example.com → sign in → lands on /score (not the attacker URL)
- [ ] Hit https://runladder.com/login#/factor-one?redirect_url=… (loop URL) → form should still render and complete sign-in
- [ ] Same for /sign-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)