### PR TITLE
Auth pages: fix blank factor-one + visual polish

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -51,28 +51,22 @@ export default function RootLayout({
           colorInputText: "#e5e5e5",
           colorNeutral: "#e5e5e5",
           colorDanger: "#ef4444",
-          borderRadius: "0px",
-          fontFamily: "Inter, sans-serif",
+          fontFamily: "var(--font-inter), Inter, sans-serif",
         },
-        elements: {
-          card: "bg-[#111] border border-[#2a2a2a] shadow-none rounded-none",
-          socialButtonsBlockButton: "bg-[#1a1a1a] border-[#2a2a2a] text-[#e5e5e5] hover:bg-[#222] rounded-none",
-          socialButtonsBlockButtonText: "text-[#e5e5e5] font-medium",
-          formFieldInput: "bg-[#1a1a1a] border-[#2a2a2a] text-[#e5e5e5] rounded-none focus:border-[#6AC89B] focus:ring-0",
-          formFieldLabel: "text-[#777]",
-          formButtonPrimary: "bg-[#6AC89B] hover:bg-[#5ab88b] text-[#111] font-semibold rounded-none",
-          headerTitle: "text-[#e5e5e5] font-bold",
-          headerSubtitle: "text-[#777]",
-          dividerLine: "bg-[#2a2a2a]",
-          dividerText: "text-[#555]",
-          footerActionLink: "text-[#6AC89B] hover:text-[#5ab88b]",
-          footerActionText: "text-[#555]",
-          identityPreviewEditButton: "text-[#6AC89B]",
-          identityPreviewText: "text-[#e5e5e5]",
-          formFieldInputShowPasswordButton: "text-[#777] hover:text-[#e5e5e5]",
-          otpCodeFieldInput: "bg-[#1a1a1a] border-[#2a2a2a] text-[#e5e5e5]",
-          alternativeMethodsBlockButton: "bg-[#1a1a1a] border-[#2a2a2a] text-[#e5e5e5] hover:bg-[#222] rounded-none",
-          badge: "bg-[#6AC89B]/10 text-[#6AC89B] border-[#6AC89B]/20",
+      }}
+      localization={{
+        signIn: {
+          start: {
+            title: "Welcome back",
+            subtitle: "Sign in to your Ladder account to keep scoring.",
+          },
+        },
+        signUp: {
+          start: {
+            title: "Start scoring",
+            subtitle:
+              "Create a free account to score any screen against the Ladder framework.",
+          },
         },
       }}
     >

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -12,14 +12,6 @@ export const metadata: Metadata = {
 export default function LoginPage() {
   return (
     <AuthShell
-      title="Welcome back"
-      subtitle={
-        <>
-          Sign in to your Ladder account
-          <br />
-          to keep scoring.
-        </>
-      }
       footer={
         <>
           New here?{" "}

--- a/src/app/sign-up/page.tsx
+++ b/src/app/sign-up/page.tsx
@@ -12,8 +12,6 @@ export const metadata: Metadata = {
 export default function SignUpPage() {
   return (
     <AuthShell
-      title="Start scoring"
-      subtitle="Create a free account to score any screen against the Ladder framework."
       footer={
         <>
           Already have an account?{" "}

--- a/src/components/AuthShell.tsx
+++ b/src/components/AuthShell.tsx
@@ -2,13 +2,9 @@ import Link from "next/link";
 import { LadderLogo } from "./LadderLogo";
 
 export function AuthShell({
-  title,
-  subtitle,
   children,
   footer,
 }: {
-  title: string;
-  subtitle: React.ReactNode;
   children: React.ReactNode;
   footer: React.ReactNode;
 }) {
@@ -26,12 +22,6 @@ export function AuthShell({
         <Link href="/" aria-label="Ladder home" className="mb-10">
           <LadderLogo height={26} className="text-white" />
         </Link>
-        <h1 className="text-3xl font-semibold text-foreground tracking-tight text-center mb-3">
-          {title}
-        </h1>
-        <p className="text-body text-base text-center mb-10 max-w-[22rem]">
-          {subtitle}
-        </p>
         <div className="w-full">{children}</div>
         <div className="text-muted text-sm text-center mt-8">{footer}</div>
       </div>

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -17,13 +17,14 @@ export const authAppearance = {
     rootBox: "!w-full !max-w-none",
     cardBox: "!w-full !max-w-none !shadow-none !border-0",
     card: "!bg-transparent !border-0 !shadow-none !p-0 !w-full",
-    header: "!hidden",
-    headerTitle: "!hidden",
-    headerSubtitle: "!hidden",
+    header: "!text-center !mb-2",
+    headerTitle:
+      "!text-foreground !text-2xl !font-semibold !tracking-tight !text-center",
+    headerSubtitle: "!text-body !text-sm !text-center !mt-2",
     main: "!gap-4",
     socialButtons: "!gap-2",
     socialButtonsBlockButton:
-      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !py-3 !shadow-none",
+      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !py-3 !shadow-none !overflow-hidden !relative",
     socialButtonsBlockButtonText: "!text-foreground !font-medium !text-sm",
     socialButtonsProviderIcon: "!w-4 !h-4",
     dividerLine: "!bg-border",


### PR DESCRIPTION
## Summary

After clicking Continue on /login (or /sign-up), the page went **blank** — entire factor-one step (password / magic link / verification code) failed to render. Bug found in production.

**Root cause:** [clerkAuthAppearance.ts](src/lib/clerkAuthAppearance.ts) was hiding Clerk's entire `header` element. On the initial step that was harmless (AuthShell rendered our brand title). But on factor-one, Clerk uses the header to deliver step-specific copy — "Check your email", "Enter your password", magic-link instructions, the identity preview. Hiding it wiped the entire next step.

## What changed

- **Move brand copy into Clerk localization** at the `ClerkProvider` level so Clerk's own header carries it on every step:
  - `signIn.start` → "Welcome back" / "Sign in to your Ladder account to keep scoring."
  - `signUp.start` → "Start scoring" / "Create a free account to score any screen against the Ladder framework."
- **AuthShell** drops `title` / `subtitle` props — now just brand frame (logo, gradient, footer link).
- **clerkAuthAppearance** unhides `header` and styles `headerTitle` / `headerSubtitle` to match Ladder type.
- **layout.tsx** sheds legacy provider-level Clerk element overrides that fought the auth page styling (had `rounded-none` against our pill design, duplicate header CSS).
- **Last-used badge polish:** added `!overflow-hidden` + `!relative` to `socialButtonsBlockButton` so the Clerk-rendered "Last used" tag gets clipped to the pill instead of leaking out the edge.

## Test plan

- [x] /login renders "Welcome back" + correct subtitle
- [x] /sign-up renders "Start scoring" + correct subtitle
- [x] Submitting an email on /login no longer produces a blank page — factor-one content renders
- [x] No duplicate footer (AuthShell footer + Clerk default)
- [x] Continue button keeps Ladder green pill
- [ ] **Production smoke:** confirm magic-link email flow renders properly after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)