### PR TITLE
Teams + Pricing: park unbuilt features (DS compliance, SSO, API allotments)

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -73,15 +73,12 @@ const SCREEN_SCORE_TIERS: ScreenTier[] = [
     price: "Custom",
     period: "",
     highlight: false,
-    limit: "Unlimited + 25,000 API pooled / mo",
+    limit: "Unlimited",
     features: [
       "Everything in Professional",
-      "25,000 pooled API calls per month, overage at $0.25 per call",
       "Team leaderboard + portfolio score",
-      "Design system compliance scoring",
       "Manager dashboard + performance tracking",
-      "SSO and advanced access controls",
-      "Access to customer sentiment and Ladder Pulse scoring data + insights, if subscribed",
+      "Access to customer sentiment and Ladder Pulse scoring data + insights, if subscribed (coming soon)",
     ],
     cta: "Talk to us about Ladder",
     href: "/contact",
@@ -271,12 +268,7 @@ export default async function PricingPage() {
             </div>
             <div className="mb-6" />
 
-            {/* Usage limit */}
-            <div className="border border-ladder-purple/30 rounded-lg px-4 py-3 mb-8">
-              <p className="font-mono text-xs text-ladder-purple">
-                50,000 queries / month
-              </p>
-            </div>
+            <div className="mb-8" />
 
             {/* Features */}
             <ul className="space-y-3 mb-10 flex-1">
@@ -285,8 +277,6 @@ export default async function PricingPage() {
                 "Field reports and internal ops signals",
                 "Custom bespoke dashboards and interfaces",
                 "Real-time tracking and alerting",
-                "50,000 queries per month, overage at $0.15 per query",
-                "Bundle with Team for pooled usage across all Ladder surfaces",
                 "Dedicated onboarding and support",
               ].map((f) => (
                 <li key={f} className="text-sm text-body flex items-start gap-2.5">
@@ -389,11 +379,11 @@ export default async function PricingPage() {
               },
               {
                 q: "How does Team seat pricing work?",
-                a: "Team pricing is custom and requires a contract. It includes up to 5 team members with additional seats available, 25,000 pooled API calls per month, SSO, team leaderboards, compliance scoring, and manager dashboards. Contact us for details.",
+                a: "Team pricing is custom and requires a contract. It includes up to 5 team members with additional seats available, team leaderboards, and manager dashboards. Contact us for details.",
               },
               {
                 q: "What\u2019s the difference between Screen Score and Pulse?",
-                a: "Screen Score analyzes individual screens and interfaces for visual and UX quality. Pulse measures experience quality at scale by ingesting customer feedback, reviews, support transcripts, and internal signals into a single Ladder score. Pulse includes 50,000 queries per month with overage at $0.15 per query.",
+                a: "Screen Score analyzes individual screens and interfaces for visual and UX quality. Pulse measures experience quality at scale by ingesting customer feedback, reviews, support transcripts, and internal signals into a single Ladder score.",
               },
               {
                 q: "What is Enterprise?",

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -24,11 +24,6 @@ const CAPABILITIES = [
     detail: "Custom rules, weighted priorities, team-specific quality definitions",
   },
   {
-    name: "Design System Compliance",
-    desc: "Connect your design system. Ladder checks every screen against your tokens, components, and patterns, then tells designers exactly where they drifted.",
-    detail: "Token validation, component coverage, drift detection",
-  },
-  {
     name: "Custom Rubric Weights",
     desc: "Care more about accessibility than visual polish? Prioritize information hierarchy over delight? Adjust the scoring weights. The Ladder score reflects your team's priorities.",
     detail: "Dimension weighting, category emphasis, scoring calibration",
@@ -43,7 +38,7 @@ const CAPABILITIES = [
 const WHAT_CHANGES = [
   {
     before: "Designers score in isolation",
-    after: "Every score factors in your brand standards, leadership lens, and design system automatically",
+    after: "Every score factors in your brand standards and leadership lens automatically",
   },
   {
     before: "Quality is subjective across the team",
@@ -52,10 +47,6 @@ const WHAT_CHANGES = [
   {
     before: "You find out about quality problems at review time",
     after: "Dashboard shows drift in real time. Intervene early, not late",
-  },
-  {
-    before: "Design system compliance is a manual audit",
-    after: "Every score includes a compliance check against your tokens and components",
   },
   {
     before: "No way to measure team improvement over time",
@@ -72,7 +63,6 @@ const TIER = {
     "Add and manage up to ten designers",
     "Team knowledge base (brand standards + leadership lens)",
     "Per-designer scores, trends, and leaderboard",
-    "Design system compliance scoring",
     "Unlimited scores on all surfaces (web and Claude)",
     "Priority support",
   ],
@@ -93,9 +83,9 @@ export default function TeamsPage() {
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto mb-12 leading-relaxed">
             Load your brand standards, encode your design leadership's
-            priorities, connect your design system, and every Ladder score
-            your team runs reflects what quality means to{" "}
-            <em>your</em> organization. Not generic. Yours.
+            priorities, and every Ladder score your team runs reflects
+            what quality means to <em>your</em> organization. Not generic.
+            Yours.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link
@@ -141,7 +131,7 @@ export default function TeamsPage() {
               doesn't just tell a designer &ldquo;this screen is a
               2.4.&rdquo; It tells them &ldquo;this screen is a 2.4
               because it violates your brand's density principles and
-              drifts from your design system's spacing tokens.&rdquo;
+              the back-path rule your VP of Design set.&rdquo;
             </p>
             <p className="text-foreground font-medium">
               Teams turns Ladder from a universal quality score into your
@@ -254,10 +244,10 @@ export default function TeamsPage() {
             </p>
             <p>
               The difference: behind the scenes, their score now factors
-              in your brand standards, your leadership's priorities, and
-              your design system. The coaching cards don't just say
-              &ldquo;improve spacing.&rdquo; They say &ldquo;your 12px
-              gap doesn't match your system's 16px base unit.&rdquo;
+              in your brand standards and your leadership's priorities.
+              The coaching cards don't just say &ldquo;improve
+              spacing.&rdquo; They say &ldquo;your hierarchy buries the
+              primary action your team agreed should always lead.&rdquo;
             </p>
             <p className="text-foreground font-medium">
               Zero onboarding friction. Every designer gets your team's
@@ -458,9 +448,9 @@ export default function TeamsPage() {
             <span className="text-ladder-green">your team's DNA.</span>
           </h2>
           <p className="text-body mb-10 leading-relaxed max-w-lg mx-auto">
-            Your brand standards. Your leadership's priorities. Your
-            design system. Baked into every score, every coaching card,
-            every designer's workflow. From day one.
+            Your brand standards. Your leadership's priorities. Baked
+            into every score, every coaching card, every designer's
+            workflow. From day one.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link


### PR DESCRIPTION
## Summary

Removes claims about features that aren't built yet so the marketing pages match what we actually ship.

**Teams page (/teams):**
- Removed the "Design System Compliance" capability card and all associated copy (hero subhead, gap quote example, designers-experience example, CTA list)
- Removed the "Design system compliance scoring" bullet from the Teams pricing card on this page
- Removed the "compliance check against tokens and components" before/after pair
- Brand Standards and Leadership Lens capabilities stay — those score through real Teams paths

**Pricing page (/pricing):**
- Team tier features: dropped "SSO and advanced access controls", "Design system compliance scoring", and the "25,000 pooled API calls per month" line
- Team tier limit chip: "Unlimited + 25,000 API pooled / mo" → "Unlimited"
- Last Team bullet (Pulse data access) gets a `(coming soon)` suffix
- Pulse tier: removed the "50,000 queries / month" limit chip, the matching feature line, and "Bundle with Team for pooled usage"
- FAQ: trimmed SSO, compliance scoring, pooled API, and per-month query mentions from the Team and Pulse answers

Enterprise SSO mentions are kept — Enterprise has real SSO and Ward's removal scope was Team-specific.

## Notes for future

The full pricing offering (API allotments, overage rates) remains in `memory/project_pricing_floors.md`. When the API surface is ready to talk about, the surfaces to revert here are documented in that memory.

## Test plan

- [ ] Visit /teams — no "Design System Compliance" copy anywhere except the one factual mention "You have a design system." in The Problem section
- [ ] Visit /pricing — Team card has 4 bullets ending with "...if subscribed (coming soon)", limit chip reads "Unlimited"
- [ ] Pulse card has no usage chip and no API/query feature lines
- [ ] FAQ "How does Team seat pricing work?" mentions only seats, leaderboards, manager dashboards
- [ ] FAQ "What's the difference between Screen Score and Pulse?" no longer ends with the queries-per-month line

🤖 Generated with [Claude Code](https://claude.com/claude-code)