### PR TITLE
Login: redirect to /dashboard, not /score

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
       <SignIn
         routing="hash"
         signUpUrl="/sign-up"
-        forceRedirectUrl="/score"
+        forceRedirectUrl="/dashboard"
         appearance={authAppearance}
       />
     </AuthShell>


### PR DESCRIPTION
## Summary
- Login's \`forceRedirectUrl\` was \`/score\` (public scoring tool). Returning users should land on \`/dashboard\` where their scores, stats, and team views live.
- Sign-up keeps \`forceRedirectUrl="/score"\` — new users have no dashboard content yet, so dropping them straight into the value-add flow makes more sense.

## Test plan
- [ ] Sign in at /login with a real account → land on /dashboard
- [ ] /sign-up flow still lands on /score

🤖 Generated with [Claude Code](https://claude.com/claude-code)