### PR TITLE
Teams MVP: admin provisioning, leader dashboard, invites, score wiring

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -362,6 +362,12 @@ export default function AdminPage() {
           </div>
           <div className="flex items-center gap-4">
             <Link
+              href="/admin/teams"
+              className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
+            >
+              Teams
+            </Link>
+            <Link
               href="/admin/comps"
               className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
             >

--- a/src/app/admin/teams/page.tsx
+++ b/src/app/admin/teams/page.tsx
@@ -27,6 +27,21 @@ type TeamSummary = {
   billing: BillingSummary;
 };
 
+type MemberDetail = {
+  userId: string;
+  role: "admin" | "member";
+  status: "active" | "paused" | "archived";
+  joinedAt: number;
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+type TeamDetail = {
+  team: TeamSummary & { usage: number };
+  members: MemberDetail[];
+};
+
 function fmtDate(ts: number): string {
   if (!ts) return "—";
   return new Date(ts).toLocaleDateString(undefined, {
@@ -81,6 +96,10 @@ export default function AdminTeamsPage() {
     overagePrice: string;
   } | null>(null);
   const [savingId, setSavingId] = useState<string | null>(null);
+
+  // Detail (members + usage) fetched when a row expands
+  const [detail, setDetail] = useState<TeamDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
 
   async function refresh() {
     setLoading(true);
@@ -138,7 +157,7 @@ export default function AdminTeamsPage() {
     }
   }
 
-  function startEdit(team: TeamSummary) {
+  async function startEdit(team: TeamSummary) {
     setEditingId(team.id);
     setEditFields({
       name: team.name,
@@ -147,11 +166,30 @@ export default function AdminTeamsPage() {
       queryPool: String(team.queryPool),
       overagePrice: String(team.perOverageSeatPrice),
     });
+    setDetail(null);
+    setDetailLoading(true);
+    try {
+      const res = await fetch(`/api/admin/teams/${team.id}`);
+      if (res.ok) {
+        const json = (await res.json()) as TeamDetail;
+        setDetail(json);
+      }
+    } catch {
+      // Silent: the edit form still works, members list just won't show.
+    } finally {
+      setDetailLoading(false);
+    }
   }
 
   function cancelEdit() {
     setEditingId(null);
     setEditFields(null);
+    setDetail(null);
+  }
+
+  function displayName(m: MemberDetail): string {
+    const full = [m.firstName, m.lastName].filter(Boolean).join(" ").trim();
+    return full || m.email || m.userId;
   }
 
   async function saveEdit(teamId: string) {
@@ -497,6 +535,83 @@ export default function AdminTeamsPage() {
                                     Cancel
                                   </button>
                                 </div>
+                              </div>
+
+                              {/* ── Members ────────────────────────── */}
+                              <div className="mt-8 pt-6 border-t border-[#2a2a2a]">
+                                <div className="flex items-baseline justify-between mb-3">
+                                  <span className="text-[10px] text-muted uppercase tracking-widest">
+                                    Members
+                                  </span>
+                                  <span className="text-[10px] text-muted">
+                                    {detailLoading
+                                      ? "Loading…"
+                                      : detail
+                                        ? `${detail.members.length} total`
+                                        : ""}
+                                  </span>
+                                </div>
+                                {detailLoading ? (
+                                  <div className="text-xs text-muted font-sans py-4">
+                                    Loading members…
+                                  </div>
+                                ) : !detail || detail.members.length === 0 ? (
+                                  <div className="text-xs text-muted font-sans py-4">
+                                    No members yet.
+                                  </div>
+                                ) : (
+                                  <div className="border border-[#2a2a2a] bg-[#111]">
+                                    {detail.members.map((m) => {
+                                      const isOwner =
+                                        m.userId === t.ownerUserId;
+                                      const statusCls =
+                                        m.status === "active"
+                                          ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+                                          : m.status === "paused"
+                                            ? "text-ladder-orange border-ladder-orange/40 bg-ladder-orange/5"
+                                            : "text-muted border-[#333] bg-[#1a1a1a]";
+                                      return (
+                                        <div
+                                          key={m.userId}
+                                          className="border-b border-[#222] last:border-0 p-3 flex items-center gap-4 flex-wrap"
+                                        >
+                                          <div className="flex-1 min-w-0">
+                                            <div className="text-xs text-foreground font-sans truncate">
+                                              {displayName(m)}
+                                              {isOwner && (
+                                                <span className="text-[9px] text-ladder-green uppercase tracking-widest ml-2">
+                                                  owner
+                                                </span>
+                                              )}
+                                            </div>
+                                            {m.email && (
+                                              <div className="text-[10px] text-muted mt-0.5">
+                                                {m.email}
+                                              </div>
+                                            )}
+                                          </div>
+                                          <span
+                                            className={`text-[9px] uppercase tracking-widest border px-2 py-0.5 ${
+                                              m.role === "admin"
+                                                ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+                                                : "text-muted border-[#333] bg-[#1a1a1a]"
+                                            }`}
+                                          >
+                                            {m.role}
+                                          </span>
+                                          <span
+                                            className={`text-[9px] uppercase tracking-widest border px-2 py-0.5 ${statusCls}`}
+                                          >
+                                            {m.status}
+                                          </span>
+                                          <span className="text-[10px] text-muted tabular-nums">
+                                            {fmtDate(m.joinedAt)}
+                                          </span>
+                                        </div>
+                                      );
+                                    })}
+                                  </div>
+                                )}
                               </div>
                             </td>
                           </tr>

--- a/src/app/admin/teams/page.tsx
+++ b/src/app/admin/teams/page.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+import { Fragment, useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
+
+type BillingSummary = {
+  active: number;
+  paused: number;
+  archived: number;
+  included: number;
+  overageSeats: number;
+  overagePrice: number;
+};
+
+type TeamSummary = {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  ownerEmail: string | null;
+  status: "active" | "paused" | "archived";
+  seatCap: number;
+  perOverageSeatPrice: number;
+  queryPool: number;
+  createdAt: number;
+  updatedAt: number;
+  billing: BillingSummary;
+};
+
+function fmtDate(ts: number): string {
+  if (!ts) return "—";
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function fmtMoney(amount: number): string {
+  return `$${amount.toLocaleString()}`;
+}
+
+function StatusChip({ status }: { status: TeamSummary["status"] }) {
+  const cls =
+    status === "active"
+      ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+      : status === "paused"
+        ? "text-ladder-orange border-ladder-orange/40 bg-ladder-orange/5"
+        : "text-muted border-[#333] bg-[#1a1a1a]";
+  return (
+    <span
+      className={`inline-block text-[9px] uppercase tracking-widest border px-2 py-0.5 ${cls}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function AdminTeamsPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  const [teams, setTeams] = useState<TeamSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Create form
+  const [name, setName] = useState("");
+  const [ownerEmail, setOwnerEmail] = useState("");
+  const [seatCap, setSeatCap] = useState("10");
+  const [queryPool, setQueryPool] = useState("25000");
+  const [overagePrice, setOveragePrice] = useState("250");
+  const [creating, setCreating] = useState(false);
+
+  // Inline edit state (one row at a time)
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editFields, setEditFields] = useState<{
+    name: string;
+    status: TeamSummary["status"];
+    seatCap: string;
+    queryPool: string;
+    overagePrice: string;
+  } | null>(null);
+  const [savingId, setSavingId] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/teams");
+      if (res.status === 403) {
+        setAuthorized(false);
+        return;
+      }
+      setAuthorized(true);
+      if (!res.ok) throw new Error(`Teams fetch ${res.status}`);
+      const json = await res.json();
+      setTeams(json.teams || []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    refresh();
+  }, [isSignedIn]);
+
+  async function createTeam(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/teams", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          ownerEmail: ownerEmail.trim(),
+          seatCap: Number(seatCap) || undefined,
+          queryPool: Number(queryPool) || undefined,
+          perOverageSeatPrice: Number(overagePrice) || undefined,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Create failed (${res.status})`);
+      setName("");
+      setOwnerEmail("");
+      setSeatCap("10");
+      setQueryPool("25000");
+      setOveragePrice("250");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Create failed");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  function startEdit(team: TeamSummary) {
+    setEditingId(team.id);
+    setEditFields({
+      name: team.name,
+      status: team.status,
+      seatCap: String(team.seatCap),
+      queryPool: String(team.queryPool),
+      overagePrice: String(team.perOverageSeatPrice),
+    });
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditFields(null);
+  }
+
+  async function saveEdit(teamId: string) {
+    if (!editFields) return;
+    setSavingId(teamId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/teams/${teamId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: editFields.name,
+          status: editFields.status,
+          seatCap: Number(editFields.seatCap) || 0,
+          queryPool: Number(editFields.queryPool) || 0,
+          perOverageSeatPrice: Number(editFields.overagePrice) || 0,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Save failed (${res.status})`);
+      cancelEdit();
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSavingId(null);
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (authorized === false) {
+    return (
+      <div className="pt-20 max-w-2xl mx-auto px-6 py-20">
+        <h1 className="text-xl font-bold font-sans mb-3">Admin access required</h1>
+        <p className="text-sm text-muted font-sans">
+          Your Clerk account is signed in but not on the admin allowlist.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8 flex items-baseline justify-between">
+          <div>
+            <h1 className="text-xl text-foreground font-sans">Teams</h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              Provision and manage Ladder for Teams accounts
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/admin"
+              className="text-xs font-semibold border border-[#333] text-muted hover:text-foreground hover:border-muted px-4 py-1.5 rounded-sm transition-colors"
+            >
+              ← Admin home
+            </Link>
+            <button
+              onClick={refresh}
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+              disabled={loading}
+            >
+              {loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* ── Create team ────────────────────────────────────────── */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Create new team
+            </span>
+          </div>
+          <form
+            onSubmit={createTeam}
+            className="border border-[#333] bg-[#1e1e1e] p-4 grid grid-cols-1 md:grid-cols-2 gap-4"
+          >
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Team name
+              </label>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Drawbackwards"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Owner email (must already have a Ladder account)
+              </label>
+              <input
+                type="email"
+                required
+                value={ownerEmail}
+                onChange={(e) => setOwnerEmail(e.target.value)}
+                placeholder="ward@drawbackwards.com"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Included seats <span className="text-[#555]">(admin counts as 1)</span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={seatCap}
+                onChange={(e) => setSeatCap(e.target.value)}
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Overage price per seat / mo
+              </label>
+              <input
+                type="number"
+                min={0}
+                value={overagePrice}
+                onChange={(e) => setOveragePrice(e.target.value)}
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Pooled queries / mo
+              </label>
+              <input
+                type="number"
+                min={0}
+                value={queryPool}
+                onChange={(e) => setQueryPool(e.target.value)}
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+              />
+            </div>
+            <div className="flex items-end">
+              <button
+                type="submit"
+                disabled={creating}
+                className="text-xs font-semibold bg-ladder-green text-background px-6 py-2 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+              >
+                {creating ? "Creating…" : "Provision team"}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {/* ── Teams list ─────────────────────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Teams
+            </span>
+            <span className="text-[10px] text-muted">{teams.length} total</span>
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3">Team</th>
+                  <th className="text-left p-3">Owner</th>
+                  <th className="text-left p-3">Status</th>
+                  <th className="text-right p-3">Seats</th>
+                  <th className="text-right p-3">Overage</th>
+                  <th className="text-right p-3">Pool</th>
+                  <th className="text-left p-3">Created</th>
+                  <th className="text-right p-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {teams.length === 0 ? (
+                  <tr>
+                    <td colSpan={8} className="p-6 text-center text-muted font-sans">
+                      {loading ? "Loading…" : "No teams yet."}
+                    </td>
+                  </tr>
+                ) : (
+                  teams.map((t) => {
+                    const editing = editingId === t.id;
+                    return (
+                      <Fragment key={t.id}>
+                        <tr className="border-b border-[#222] hover:bg-[#222]">
+                          <td className="p-3">
+                            <div className="text-foreground">{t.name}</div>
+                            <div className="text-[10px] text-muted tabular-nums">{t.id}</div>
+                          </td>
+                          <td className="p-3 text-muted">
+                            {t.ownerEmail || <span className="text-[#555]">—</span>}
+                          </td>
+                          <td className="p-3">
+                            <StatusChip status={t.status} />
+                          </td>
+                          <td className="p-3 text-right tabular-nums">
+                            <span className="text-foreground">
+                              {t.billing.active}
+                            </span>
+                            <span className="text-muted"> / {t.seatCap}</span>
+                            {t.billing.paused > 0 && (
+                              <div className="text-[9px] text-muted">
+                                {t.billing.paused} paused
+                              </div>
+                            )}
+                          </td>
+                          <td className="p-3 text-right tabular-nums">
+                            {t.billing.overageSeats > 0 ? (
+                              <span className="text-ladder-orange">
+                                +{t.billing.overageSeats} = {fmtMoney(t.billing.overagePrice)}/mo
+                              </span>
+                            ) : (
+                              <span className="text-muted">—</span>
+                            )}
+                          </td>
+                          <td className="p-3 text-right tabular-nums text-muted">
+                            {t.queryPool.toLocaleString()}
+                          </td>
+                          <td className="p-3 text-muted">{fmtDate(t.createdAt)}</td>
+                          <td className="p-3 text-right">
+                            <button
+                              onClick={() => (editing ? cancelEdit() : startEdit(t))}
+                              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+                            >
+                              {editing ? "Cancel" : "Edit"}
+                            </button>
+                          </td>
+                        </tr>
+                        {editing && editFields && (
+                          <tr className="border-b border-[#222] bg-[#161616]">
+                            <td colSpan={8} className="p-5">
+                              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                <div>
+                                  <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                                    Name
+                                  </label>
+                                  <input
+                                    type="text"
+                                    value={editFields.name}
+                                    onChange={(e) =>
+                                      setEditFields({
+                                        ...editFields,
+                                        name: e.target.value,
+                                      })
+                                    }
+                                    className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                                    Status
+                                  </label>
+                                  <select
+                                    value={editFields.status}
+                                    onChange={(e) =>
+                                      setEditFields({
+                                        ...editFields,
+                                        status: e.target.value as TeamSummary["status"],
+                                      })
+                                    }
+                                    className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted"
+                                  >
+                                    <option value="active">active</option>
+                                    <option value="paused">paused</option>
+                                    <option value="archived">archived</option>
+                                  </select>
+                                </div>
+                                <div>
+                                  <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                                    Included seats
+                                  </label>
+                                  <input
+                                    type="number"
+                                    min={1}
+                                    value={editFields.seatCap}
+                                    onChange={(e) =>
+                                      setEditFields({
+                                        ...editFields,
+                                        seatCap: e.target.value,
+                                      })
+                                    }
+                                    className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                                    Overage / seat / mo
+                                  </label>
+                                  <input
+                                    type="number"
+                                    min={0}
+                                    value={editFields.overagePrice}
+                                    onChange={(e) =>
+                                      setEditFields({
+                                        ...editFields,
+                                        overagePrice: e.target.value,
+                                      })
+                                    }
+                                    className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+                                  />
+                                </div>
+                                <div>
+                                  <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                                    Pooled queries / mo
+                                  </label>
+                                  <input
+                                    type="number"
+                                    min={0}
+                                    value={editFields.queryPool}
+                                    onChange={(e) =>
+                                      setEditFields({
+                                        ...editFields,
+                                        queryPool: e.target.value,
+                                      })
+                                    }
+                                    className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted font-sans"
+                                  />
+                                </div>
+                                <div className="flex items-end gap-2">
+                                  <button
+                                    onClick={() => saveEdit(t.id)}
+                                    disabled={savingId === t.id}
+                                    className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+                                  >
+                                    {savingId === t.id ? "Saving…" : "Save"}
+                                  </button>
+                                  <button
+                                    onClick={cancelEdit}
+                                    className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+                                  >
+                                    Cancel
+                                  </button>
+                                </div>
+                              </div>
+                            </td>
+                          </tr>
+                        )}
+                      </Fragment>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/teams/[teamId]/route.ts
+++ b/src/app/api/admin/teams/[teamId]/route.ts
@@ -1,0 +1,167 @@
+/**
+ * Admin single-team detail and update.
+ *
+ * GET    → team metadata, members (with email), billing summary, monthly usage
+ * PATCH  → update name, status, seatCap, perOverageSeatPrice, queryPool
+ *
+ * Gated by the runladder admin email allowlist (getAdminEmail).
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { getAdminEmail } from "@/lib/admin";
+import {
+  getBillingSummary,
+  getTeam,
+  getTeamUsage,
+  listMembers,
+  updateTeam,
+  type Membership,
+  type TeamStatus,
+} from "@/lib/teams";
+
+export const runtime = "nodejs";
+
+type MemberWithEmail = Membership & {
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+async function hydrateMembers(
+  members: Membership[],
+): Promise<MemberWithEmail[]> {
+  if (members.length === 0) return [];
+  const client = await clerkClient();
+  const ids = members.map((m) => m.userId);
+  const users = await client.users.getUserList({
+    userId: ids,
+    limit: Math.max(ids.length, 1),
+  });
+  const byId = new Map(users.data.map((u) => [u.id, u] as const));
+  return members.map((m) => {
+    const u = byId.get(m.userId);
+    return {
+      ...m,
+      email: u?.primaryEmailAddress?.emailAddress ?? null,
+      firstName: u?.firstName ?? null,
+      lastName: u?.lastName ?? null,
+    };
+  });
+}
+
+export async function GET(
+  _req: NextRequest,
+  ctx: { params: Promise<{ teamId: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const { teamId } = await ctx.params;
+  const team = await getTeam(teamId);
+  if (!team) {
+    return NextResponse.json({ error: "Team not found" }, { status: 404 });
+  }
+
+  const [members, billing, usage] = await Promise.all([
+    listMembers(teamId),
+    getBillingSummary(teamId),
+    getTeamUsage(teamId),
+  ]);
+
+  const hydrated = await hydrateMembers(members);
+  const ownerEmail = hydrated.find((m) => m.userId === team.ownerUserId)?.email ?? null;
+
+  return NextResponse.json({
+    team: {
+      ...team,
+      ownerEmail,
+      billing,
+      usage,
+    },
+    members: hydrated,
+  });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  ctx: { params: Promise<{ teamId: string }> },
+) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const { teamId } = await ctx.params;
+  const team = await getTeam(teamId);
+  if (!team) {
+    return NextResponse.json({ error: "Team not found" }, { status: 404 });
+  }
+
+  let body: {
+    name?: string;
+    status?: TeamStatus;
+    seatCap?: number;
+    perOverageSeatPrice?: number;
+    queryPool?: number;
+  } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const patch: Parameters<typeof updateTeam>[1] = {};
+  if (typeof body.name === "string") {
+    const trimmed = body.name.trim();
+    if (!trimmed || trimmed.length > 200) {
+      return NextResponse.json(
+        { error: "Team name must be 1–200 chars" },
+        { status: 400 },
+      );
+    }
+    patch.name = trimmed;
+  }
+  if (
+    body.status === "active" ||
+    body.status === "paused" ||
+    body.status === "archived"
+  ) {
+    patch.status = body.status;
+  }
+  if (typeof body.seatCap === "number" && body.seatCap >= 0) {
+    patch.seatCap = Math.floor(body.seatCap);
+  }
+  if (
+    typeof body.perOverageSeatPrice === "number" &&
+    body.perOverageSeatPrice >= 0
+  ) {
+    patch.perOverageSeatPrice = Math.floor(body.perOverageSeatPrice);
+  }
+  if (typeof body.queryPool === "number" && body.queryPool >= 0) {
+    patch.queryPool = Math.floor(body.queryPool);
+  }
+
+  if (Object.keys(patch).length === 0) {
+    return NextResponse.json({ error: "No valid fields to update" }, { status: 400 });
+  }
+
+  const next = await updateTeam(teamId, patch);
+  if (!next) {
+    return NextResponse.json({ error: "Team not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    team: {
+      ...next,
+      billing: await getBillingSummary(teamId),
+    },
+  });
+}

--- a/src/app/api/admin/teams/route.ts
+++ b/src/app/api/admin/teams/route.ts
@@ -1,0 +1,154 @@
+/**
+ * Admin teams — list and create.
+ *
+ * GET   → list every team plus its billing summary
+ * POST  → provision a new team (name, ownerEmail, optional caps)
+ *
+ * Gated by the runladder admin email allowlist (getAdminEmail). Drawbackwards
+ * uses this to turn on Teams accounts after an MSA closes — Stripe is only
+ * involved for self-serve Pro, never for Teams.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { getAdminEmail } from "@/lib/admin";
+import {
+  createTeam,
+  getBillingSummary,
+  getUserTeamId,
+  listTeams,
+  type BillingSummary,
+  type Team,
+} from "@/lib/teams";
+import { setUserSubscription } from "@/lib/tier";
+
+export const runtime = "nodejs";
+
+type TeamWithSummary = Team & {
+  billing: BillingSummary;
+  ownerEmail: string | null;
+};
+
+async function emailForUser(userId: string): Promise<string | null> {
+  try {
+    const client = await clerkClient();
+    const user = await client.users.getUser(userId);
+    return user.primaryEmailAddress?.emailAddress ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function userIdForEmail(email: string): Promise<string | null> {
+  const client = await clerkClient();
+  const list = await client.users.getUserList({
+    emailAddress: [email.toLowerCase()],
+    limit: 1,
+  });
+  return list.data[0]?.id ?? null;
+}
+
+export async function GET() {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  const teams = await listTeams();
+  const enriched: TeamWithSummary[] = await Promise.all(
+    teams.map(async (t) => ({
+      ...t,
+      billing: await getBillingSummary(t.id),
+      ownerEmail: await emailForUser(t.ownerUserId),
+    })),
+  );
+
+  // Most recently created first.
+  enriched.sort((a, b) => b.createdAt - a.createdAt);
+
+  return NextResponse.json({ teams: enriched });
+}
+
+export async function POST(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403 },
+    );
+  }
+
+  let body: {
+    name?: string;
+    ownerEmail?: string;
+    seatCap?: number;
+    perOverageSeatPrice?: number;
+    queryPool?: number;
+  } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const name = (body.name || "").trim();
+  const ownerEmail = (body.ownerEmail || "").trim().toLowerCase();
+  if (!name || name.length > 200) {
+    return NextResponse.json(
+      { error: "Team name is required (max 200 chars)" },
+      { status: 400 },
+    );
+  }
+  if (!ownerEmail || !ownerEmail.includes("@")) {
+    return NextResponse.json(
+      { error: "Valid owner email is required" },
+      { status: 400 },
+    );
+  }
+
+  const ownerUserId = await userIdForEmail(ownerEmail);
+  if (!ownerUserId) {
+    return NextResponse.json(
+      {
+        error: `No Ladder account found for ${ownerEmail}. Have them sign up first, then create the team.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const existingTeam = await getUserTeamId(ownerUserId);
+  if (existingTeam) {
+    return NextResponse.json(
+      {
+        error: `${ownerEmail} is already on team ${existingTeam}. Remove them first or pick a different owner.`,
+      },
+      { status: 409 },
+    );
+  }
+
+  const team = await createTeam({
+    name,
+    ownerUserId,
+    seatCap: typeof body.seatCap === "number" ? body.seatCap : undefined,
+    perOverageSeatPrice:
+      typeof body.perOverageSeatPrice === "number"
+        ? body.perOverageSeatPrice
+        : undefined,
+    queryPool: typeof body.queryPool === "number" ? body.queryPool : undefined,
+  });
+
+  // Stamp the team tier on the owner so paid-tier checks pass everywhere.
+  // We deliberately do not touch their Stripe IDs — if they had a Pro sub,
+  // it stays in privateMetadata until the admin/owner cancels it manually.
+  await setUserSubscription(ownerUserId, { tier: "team" });
+
+  return NextResponse.json({
+    team: {
+      ...team,
+      billing: await getBillingSummary(team.id),
+      ownerEmail,
+    },
+  });
+}

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -4,6 +4,7 @@ import { redis, lifetimeScansKey } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription } from "@/lib/tier";
 import { getUserStats } from "@/lib/scores";
+import { getMember, getTeam, getUserTeamId } from "@/lib/teams";
 
 export async function GET() {
   const { userId } = await auth();
@@ -12,12 +13,26 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const [scores, used, sub, stats] = await Promise.all([
+  const [scores, used, sub, stats, teamId] = await Promise.all([
     redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true }),
     redis.get<number>(lifetimeScansKey(userId)),
     getUserSubscription(userId),
     getUserStats(userId),
+    getUserTeamId(userId),
   ]);
+
+  // If on a team, resolve the team name + role so the dashboard banner can
+  // show "Member of [Team]" instead of the generic paid banner.
+  let team: { id: string; name: string; role: "admin" | "member" } | null = null;
+  if (teamId) {
+    const [t, membership] = await Promise.all([
+      getTeam(teamId),
+      getMember(teamId, userId),
+    ]);
+    if (t && membership && membership.status !== "archived") {
+      team = { id: t.id, name: t.name, role: membership.role };
+    }
+  }
 
   const parsedScores = (scores as string[]).map((entry) => {
     if (typeof entry === "string") {
@@ -35,6 +50,7 @@ export async function GET() {
     stats,
     tier: sub.tier,
     paid: isPaidTier(sub.tier),
+    team,
     comp: sub.comp
       ? {
           reason: sub.comp.reason,

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,10 +1,15 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { redis, lifetimeScansKey } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription } from "@/lib/tier";
 import { getUserStats } from "@/lib/scores";
-import { getMember, getTeam, getUserTeamId } from "@/lib/teams";
+import {
+  claimPendingTeamInviteForEmails,
+  getMember,
+  getTeam,
+  getUserTeamId,
+} from "@/lib/teams";
 
 export async function GET() {
   const { userId } = await auth();
@@ -12,6 +17,16 @@ export async function GET() {
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
+
+  // Pull the Clerk user up front so we can both auto-claim any pending team
+  // invites that were sent to one of their verified emails, and (later)
+  // surface the right banner without a second Clerk read.
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const emails = user.emailAddresses
+    .map((e) => e.emailAddress?.toLowerCase())
+    .filter((e): e is string => Boolean(e));
+  await claimPendingTeamInviteForEmails(userId, emails);
 
   const [scores, used, sub, stats, teamId] = await Promise.all([
     redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true }),

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -1,0 +1,55 @@
+/**
+ * Lightweight identity endpoint — returns the signed-in user's tier and
+ * team membership (if any). Used by surfaces that need to gate UI on tier
+ * but don't need the full /api/dashboard payload (scores, stats, etc).
+ *
+ * Returns 200 in every case. For anonymous callers, returns
+ * `{ signedIn: false, tier: "free", paid: false, team: null }`.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { isPaidTier } from "@/lib/plans";
+import { getUserSubscription } from "@/lib/tier";
+import { getMember, getTeam, getUserTeamId } from "@/lib/teams";
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const { userId } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({
+      signedIn: false,
+      tier: "free" as const,
+      paid: false,
+      team: null,
+    });
+  }
+
+  const [sub, teamId] = await Promise.all([
+    getUserSubscription(userId),
+    getUserTeamId(userId),
+  ]);
+
+  let team: {
+    id: string;
+    name: string;
+    role: "admin" | "member";
+  } | null = null;
+  if (teamId) {
+    const [t, membership] = await Promise.all([
+      getTeam(teamId),
+      getMember(teamId, userId),
+    ]);
+    if (t && membership && membership.status !== "archived") {
+      team = { id: t.id, name: t.name, role: membership.role };
+    }
+  }
+
+  return NextResponse.json({
+    signedIn: true,
+    tier: sub.tier,
+    paid: isPaidTier(sub.tier),
+    team,
+  });
+}

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -7,10 +7,15 @@
  * `{ signedIn: false, tier: "free", paid: false, team: null }`.
  */
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { isPaidTier } from "@/lib/plans";
 import { getUserSubscription } from "@/lib/tier";
-import { getMember, getTeam, getUserTeamId } from "@/lib/teams";
+import {
+  claimPendingTeamInviteForEmails,
+  getMember,
+  getTeam,
+  getUserTeamId,
+} from "@/lib/teams";
 
 export const runtime = "nodejs";
 
@@ -25,6 +30,16 @@ export async function GET() {
       team: null,
     });
   }
+
+  // Auto-claim any pending team invite sent to one of this user's emails
+  // so the first request after sign-in flips them into team tier even if
+  // they never clicked the magic accept link.
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const emails = user.emailAddresses
+    .map((e) => e.emailAddress?.toLowerCase())
+    .filter((e): e is string => Boolean(e));
+  await claimPendingTeamInviteForEmails(userId, emails);
 
   const [sub, teamId] = await Promise.all([
     getUserSubscription(userId),

--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -4,6 +4,7 @@ import { parseImageDataUrl } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
 import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
+import { recordScoreForTeam } from "@/lib/teams";
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
 
@@ -87,6 +88,20 @@ export async function POST(req: NextRequest) {
       isPublic: !!score.isPublic,
       timestamp: score.timestamp || Date.now(),
     });
+
+    try {
+      await recordScoreForTeam(userId, {
+        timestamp: stored.timestamp,
+        scoreId: stored.id,
+        score: stored.score,
+        label: stored.label,
+        screenName: stored.screenName,
+        source: stored.source,
+        thumbnail: stored.thumbnail,
+      });
+    } catch (err) {
+      console.error("[LADDER:TEAMS] recordScoreForTeam (plugin) failed:", err);
+    }
 
     // Diagnostic log: keep the last 50 persist attempts for 24h so we can
     // verify cross-repo calls land without trawling Vercel logs by hand.

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -10,6 +10,7 @@ import { makeThumbnail } from "@/lib/thumbnail";
 import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
 import { persistScoreEntry } from "@/lib/scores";
+import { getTeamPoolStatus, recordScoreForTeam } from "@/lib/teams";
 
 export const maxDuration = 60;
 
@@ -46,6 +47,19 @@ export async function POST(req: NextRequest) {
             { status: 429 }
           );
         }
+      }
+
+      // Team members also draw from a pooled monthly query allowance.
+      // The pool is shared across the whole team and resets each calendar month.
+      const teamPool = await getTeamPoolStatus(userId);
+      if (teamPool && teamPool.exceeded) {
+        return NextResponse.json(
+          {
+            error: `Your team has used all ${teamPool.pool.toLocaleString()} pooled queries this month. Ask a team admin to raise the cap or wait until the new month.`,
+            poolExceeded: true,
+          },
+          { status: 429 }
+        );
       }
     } else {
       const anonKey = `rate:anon:${ip}`;
@@ -87,8 +101,10 @@ export async function POST(req: NextRequest) {
         parsed.mediaType,
       );
 
+      const scoreId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      const timestamp = Date.now();
       await persistScoreEntry(userId, {
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        id: scoreId,
         score: result.score,
         label: result.label,
         screenName: result.screenName || source || "upload",
@@ -99,8 +115,24 @@ export async function POST(req: NextRequest) {
         source: source || "upload",
         thumbnail,
         isPublic: !!isPublic,
-        timestamp: Date.now(),
+        timestamp,
       });
+
+      // If the scorer is on a team, mirror the score into the team activity
+      // feed and tick the pooled usage. Best-effort — never fail the score.
+      try {
+        await recordScoreForTeam(userId, {
+          timestamp,
+          scoreId,
+          score: result.score,
+          label: result.label,
+          screenName: result.screenName || source || "upload",
+          source: source || "upload",
+          thumbnail,
+        });
+      } catch (err) {
+        console.error("[LADDER:TEAMS] recordScoreForTeam failed:", err);
+      }
     } else {
       const anonKey = `rate:anon:${ip}`;
       await redis.incr(anonKey);

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -10,6 +10,7 @@ import { userIdFromBearer, touchSkillToken } from "@/lib/skill-auth";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
 import { persistScoreEntry } from "@/lib/scores";
+import { getTeamPoolStatus, recordScoreForTeam } from "@/lib/teams";
 
 export const maxDuration = 60;
 
@@ -59,6 +60,19 @@ export async function POST(req: NextRequest) {
       }
     }
 
+    // Team-pooled query cap. Enforced for every member regardless of tier
+    // since paid Pro and Team are both `isPaidTier` true above.
+    const teamPool = await getTeamPoolStatus(userId);
+    if (teamPool && teamPool.exceeded) {
+      return NextResponse.json(
+        {
+          error: `Your team has used all ${teamPool.pool.toLocaleString()} pooled queries this month.`,
+          poolExceeded: true,
+        },
+        { status: 429 }
+      );
+    }
+
     const body = await req.json();
     const { image, source } = body;
 
@@ -87,8 +101,10 @@ export async function POST(req: NextRequest) {
       parsed.mediaType,
     );
 
+    const scoreId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const timestamp = Date.now();
     const scoreEntry = await persistScoreEntry(userId, {
-      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      id: scoreId,
       score: result.score,
       label: result.label,
       screenName: result.screenName || source || "Skill",
@@ -99,9 +115,23 @@ export async function POST(req: NextRequest) {
       source: source || "claude-skill",
       thumbnail,
       isPublic: false,
-      timestamp: Date.now(),
+      timestamp,
     });
     await touchSkillToken(userId, installedVersion);
+
+    try {
+      await recordScoreForTeam(userId, {
+        timestamp,
+        scoreId,
+        score: result.score,
+        label: result.label,
+        screenName: result.screenName || source || "Skill",
+        source: source || "claude-skill",
+        thumbnail,
+      });
+    } catch (err) {
+      console.error("[LADDER:TEAMS] recordScoreForTeam (skill) failed:", err);
+    }
 
     return NextResponse.json({
       score: result.score,

--- a/src/app/api/team/accept/route.ts
+++ b/src/app/api/team/accept/route.ts
@@ -1,0 +1,92 @@
+/**
+ * Accept a team invite.
+ *
+ * POST { token } →
+ *   - validates the token
+ *   - checks the signed-in Clerk user has an email matching the invite
+ *   - rejects if the user is already on another team
+ *   - adds the user as a member with the role set on the invite
+ *   - stamps `tier: "team"` on Clerk publicMetadata
+ *   - deletes the invite
+ *
+ * Returns the team summary the client can navigate into.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import {
+  addMember,
+  deleteInvite,
+  getInviteByToken,
+  getTeam,
+  getUserTeamId,
+} from "@/lib/teams";
+import { setUserSubscription } from "@/lib/tier";
+
+export const runtime = "nodejs";
+
+export async function POST(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Sign in required" }, { status: 401 });
+  }
+
+  let body: { token?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const token = (body.token || "").trim();
+  if (!token) {
+    return NextResponse.json({ error: "Token is required" }, { status: 400 });
+  }
+
+  const invite = await getInviteByToken(token);
+  if (!invite) {
+    return NextResponse.json(
+      { error: "Invite is invalid or expired" },
+      { status: 404 },
+    );
+  }
+
+  const team = await getTeam(invite.teamId);
+  if (!team) {
+    return NextResponse.json({ error: "Team no longer exists" }, { status: 404 });
+  }
+
+  // Email match — Clerk users may have multiple email addresses; accept any.
+  const client = await clerkClient();
+  const user = await client.users.getUser(userId);
+  const userEmails = user.emailAddresses
+    .map((e) => e.emailAddress?.toLowerCase())
+    .filter((e): e is string => Boolean(e));
+  if (!userEmails.includes(invite.email.toLowerCase())) {
+    return NextResponse.json(
+      {
+        error: `This invite was sent to ${invite.email}. Sign in with that email to accept.`,
+      },
+      { status: 403 },
+    );
+  }
+
+  const existingTeam = await getUserTeamId(userId);
+  if (existingTeam && existingTeam !== team.id) {
+    return NextResponse.json(
+      {
+        error:
+          "You're already on another team. Leave that team first, then accept this invite.",
+      },
+      { status: 409 },
+    );
+  }
+
+  await addMember(team.id, userId, invite.role, invite.invitedBy);
+  await setUserSubscription(userId, { tier: "team" });
+  await deleteInvite(team.id, token);
+
+  return NextResponse.json({
+    team: { id: team.id, name: team.name },
+    role: invite.role,
+  });
+}

--- a/src/app/api/team/invites/[token]/route.ts
+++ b/src/app/api/team/invites/[token]/route.ts
@@ -1,0 +1,27 @@
+/**
+ * Revoke a pending invite. Admin-only.
+ *
+ * DELETE → remove the invite from the team and invalidate the token.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireTeamAdmin } from "@/lib/team-auth";
+import { deleteInvite, getInviteByToken } from "@/lib/teams";
+
+export const runtime = "nodejs";
+
+export async function DELETE(
+  _req: NextRequest,
+  ctx: { params: Promise<{ token: string }> },
+) {
+  const auth = await requireTeamAdmin();
+  if (!auth.ok) return auth.response;
+
+  const { token } = await ctx.params;
+  const invite = await getInviteByToken(token);
+  if (!invite || invite.teamId !== auth.team.id) {
+    return NextResponse.json({ error: "Invite not found" }, { status: 404 });
+  }
+
+  await deleteInvite(auth.team.id, token);
+  return NextResponse.json({ revoked: true });
+}

--- a/src/app/api/team/members/[userId]/route.ts
+++ b/src/app/api/team/members/[userId]/route.ts
@@ -1,0 +1,116 @@
+/**
+ * Single-member ops — pause, archive, reactivate, promote, demote, remove.
+ *
+ * PATCH { status?, role? } → update membership
+ * DELETE                   → remove the member from the team
+ *
+ * Admin-only. The team owner cannot be demoted, paused, archived, or removed
+ * through this route — that prevents an admin from accidentally locking
+ * everyone out. To replace an owner, the Ladder admin (Drawbackwards) must
+ * create a new team or update the team record directly.
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { requireTeamAdmin } from "@/lib/team-auth";
+import {
+  getMember,
+  removeMember,
+  setMemberRole,
+  setMemberStatus,
+  type MemberStatus,
+  type TeamRole,
+} from "@/lib/teams";
+import { setUserSubscription } from "@/lib/tier";
+
+export const runtime = "nodejs";
+
+export async function PATCH(
+  req: NextRequest,
+  ctx: { params: Promise<{ userId: string }> },
+) {
+  const auth = await requireTeamAdmin();
+  if (!auth.ok) return auth.response;
+
+  const { userId: targetUserId } = await ctx.params;
+  const target = await getMember(auth.team.id, targetUserId);
+  if (!target) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  let body: { status?: MemberStatus; role?: TeamRole } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const isOwner = targetUserId === auth.team.ownerUserId;
+
+  let next = target;
+
+  if (body.status) {
+    if (
+      body.status !== "active" &&
+      body.status !== "paused" &&
+      body.status !== "archived"
+    ) {
+      return NextResponse.json({ error: "Invalid status" }, { status: 400 });
+    }
+    if (isOwner && body.status !== "active") {
+      return NextResponse.json(
+        { error: "The team owner must remain active. Replace the owner first." },
+        { status: 400 },
+      );
+    }
+    const updated = await setMemberStatus(auth.team.id, targetUserId, body.status);
+    if (updated) next = updated;
+    // Pausing or archiving means they no longer get team-tier access.
+    if (body.status === "active") {
+      await setUserSubscription(targetUserId, { tier: "team" });
+    } else {
+      await setUserSubscription(targetUserId, { tier: "free" });
+    }
+  }
+
+  if (body.role) {
+    if (body.role !== "admin" && body.role !== "member") {
+      return NextResponse.json({ error: "Invalid role" }, { status: 400 });
+    }
+    if (isOwner && body.role !== "admin") {
+      return NextResponse.json(
+        { error: "The team owner cannot be demoted." },
+        { status: 400 },
+      );
+    }
+    const updated = await setMemberRole(auth.team.id, targetUserId, body.role);
+    if (updated) next = updated;
+  }
+
+  return NextResponse.json({ membership: next });
+}
+
+export async function DELETE(
+  _req: NextRequest,
+  ctx: { params: Promise<{ userId: string }> },
+) {
+  const auth = await requireTeamAdmin();
+  if (!auth.ok) return auth.response;
+
+  const { userId: targetUserId } = await ctx.params;
+  const target = await getMember(auth.team.id, targetUserId);
+  if (!target) {
+    return NextResponse.json({ error: "Member not found" }, { status: 404 });
+  }
+
+  if (targetUserId === auth.team.ownerUserId) {
+    return NextResponse.json(
+      { error: "The team owner cannot be removed through this route." },
+      { status: 400 },
+    );
+  }
+
+  await removeMember(auth.team.id, targetUserId);
+  // Drop their team-tier access. They stay a Ladder user at "free".
+  await setUserSubscription(targetUserId, { tier: "free" });
+
+  return NextResponse.json({ removed: true });
+}

--- a/src/app/api/team/members/route.ts
+++ b/src/app/api/team/members/route.ts
@@ -1,0 +1,156 @@
+/**
+ * Team member ops — invite (POST).
+ *
+ * Listing members happens via GET /api/team. Invitations are admin-only.
+ *
+ * POST { email, role? } → creates an invite, emails the recipient a magic
+ * accept link. Role defaults to "member".
+ */
+import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { requireTeamAdmin } from "@/lib/team-auth";
+import { createInvite, getUserTeamId, type TeamRole } from "@/lib/teams";
+
+export const runtime = "nodejs";
+
+const RESEND_FROM = "Ladder <invites@runladder.com>";
+
+async function sendInviteEmail(args: {
+  to: string;
+  teamName: string;
+  inviterName: string;
+  acceptUrl: string;
+}): Promise<void> {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    console.warn("[LADDER:TEAMS] RESEND_API_KEY missing — invite email skipped.");
+    return;
+  }
+  const subject = `${args.inviterName} invited you to ${args.teamName} on Ladder`;
+  const text = [
+    `${args.inviterName} invited you to join ${args.teamName} on Ladder.`,
+    "",
+    "Ladder is the quality score for every product experience. Your team uses it to score screens, share standards, and track quality together.",
+    "",
+    `Accept the invite: ${args.acceptUrl}`,
+    "",
+    "This link expires in 14 days.",
+  ].join("\n");
+  const html = `
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Inter, sans-serif; max-width: 520px; margin: 0 auto; padding: 32px 24px; color: #111;">
+      <p style="font-size: 15px; line-height: 1.6;">
+        <strong>${args.inviterName}</strong> invited you to join <strong>${args.teamName}</strong> on Ladder.
+      </p>
+      <p style="font-size: 14px; line-height: 1.6; color: #444;">
+        Ladder is the quality score for every product experience. Your team uses it to score screens, share standards, and track quality together.
+      </p>
+      <p style="margin: 32px 0;">
+        <a href="${args.acceptUrl}"
+           style="display: inline-block; background: #6AC89B; color: #0a0a0a; font-weight: 600; padding: 12px 24px; border-radius: 999px; text-decoration: none; font-size: 14px;">
+          Accept invite
+        </a>
+      </p>
+      <p style="font-size: 12px; color: #666;">
+        This link expires in 14 days. If the button doesn't work, paste this URL into your browser:<br>
+        <span style="word-break: break-all;">${args.acceptUrl}</span>
+      </p>
+    </div>
+  `;
+
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${key}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: RESEND_FROM,
+      to: [args.to],
+      subject,
+      text,
+      html,
+    }),
+  });
+}
+
+function siteOrigin(req: NextRequest): string {
+  const proto = req.headers.get("x-forwarded-proto") || "https";
+  const host = req.headers.get("x-forwarded-host") || req.headers.get("host");
+  if (host) return `${proto}://${host}`;
+  return process.env.NEXT_PUBLIC_SITE_URL || "https://runladder.com";
+}
+
+export async function POST(req: NextRequest) {
+  const auth = await requireTeamAdmin();
+  if (!auth.ok) return auth.response;
+
+  let body: { email?: string; role?: TeamRole } = {};
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const email = (body.email || "").trim().toLowerCase();
+  if (!email || !email.includes("@") || email.length > 200) {
+    return NextResponse.json(
+      { error: "Valid email is required" },
+      { status: 400 },
+    );
+  }
+  const role: TeamRole = body.role === "admin" ? "admin" : "member";
+
+  // If the email already belongs to a Ladder user on another team, surface
+  // that early so the inviter knows before the invite goes out.
+  const client = await clerkClient();
+  const existingList = await client.users.getUserList({
+    emailAddress: [email],
+    limit: 1,
+  });
+  const existingUser = existingList.data[0];
+  if (existingUser) {
+    const otherTeam = await getUserTeamId(existingUser.id);
+    if (otherTeam && otherTeam !== auth.team.id) {
+      return NextResponse.json(
+        {
+          error: `${email} is already a member of another team. They must leave that team before they can accept this invite.`,
+        },
+        { status: 409 },
+      );
+    }
+    if (otherTeam === auth.team.id) {
+      return NextResponse.json(
+        { error: `${email} is already a member of this team.` },
+        { status: 409 },
+      );
+    }
+  }
+
+  const invite = await createInvite({
+    teamId: auth.team.id,
+    email,
+    role,
+    invitedBy: auth.userId,
+  });
+
+  const inviterClerk = await client.users.getUser(auth.userId);
+  const inviterName =
+    [inviterClerk.firstName, inviterClerk.lastName].filter(Boolean).join(" ") ||
+    inviterClerk.primaryEmailAddress?.emailAddress ||
+    "A teammate";
+
+  const acceptUrl = `${siteOrigin(req)}/team/join/${invite.token}`;
+  try {
+    await sendInviteEmail({
+      to: email,
+      teamName: auth.team.name,
+      inviterName,
+      acceptUrl,
+    });
+  } catch (err) {
+    // Don't fail the request — the invite exists, we just couldn't email yet.
+    console.error("[LADDER:TEAMS] Invite email send failed:", err);
+  }
+
+  return NextResponse.json({ invite, acceptUrl });
+}

--- a/src/app/api/team/route.ts
+++ b/src/app/api/team/route.ts
@@ -1,0 +1,99 @@
+/**
+ * Current user's team summary — what /dashboard/team uses to render.
+ *
+ * GET → { team, membership, members[], invites[], billing, usage }
+ *
+ * Members and invites are visible to every team member. Sensitive admin-only
+ * actions (invite, pause, archive, delete, promote) live on dedicated routes.
+ */
+import { NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { requireTeamMember } from "@/lib/team-auth";
+import {
+  getBillingSummary,
+  getTeamActivity,
+  getTeamUsage,
+  listInvites,
+  listMembers,
+  type Membership,
+} from "@/lib/teams";
+
+export const runtime = "nodejs";
+
+type MemberWithUser = Membership & {
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+async function hydrateMembers(members: Membership[]): Promise<MemberWithUser[]> {
+  if (members.length === 0) return [];
+  const client = await clerkClient();
+  const ids = members.map((m) => m.userId);
+  const list = await client.users.getUserList({
+    userId: ids,
+    limit: Math.max(ids.length, 1),
+  });
+  const byId = new Map(list.data.map((u) => [u.id, u] as const));
+  return members.map((m) => {
+    const u = byId.get(m.userId);
+    return {
+      ...m,
+      email: u?.primaryEmailAddress?.emailAddress ?? null,
+      firstName: u?.firstName ?? null,
+      lastName: u?.lastName ?? null,
+    };
+  });
+}
+
+export async function GET() {
+  const auth = await requireTeamMember();
+  if (!auth.ok) return auth.response;
+
+  const { team, membership } = auth;
+  const isAdmin = membership.role === "admin";
+
+  const [members, invites, billing, usage, activity] = await Promise.all([
+    listMembers(team.id),
+    isAdmin ? listInvites(team.id) : Promise.resolve([]),
+    getBillingSummary(team.id),
+    getTeamUsage(team.id),
+    getTeamActivity(team.id, 50),
+  ]);
+
+  const hydrated = await hydrateMembers(members);
+  const memberById = new Map(hydrated.map((m) => [m.userId, m] as const));
+
+  // Annotate each activity event with the scorer's display name so the UI
+  // doesn't need a separate Clerk lookup pass.
+  const annotatedActivity = activity.map((ev) => {
+    const m = memberById.get(ev.userId);
+    return {
+      ...ev,
+      scorerName:
+        m
+          ? [m.firstName, m.lastName].filter(Boolean).join(" ").trim() ||
+            m.email ||
+            null
+          : null,
+    };
+  });
+
+  return NextResponse.json({
+    team: {
+      id: team.id,
+      name: team.name,
+      status: team.status,
+      seatCap: team.seatCap,
+      perOverageSeatPrice: team.perOverageSeatPrice,
+      queryPool: team.queryPool,
+      createdAt: team.createdAt,
+    },
+    membership,
+    members: hydrated,
+    invites: isAdmin ? invites : [],
+    billing,
+    usage,
+    activity: annotatedActivity,
+  });
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -43,6 +43,12 @@ type CompMeta = {
   expiresAt: number | null;
 };
 
+type TeamMembership = {
+  id: string;
+  name: string;
+  role: "admin" | "member";
+};
+
 type DashboardData = {
   scores: ScoreEntry[];
   stats: UserStats;
@@ -50,6 +56,7 @@ type DashboardData = {
   tier: "free" | "pro" | "team" | "pulse";
   paid: boolean;
   comp: CompMeta | null;
+  team: TeamMembership | null;
 };
 
 function timeAgo(ts: number): string {
@@ -70,13 +77,40 @@ function UpgradeStrip({
   paid,
   tier,
   comp,
+  team,
 }: {
   usage: UsageInfo;
   paid: boolean;
   tier: "free" | "pro" | "team" | "pulse";
   comp: CompMeta | null;
+  team: TeamMembership | null;
 }) {
   const tierLabel = tier === "pro" ? "Pro" : tier === "team" ? "Team" : tier === "pulse" ? "Pulse" : "Free";
+
+  // Team members get a team-aware banner that routes to the team dashboard
+  // instead of the (broken-for-Teams) Stripe portal.
+  if (team) {
+    return (
+      <div className="border-b border-ladder-green/20 bg-ladder-green/5">
+        <div className="max-w-6xl mx-auto px-6 py-2.5 flex items-center justify-center gap-4 flex-wrap">
+          <span className="text-[11px] text-muted font-sans">
+            <span className="text-ladder-green font-semibold uppercase tracking-widest text-[10px]">
+              {team.role === "admin" ? "Team admin" : "Team member"}
+            </span>{" "}
+            — you&rsquo;re on the{" "}
+            <span className="text-foreground font-semibold">{team.name}</span>{" "}
+            account. Unlimited scoring across every Ladder surface.
+          </span>
+          <Link
+            href="/dashboard/team"
+            className="text-[10px] uppercase tracking-widest font-semibold text-ladder-green hover:text-ladder-green/80 transition-colors"
+          >
+            Team dashboard →
+          </Link>
+        </div>
+      </div>
+    );
+  }
 
   if (paid && comp) {
     const expiry =
@@ -324,11 +358,12 @@ export default function DashboardPage() {
   const paid = data?.paid ?? false;
   const tier = data?.tier ?? "free";
   const comp = data?.comp ?? null;
+  const team = data?.team ?? null;
   const firstName = user?.firstName || null;
 
   return (
     <div className="pt-20 font-mono">
-      <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} />
+      <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} team={team} />
       <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="mb-8">
           <h1 className="text-xl text-foreground font-sans">

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,0 +1,639 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
+import { getScoreColor } from "@/lib/ladder";
+
+type Membership = {
+  userId: string;
+  role: "admin" | "member";
+  status: "active" | "paused" | "archived";
+  joinedAt: number;
+  invitedBy?: string;
+};
+
+type MemberWithUser = Membership & {
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+};
+
+type Invite = {
+  token: string;
+  teamId: string;
+  email: string;
+  role: "admin" | "member";
+  invitedBy: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+type BillingSummary = {
+  active: number;
+  paused: number;
+  archived: number;
+  included: number;
+  overageSeats: number;
+  overagePrice: number;
+};
+
+type ActivityEvent = {
+  type: "score";
+  timestamp: number;
+  userId: string;
+  scoreId: string;
+  score: number;
+  label: string;
+  screenName?: string;
+  source: string;
+  thumbnail?: string;
+  scorerName: string | null;
+};
+
+type TeamData = {
+  team: {
+    id: string;
+    name: string;
+    status: "active" | "paused" | "archived";
+    seatCap: number;
+    perOverageSeatPrice: number;
+    queryPool: number;
+    createdAt: number;
+  };
+  membership: Membership;
+  members: MemberWithUser[];
+  invites: Invite[];
+  billing: BillingSummary;
+  usage: number;
+  activity: ActivityEvent[];
+};
+
+function fmtDate(ts: number): string {
+  if (!ts) return "—";
+  return new Date(ts).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function StatusChip({ status }: { status: Membership["status"] }) {
+  const cls =
+    status === "active"
+      ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+      : status === "paused"
+        ? "text-ladder-orange border-ladder-orange/40 bg-ladder-orange/5"
+        : "text-muted border-[#333] bg-[#1a1a1a]";
+  return (
+    <span
+      className={`inline-block text-[9px] uppercase tracking-widest border px-2 py-0.5 ${cls}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function RoleChip({ role }: { role: Membership["role"] }) {
+  const cls =
+    role === "admin"
+      ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+      : "text-muted border-[#333] bg-[#1a1a1a]";
+  return (
+    <span
+      className={`inline-block text-[9px] uppercase tracking-widest border px-2 py-0.5 ${cls}`}
+    >
+      {role}
+    </span>
+  );
+}
+
+function displayName(m: MemberWithUser): string {
+  const full = [m.firstName, m.lastName].filter(Boolean).join(" ").trim();
+  return full || m.email || m.userId;
+}
+
+export default function TeamDashboardPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [data, setData] = useState<TeamData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  // Invite form
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"admin" | "member">("member");
+  const [inviting, setInviting] = useState(false);
+  const [inviteMsg, setInviteMsg] = useState<string | null>(null);
+
+  // Per-member busy state
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/team");
+      if (res.status === 404) {
+        setNotFound(true);
+        return;
+      }
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Failed to load team (${res.status})`);
+      }
+      const json = (await res.json()) as TeamData;
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    refresh();
+  }, [isSignedIn]);
+
+  async function sendInvite(e: React.FormEvent) {
+    e.preventDefault();
+    setInviting(true);
+    setInviteMsg(null);
+    setError(null);
+    try {
+      const res = await fetch("/api/team/members", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: inviteEmail.trim(), role: inviteRole }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Invite failed (${res.status})`);
+      setInviteEmail("");
+      setInviteRole("member");
+      setInviteMsg(`Invite sent to ${json.invite.email}.`);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Invite failed");
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  async function patchMember(
+    userId: string,
+    patch: { status?: Membership["status"]; role?: Membership["role"] },
+  ) {
+    setBusyId(userId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/team/members/${userId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(patch),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Update failed (${res.status})`);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function removeMember(userId: string) {
+    if (!confirm("Remove this member from the team? Their score history stays in their personal dashboard.")) {
+      return;
+    }
+    setBusyId(userId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/team/members/${userId}`, {
+        method: "DELETE",
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Remove failed (${res.status})`);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Remove failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function revokeInvite(token: string) {
+    if (!confirm("Revoke this invite? The link will stop working.")) return;
+    setBusyId(token);
+    setError(null);
+    try {
+      const res = await fetch(`/api/team/invites/${token}`, { method: "DELETE" });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error || `Revoke failed (${res.status})`);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Revoke failed");
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (notFound) {
+    return (
+      <div className="pt-32 max-w-2xl mx-auto px-6 py-20 text-center">
+        <h1 className="text-2xl font-bold mb-4">No team yet</h1>
+        <p className="text-sm text-body font-sans mb-8">
+          You aren&rsquo;t a member of a Ladder Teams account. If your organization
+          should have one, contact us so we can set it up.
+        </p>
+        <Link
+          href="/teams"
+          className="inline-block bg-ladder-green text-background font-semibold px-8 py-3 rounded-full hover:bg-ladder-green/90 transition-colors text-sm"
+        >
+          Learn about Teams
+        </Link>
+      </div>
+    );
+  }
+
+  if (loading || !data) {
+    return (
+      <div className="pt-32 max-w-6xl mx-auto px-6 py-20 text-center text-muted font-sans text-sm">
+        Loading…
+      </div>
+    );
+  }
+
+  const isAdmin = data.membership.role === "admin";
+  const billing = data.billing;
+  const usagePercent = data.team.queryPool
+    ? Math.min(100, Math.round((data.usage / data.team.queryPool) * 100))
+    : 0;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        {/* ── Header ─────────────────────────────────────────────── */}
+        <div className="mb-8 flex items-baseline justify-between flex-wrap gap-4">
+          <div>
+            <p className="text-[10px] text-muted uppercase tracking-widest mb-1">
+              Team
+            </p>
+            <h1 className="text-2xl text-foreground font-sans">{data.team.name}</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <Link
+              href="/dashboard"
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              ← My dashboard
+            </Link>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* ── Stat tiles ─────────────────────────────────────────── */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mb-12">
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Active seats
+            </p>
+            <p className="text-2xl font-bold text-foreground tabular-nums">
+              {billing.active}
+              <span className="text-muted text-base"> / {billing.included}</span>
+            </p>
+            {billing.paused > 0 && (
+              <p className="text-[10px] text-muted mt-1">
+                {billing.paused} paused
+              </p>
+            )}
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Overage
+            </p>
+            <p
+              className="text-2xl font-bold tabular-nums"
+              style={{
+                color: billing.overageSeats > 0 ? "#f97316" : "#444",
+              }}
+            >
+              {billing.overageSeats > 0
+                ? `$${billing.overagePrice.toLocaleString()}`
+                : "$0"}
+            </p>
+            <p className="text-[10px] text-muted mt-1">
+              {billing.overageSeats > 0
+                ? `+${billing.overageSeats} seat${billing.overageSeats === 1 ? "" : "s"} / mo`
+                : "Within plan"}
+            </p>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Pool used
+            </p>
+            <p className="text-2xl font-bold text-foreground tabular-nums">
+              {data.usage.toLocaleString()}
+              <span className="text-muted text-base">
+                {" "}
+                / {data.team.queryPool.toLocaleString()}
+              </span>
+            </p>
+            <p className="text-[10px] text-muted mt-1">
+              {usagePercent}% this month
+            </p>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Members
+            </p>
+            <p className="text-2xl font-bold text-foreground tabular-nums">
+              {data.members.length}
+            </p>
+            <p className="text-[10px] text-muted mt-1">
+              {data.invites.length > 0
+                ? `${data.invites.length} pending invite${data.invites.length === 1 ? "" : "s"}`
+                : "All accepted"}
+            </p>
+          </div>
+        </div>
+
+        {/* ── Activity feed ──────────────────────────────────────── */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Activity
+            </span>
+            <Link
+              href="/score"
+              className="text-[10px] uppercase tracking-widest text-ladder-green hover:text-ladder-green/80 transition-colors"
+            >
+              Score a screen →
+            </Link>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            {data.activity.length === 0 ? (
+              <div className="p-8 text-center text-muted font-sans text-sm">
+                Score activity will appear here as your team scores screens.
+              </div>
+            ) : (
+              data.activity.map((ev) => (
+                <Link
+                  key={ev.scoreId}
+                  href={`/dashboard/scores/${ev.scoreId}`}
+                  className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4 hover:bg-[#222] transition-colors"
+                >
+                  {ev.thumbnail ? (
+                    <div className="flex-shrink-0 w-16 h-16 border border-[#333] bg-[#111] overflow-hidden">
+                      <img
+                        src={ev.thumbnail}
+                        alt=""
+                        className="w-full h-full object-cover object-top"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex-shrink-0 w-16 h-16 border border-[#333] bg-[#111] flex items-center justify-center">
+                      <span className="text-[#333] text-xs">—</span>
+                    </div>
+                  )}
+                  <div className="flex-shrink-0 w-14 text-center">
+                    <span
+                      className="text-xl font-bold tabular-nums"
+                      style={{ color: getScoreColor(ev.score) }}
+                    >
+                      {ev.score.toFixed(1)}
+                    </span>
+                    <span
+                      className="block text-[9px] uppercase tracking-widest mt-0.5"
+                      style={{ color: getScoreColor(ev.score) }}
+                    >
+                      {ev.label}
+                    </span>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-foreground font-sans truncate">
+                      {ev.screenName || ev.source}
+                    </p>
+                    <p className="text-[10px] text-muted mt-1">
+                      {ev.scorerName || "Team member"} · {ev.source} ·{" "}
+                      {timeAgo(ev.timestamp)}
+                    </p>
+                  </div>
+                </Link>
+              ))
+            )}
+          </div>
+        </section>
+
+        {/* ── Invite (admin only) ────────────────────────────────── */}
+        {isAdmin && (
+          <section className="mb-12">
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-[10px] text-muted uppercase tracking-widest">
+                Invite a designer
+              </span>
+            </div>
+            <form
+              onSubmit={sendInvite}
+              className="border border-[#333] bg-[#1e1e1e] p-4 grid grid-cols-1 md:grid-cols-[1fr_140px_auto] gap-3"
+            >
+              <input
+                type="email"
+                required
+                placeholder="designer@yourcompany.com"
+                value={inviteEmail}
+                onChange={(e) => setInviteEmail(e.target.value)}
+                className="bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+              <select
+                value={inviteRole}
+                onChange={(e) => setInviteRole(e.target.value as "admin" | "member")}
+                className="bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted"
+              >
+                <option value="member">member</option>
+                <option value="admin">admin</option>
+              </select>
+              <button
+                type="submit"
+                disabled={inviting}
+                className="text-xs font-semibold bg-ladder-green text-background px-6 py-2 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+              >
+                {inviting ? "Sending…" : "Send invite"}
+              </button>
+            </form>
+            {inviteMsg && (
+              <p className="text-[11px] text-ladder-green mt-2 font-sans">{inviteMsg}</p>
+            )}
+          </section>
+        )}
+
+        {/* ── Pending invites (admin only) ───────────────────────── */}
+        {isAdmin && data.invites.length > 0 && (
+          <section className="mb-12">
+            <div className="flex items-center justify-between mb-4">
+              <span className="text-[10px] text-muted uppercase tracking-widest">
+                Pending invites
+              </span>
+              <span className="text-[10px] text-muted">{data.invites.length}</span>
+            </div>
+            <div className="border border-[#333] bg-[#1e1e1e]">
+              {data.invites.map((inv) => (
+                <div
+                  key={inv.token}
+                  className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-sm text-foreground font-sans truncate">
+                      {inv.email}
+                    </p>
+                    <p className="text-[10px] text-muted mt-1">
+                      <RoleChip role={inv.role} /> · sent {fmtDate(inv.createdAt)} · expires {fmtDate(inv.expiresAt)}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => revokeInvite(inv.token)}
+                    disabled={busyId === inv.token}
+                    className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
+                  >
+                    Revoke
+                  </button>
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* ── Members ────────────────────────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Members
+            </span>
+            <span className="text-[10px] text-muted">
+              {data.members.length} member{data.members.length === 1 ? "" : "s"}
+            </span>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            {data.members.length === 0 ? (
+              <div className="p-6 text-center text-muted font-sans text-sm">
+                No members yet.
+              </div>
+            ) : (
+              data.members.map((m) => {
+                const isMe = m.userId === data.membership.userId;
+                return (
+                  <div
+                    key={m.userId}
+                    className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-foreground font-sans truncate">
+                        {displayName(m)}
+                        {isMe && (
+                          <span className="text-[10px] text-muted ml-2">(you)</span>
+                        )}
+                      </p>
+                      <div className="flex items-center gap-2 mt-1.5">
+                        <RoleChip role={m.role} />
+                        <StatusChip status={m.status} />
+                        {m.email && (
+                          <span className="text-[10px] text-muted">{m.email}</span>
+                        )}
+                        <span className="text-[10px] text-muted">
+                          · joined {fmtDate(m.joinedAt)}
+                        </span>
+                      </div>
+                    </div>
+
+                    {isAdmin && !isMe && (
+                      <div className="flex items-center gap-3">
+                        {m.status === "active" && (
+                          <>
+                            <button
+                              onClick={() =>
+                                patchMember(m.userId, { status: "paused" })
+                              }
+                              disabled={busyId === m.userId}
+                              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
+                            >
+                              Pause
+                            </button>
+                            {m.role === "member" ? (
+                              <button
+                                onClick={() => patchMember(m.userId, { role: "admin" })}
+                                disabled={busyId === m.userId}
+                                className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
+                              >
+                                Make admin
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() => patchMember(m.userId, { role: "member" })}
+                                disabled={busyId === m.userId}
+                                className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
+                              >
+                                Demote
+                              </button>
+                            )}
+                          </>
+                        )}
+                        {m.status === "paused" && (
+                          <button
+                            onClick={() => patchMember(m.userId, { status: "active" })}
+                            disabled={busyId === m.userId}
+                            className="text-[10px] uppercase tracking-widest text-ladder-green hover:text-ladder-green/80 transition-colors disabled:opacity-40"
+                          >
+                            Reactivate
+                          </button>
+                        )}
+                        {m.status !== "archived" && (
+                          <button
+                            onClick={() =>
+                              patchMember(m.userId, { status: "archived" })
+                            }
+                            disabled={busyId === m.userId}
+                            className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
+                          >
+                            Archive
+                          </button>
+                        )}
+                        <button
+                          onClick={() => removeMember(m.userId)}
+                          disabled={busyId === m.userId}
+                          className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -216,6 +216,13 @@ function timeAgo(ts: number): string {
   return `${days}d ago`;
 }
 
+type MeResponse = {
+  signedIn: boolean;
+  tier: "free" | "pro" | "team" | "pulse";
+  paid: boolean;
+  team: { id: string; name: string; role: "admin" | "member" } | null;
+};
+
 export default function ScorePage() {
   const { isSignedIn, isLoaded } = useAuth();
   const [image, setImage] = useState<string | null>(null);
@@ -231,12 +238,30 @@ export default function ScorePage() {
   const [isDragOver, setIsDragOver] = useState(false);
   const [pastScores, setPastScores] = useState<PastScore[]>([]);
   const [isPublic, setIsPublic] = useState(true);
+  const [me, setMe] = useState<MeResponse | null>(null);
   const fileRef = useRef<HTMLInputElement>(null);
 
   // Load past scores on mount
   useEffect(() => {
     setPastScores(loadPastScores());
   }, []);
+
+  // Fetch tier + team info so we can hide the Pro promo for paid users
+  // (Pro, Team, Pulse) and surface team context to team members.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/me")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((json: MeResponse | null) => {
+        if (!cancelled && json) setMe(json);
+      })
+      .catch(() => {
+        // Silent failure — the page still works for anonymous use.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn]);
 
   const scanMessages = [
     "Initializing Ladder engine",
@@ -354,12 +379,8 @@ export default function ScorePage() {
       let data;
       try { data = JSON.parse(text); } catch { throw new Error("Scoring service returned an unexpected response. Please try again."); }
       if (!res.ok) {
-        if (data.signup) {
-          throw new Error("Sign up for free to get 5 Ladder scores. Log in at runladder.com/login");
-        }
-        if (data.upgrade) {
-          throw new Error("You've used all 15 free scores this month. Upgrade at runladder.com/pricing for unlimited scoring.");
-        }
+        // Prefer the server's error message — it's tier-aware (free cap,
+        // team pool exceeded, etc) and stays in sync with plans.ts.
         throw new Error(data.error || "Scoring failed");
       }
       setResult(data);
@@ -883,67 +904,92 @@ export default function ScorePage() {
               </div>
             )}
 
-            {/* Pro upgrade promo */}
-            <div className="border border-ladder-green/20 bg-[#1e1e1e] p-8">
-              <div className="flex items-start gap-6">
-                <div className="flex-1">
-                  <span className="text-[10px] text-ladder-green uppercase tracking-widest font-semibold">Upgrade to Pro</span>
-                  <h3 className="text-lg font-bold text-foreground mt-2 font-sans">See more. Fix faster.</h3>
-                  <p className="text-sm text-body leading-relaxed mt-3 font-sans">
-                    Free scores show you where you stand. Pro shows you exactly how to move up.
-                  </p>
-                  <ul className="mt-4 space-y-2">
-                    {[
-                      "Accessibility audit",
-                      "UX copy suggestions",
-                      "Per-dimension scoring (hierarchy, spacing, copy, a11y, navigation, visual)",
-                      "Fix suggestions with score uplift estimates",
-                      "Full score history + trend line",
-                      "All scores are private",
-                    ].map((f) => (
-                      <li key={f} className="flex items-start gap-2 text-xs text-body font-sans">
+            {/* Pro upgrade promo — hidden for paid users (Pro, Team, Pulse).
+                Team members see their team banner on /dashboard instead. */}
+            {!me?.paid && (
+              <div className="border border-ladder-green/20 bg-[#1e1e1e] p-8">
+                <div className="flex items-start gap-6">
+                  <div className="flex-1">
+                    <span className="text-[10px] text-ladder-green uppercase tracking-widest font-semibold">Upgrade to Pro</span>
+                    <h3 className="text-lg font-bold text-foreground mt-2 font-sans">See more. Fix faster.</h3>
+                    <p className="text-sm text-body leading-relaxed mt-3 font-sans">
+                      Free scores show you where you stand. Pro shows you exactly how to move up.
+                    </p>
+                    <ul className="mt-4 space-y-2">
+                      {[
+                        "Accessibility audit",
+                        "UX copy suggestions",
+                        "Per-dimension scoring (hierarchy, spacing, copy, a11y, navigation, visual)",
+                        "Fix suggestions with score uplift estimates",
+                        "Full score history + trend line",
+                        "All scores are private",
+                      ].map((f) => (
+                        <li key={f} className="flex items-start gap-2 text-xs text-body font-sans">
+                          <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+                          {f}
+                        </li>
+                      ))}
+                      <li className="flex items-start gap-2 text-xs text-body font-sans">
                         <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
-                        {f}
+                        Ladder for Figma — score frames in the canvas
                       </li>
-                    ))}
-                    <li className="flex items-start gap-2 text-xs text-body font-sans">
-                      <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
-                      Ladder for Figma — score frames in the canvas
-                    </li>
-                    <li className="flex items-start gap-2 text-xs text-body font-sans">
-                      <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
-                      Ladder for Claude — score in any AI conversation
-                    </li>
-                  </ul>
-                  <Link
-                    href="/pricing"
-                    className="inline-block mt-6 text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
-                  >
-                    $250/mo — Upgrade to Pro
-                  </Link>
-                </div>
-
-                {/* Pro preview thumbnail mockup */}
-                <div className="hidden md:block flex-shrink-0 w-48 border border-[#333] bg-[#161616] p-3 opacity-60">
-                  <span className="text-[8px] text-muted uppercase tracking-widest block mb-2">Pro preview</span>
-                  <div className="space-y-2">
-                    {["Hierarchy", "Spacing", "Copy", "A11y", "Navigation", "Visual"].map((dim) => (
-                      <div key={dim} className="flex items-center gap-2">
-                        <span className="text-[8px] text-[#555] w-14 truncate">{dim}</span>
-                        <div className="flex-1 h-1 bg-[#333] rounded-full">
-                          <div className="h-full bg-ladder-green/40 rounded-full" style={{ width: `${40 + Math.random() * 40}%` }} />
-                        </div>
-                      </div>
-                    ))}
+                      <li className="flex items-start gap-2 text-xs text-body font-sans">
+                        <span className="text-ladder-green mt-0.5 flex-shrink-0">+</span>
+                        Ladder for Claude — score in any AI conversation
+                      </li>
+                    </ul>
+                    <Link
+                      href="/pricing"
+                      className="inline-block mt-6 text-xs font-semibold bg-ladder-green text-[#1a1a1a] px-6 py-3 hover:bg-ladder-green/90 transition-colors uppercase tracking-widest"
+                    >
+                      $250/mo — Upgrade to Pro
+                    </Link>
                   </div>
-                  <div className="mt-3 border-t border-[#333] pt-2">
-                    <span className="text-[8px] text-[#555] block">A11y audit</span>
-                    <div className="mt-1 h-2 bg-[#333] rounded w-full" />
-                    <div className="mt-1 h-2 bg-[#333] rounded w-3/4" />
+
+                  {/* Pro preview thumbnail mockup */}
+                  <div className="hidden md:block flex-shrink-0 w-48 border border-[#333] bg-[#161616] p-3 opacity-60">
+                    <span className="text-[8px] text-muted uppercase tracking-widest block mb-2">Pro preview</span>
+                    <div className="space-y-2">
+                      {["Hierarchy", "Spacing", "Copy", "A11y", "Navigation", "Visual"].map((dim) => (
+                        <div key={dim} className="flex items-center gap-2">
+                          <span className="text-[8px] text-[#555] w-14 truncate">{dim}</span>
+                          <div className="flex-1 h-1 bg-[#333] rounded-full">
+                            <div className="h-full bg-ladder-green/40 rounded-full" style={{ width: `${40 + Math.random() * 40}%` }} />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    <div className="mt-3 border-t border-[#333] pt-2">
+                      <span className="text-[8px] text-[#555] block">A11y audit</span>
+                      <div className="mt-1 h-2 bg-[#333] rounded w-full" />
+                      <div className="mt-1 h-2 bg-[#333] rounded w-3/4" />
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
+
+            {/* Team-aware footer for team members on the score result. */}
+            {me?.team && (
+              <div className="border border-ladder-green/20 bg-ladder-green/5 p-6 flex items-center justify-between gap-4 flex-wrap">
+                <div>
+                  <span className="text-[10px] text-ladder-green uppercase tracking-widest font-semibold">
+                    {me.team.role === "admin" ? "Team admin" : "Team member"}
+                  </span>
+                  <p className="text-sm text-foreground mt-1 font-sans">
+                    This score landed on the{" "}
+                    <span className="font-semibold">{me.team.name}</span>{" "}
+                    team feed.
+                  </p>
+                </div>
+                <Link
+                  href="/dashboard/team"
+                  className="text-[10px] uppercase tracking-widest font-semibold text-ladder-green hover:text-ladder-green/80 transition-colors"
+                >
+                  Team dashboard →
+                </Link>
+              </div>
+            )}
           </div>
         )}
 

--- a/src/app/team/join/[token]/page.tsx
+++ b/src/app/team/join/[token]/page.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
+import { useParams, useRouter } from "next/navigation";
+
+type AcceptResult =
+  | { state: "idle" }
+  | { state: "loading" }
+  | { state: "success"; teamName: string }
+  | { state: "error"; message: string };
+
+export default function AcceptInvitePage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const { user } = useUser();
+  const router = useRouter();
+  const params = useParams<{ token: string }>();
+  const token = params?.token;
+
+  const [result, setResult] = useState<AcceptResult>({ state: "idle" });
+
+  useEffect(() => {
+    if (!isLoaded || !isSignedIn || !token) return;
+
+    let cancelled = false;
+    async function accept() {
+      setResult({ state: "loading" });
+      try {
+        const res = await fetch("/api/team/accept", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ token }),
+        });
+        const json = await res.json();
+        if (!res.ok) {
+          throw new Error(json.error || `Accept failed (${res.status})`);
+        }
+        if (!cancelled) {
+          setResult({
+            state: "success",
+            teamName: json.team?.name || "your team",
+          });
+          // Brief hold so the user can read the success message.
+          setTimeout(() => router.push("/dashboard/team"), 1200);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setResult({
+            state: "error",
+            message: e instanceof Error ? e.message : "Accept failed",
+          });
+        }
+      }
+    }
+
+    accept();
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoaded, isSignedIn, token, router]);
+
+  if (!isLoaded) return null;
+
+  if (!isSignedIn) {
+    const redirectUrl =
+      typeof window !== "undefined" ? window.location.pathname : `/team/join/${token}`;
+    return <RedirectToSignIn redirectUrl={redirectUrl} />;
+  }
+
+  return (
+    <div className="pt-32 px-6">
+      <div className="max-w-md mx-auto text-center">
+        <p className="font-mono text-xs text-ladder-green uppercase tracking-widest mb-6">
+          Team invite
+        </p>
+
+        {result.state === "loading" && (
+          <p className="text-sm text-body font-sans">
+            Accepting your invite{user?.firstName ? `, ${user.firstName}` : ""}…
+          </p>
+        )}
+
+        {result.state === "success" && (
+          <>
+            <h1 className="text-2xl font-bold mb-3">
+              You&rsquo;re in.
+            </h1>
+            <p className="text-sm text-body font-sans">
+              Welcome to <span className="text-foreground">{result.teamName}</span>.
+              Taking you to the team dashboard…
+            </p>
+          </>
+        )}
+
+        {result.state === "error" && (
+          <>
+            <h1 className="text-2xl font-bold mb-3">Couldn&rsquo;t accept</h1>
+            <p className="text-sm text-ladder-red font-sans mb-6">
+              {result.message}
+            </p>
+            <button
+              onClick={() => router.push("/dashboard")}
+              className="text-xs uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Go to dashboard
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/teams/page.tsx
+++ b/src/app/teams/page.tsx
@@ -4,66 +4,54 @@ import Link from "next/link";
 export const metadata: Metadata = {
   title: "Ladder for Teams | The quality standard for design organizations",
   description:
-    "Give your design team a shared quality bar. Brand standards, custom rubrics, designer dashboards, and score trends, all managed from one place. $12,000/year.",
+    "Give your design team a shared quality bar. Live activity feed, per-designer trends, pooled scoring across every Ladder surface. Talk to us.",
 };
 
 const CAPABILITIES = [
   {
     name: "Team Dashboard",
-    desc: "Every designer, every score, every trend in one view. See who's improving, who's shipping, and where your team's quality stands right now.",
-    detail: "Portfolio score, individual trends, activity feed, improvement velocity",
-  },
-  {
-    name: "Brand Standards",
-    desc: "Upload your brand guidelines. Ladder scores every screen against them automatically. Every score reflects your brand, not just generic UX principles.",
-    detail: "Brand voice, visual identity, interaction patterns, tone rules",
-  },
-  {
-    name: "Leadership Lens",
-    desc: "Your VP of Design has opinions that no framework captures. Encode them. 'We never use modals.' 'Density is intentional.' 'Every screen needs a clear back path.' Ladder learns what your leadership cares about.",
-    detail: "Custom rules, weighted priorities, team-specific quality definitions",
-  },
-  {
-    name: "Custom Rubric Weights",
-    desc: "Care more about accessibility than visual polish? Prioritize information hierarchy over delight? Adjust the scoring weights. The Ladder score reflects your team's priorities.",
-    detail: "Dimension weighting, category emphasis, scoring calibration",
+    desc: "Every designer, every score, every trend in one view. Live activity feed, per-member trajectory, and pooled usage in real time.",
+    detail: "Portfolio score, individual trends, activity feed",
   },
   {
     name: "Designer Management",
-    desc: "Invite designers by email. See each person's score history, improvement trajectory, and areas of strength. Know who needs coaching before they ask for it.",
-    detail: "Invite flow, individual profiles, skill mapping, coaching signals",
+    desc: "Invite designers by email. Promote co-admins, pause members during leave, archive alumni, and remove anyone who shouldn't be on the team.",
+    detail: "Invite flow, role and status controls, audit trail",
+  },
+  {
+    name: "Pooled Scoring",
+    desc: "One monthly allowance shared across the whole team, every surface. Web, Figma, and the Claude Skill all draw from the same pool, all show up in your team feed.",
+    detail: "Shared queries, unified history, every Ladder surface",
   },
 ];
 
 const WHAT_CHANGES = [
   {
     before: "Designers score in isolation",
-    after: "Every score factors in your brand standards and leadership lens automatically",
+    after: "Every score lands in a shared team feed the leader watches in real time",
   },
   {
     before: "Quality is subjective across the team",
-    after: "One number, calibrated to your organization's definition of good",
+    after: "One framework, one score, calibrated to the same five-rung Ladder",
   },
   {
     before: "You find out about quality problems at review time",
-    after: "Dashboard shows drift in real time. Intervene early, not late",
+    after: "Dashboard surfaces every score as it lands. Catch drift early, not late",
   },
   {
     before: "No way to measure team improvement over time",
-    after: "Portfolio score trends, individual growth curves, velocity metrics",
+    after: "Per-designer trajectory, team portfolio score, monthly pooled usage",
   },
 ];
 
 const TIER = {
   name: "Teams",
-  price: "$12,000",
-  period: "/ year",
   features: [
     "Team leader dashboard on runladder.com",
-    "Add and manage up to ten designers",
-    "Team knowledge base (brand standards + leadership lens)",
-    "Per-designer scores, trends, and leaderboard",
-    "Unlimited scores on all surfaces (web and Claude)",
+    "Up to 10 active designers included (extra seats available)",
+    "Live activity feed across web, Figma, and the Claude Skill",
+    "Per-designer scores and trajectory",
+    "Pooled monthly query allowance shared across the team",
     "Priority support",
   ],
 };
@@ -78,14 +66,13 @@ export default function TeamsPage() {
             Ladder for Teams
           </p>
           <h1 className="text-[3.5rem] md:text-[5rem] font-bold tracking-tight leading-[1.05] mb-8">
-            Your standards.{" "}
-            <span className="text-ladder-green">Every score.</span>
+            Your team.{" "}
+            <span className="text-ladder-green">One quality bar.</span>
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto mb-12 leading-relaxed">
-            Load your brand standards, encode your design leadership's
-            priorities, and every Ladder score your team runs reflects
-            what quality means to <em>your</em> organization. Not generic.
-            Yours.
+            Every designer&rsquo;s scores in one feed. Per-member trends,
+            pooled usage, full member management. The dashboard your design
+            organization should have had years ago.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link
@@ -111,31 +98,28 @@ export default function TeamsPage() {
             The gap
           </p>
           <h2 className="text-[2rem] md:text-[2.5rem] font-bold leading-snug mb-10">
-            Generic quality frameworks{" "}
+            Design quality is invisible{" "}
             <br />
             <span className="text-body">
-              don&rsquo;t know your brand.
+              until the review meeting.
             </span>
           </h2>
           <div className="space-y-6 text-body leading-relaxed">
             <p>
-              Your design team has standards that go beyond basic UX. You
-              have a brand voice. You have a design system. Your VP of
-              Design has specific things they care about that no external
-              tool knows. When a new designer joins, it takes months
-              before they internalize all of it.
+              Designers ship. Leaders catch up. By the time a quality
+              problem surfaces in a review, it has been in production for a
+              week. Coaching happens too late. New hires drift before
+              anyone notices. The team has no shared number to point at.
             </p>
             <p>
-              A Ladder score is already honest. But a Ladder score
-              calibrated to your organization is transformative. It
-              doesn't just tell a designer &ldquo;this screen is a
-              2.4.&rdquo; It tells them &ldquo;this screen is a 2.4
-              because it violates your brand's density principles and
-              the back-path rule your VP of Design set.&rdquo;
+              Teams puts every score your designers run in one live feed.
+              You see the scan the moment it lands. You see the trend per
+              designer. You see which surfaces are weakest. You manage who
+              is on the team and when. Same Ladder framework. Now you can
+              actually run a design quality program with it.
             </p>
             <p className="text-foreground font-medium">
-              Teams turns Ladder from a universal quality score into your
-              team's quality score. Same rigor, your rules.
+              Stop finding out at review time. Watch quality in real time.
             </p>
           </div>
         </div>
@@ -146,15 +130,15 @@ export default function TeamsPage() {
         <div className="max-w-4xl mx-auto">
           <div className="text-center mb-20">
             <p className="font-mono text-xs text-muted uppercase tracking-widest mb-8">
-              What you control
+              What you get
             </p>
             <h2 className="text-[2rem] md:text-[2.5rem] font-bold mb-6">
               A dashboard built for{" "}
               <span className="text-ladder-green">design leaders.</span>
             </h2>
             <p className="text-body max-w-lg mx-auto leading-relaxed">
-              Log in to runladder.com. See your team. Manage your
-              standards. Watch quality improve.
+              Log in to runladder.com. See your team. Run the team.
+              Watch quality move.
             </p>
           </div>
 
@@ -234,24 +218,21 @@ export default function TeamsPage() {
           <h2 className="text-[2rem] md:text-[2.5rem] font-bold leading-snug mb-10">
             Nothing changes for them.{" "}
             <br />
-            <span className="text-ladder-green">Everything improves.</span>
+            <span className="text-ladder-green">You see everything.</span>
           </h2>
           <div className="space-y-6 text-body leading-relaxed">
             <p>
-              Designers keep using runladder.com
-              exactly as they do now. They hit &ldquo;Score This
-              Screen&rdquo; and get a Ladder score with coaching cards.
+              Designers keep using runladder.com, the Figma plugin, and
+              the Claude Skill exactly as they do today. Score a screen,
+              get a Ladder score with coaching cards.
             </p>
             <p>
-              The difference: behind the scenes, their score now factors
-              in your brand standards and your leadership's priorities.
-              The coaching cards don't just say &ldquo;improve
-              spacing.&rdquo; They say &ldquo;your hierarchy buries the
-              primary action your team agreed should always lead.&rdquo;
+              Once they accept the team invite, every score they run shows
+              up on the leader&rsquo;s team dashboard automatically. No
+              extra UI to learn. No new workflow to adopt.
             </p>
             <p className="text-foreground font-medium">
-              Zero onboarding friction. Every designer gets your team's
-              quality DNA baked into every score, from their first day.
+              Zero onboarding friction. Full visibility from day one.
             </p>
           </div>
         </div>
@@ -259,137 +240,52 @@ export default function TeamsPage() {
 
       {/* Pricing */}
       <section className="py-36 px-6 border-t border-border">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center mb-20">
+        <div className="max-w-3xl mx-auto">
+          <div className="text-center mb-16">
             <p className="font-mono text-xs text-muted uppercase tracking-widest mb-8">
               Pricing
             </p>
             <h2 className="text-[2rem] md:text-[2.5rem] font-bold mb-6">
-              Annual plans for{" "}
+              Built for{" "}
               <span className="text-ladder-green">serious teams.</span>
             </h2>
             <p className="text-body max-w-lg mx-auto leading-relaxed">
-              Teams is infrastructure, not a trial. Annual commitment,
-              full customization, dedicated support.
+              Teams is sold through a master services agreement, not self-serve
+              checkout. We set the seat count and pool that fits your team.
             </p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-3xl mx-auto">
-            {/* Try it out — single designer */}
-            <div className="rounded-2xl p-8 flex flex-col border border-border bg-card">
-              <span className="self-start text-[11px] font-mono uppercase tracking-widest px-3 py-1 mb-6 bg-border/50 text-muted">
-                Try it out
-              </span>
-              <h3 className="text-lg font-bold text-foreground mb-4">
-                One Designer
-              </h3>
+          <div className="rounded-2xl p-10 flex flex-col border-2 border-ladder-green bg-ladder-green/5 max-w-2xl mx-auto">
+            <span className="self-start text-[11px] font-mono uppercase tracking-widest px-3 py-1 mb-6 bg-ladder-green/15 text-ladder-green">
+              Full team
+            </span>
+            <h3 className="text-lg font-bold text-foreground mb-3">
+              {TIER.name}
+            </h3>
+            <p className="text-sm text-muted mb-8">
+              Talk to us. We&rsquo;ll work out the right plan for your design org.
+            </p>
 
-              <div className="flex items-baseline gap-1.5 mb-1">
-                <span className="text-[2.5rem] font-bold text-foreground leading-none">
-                  $29
-                </span>
-                <span className="text-sm text-muted">/ mo</span>
-              </div>
-              <p className="text-xs text-muted mb-6">Test it out with one designer</p>
+            <ul className="space-y-3 mb-10 flex-1">
+              {TIER.features.map((f: string) => (
+                <li
+                  key={f}
+                  className="text-sm text-body flex items-start gap-2.5"
+                >
+                  <span className="text-ladder-green text-xs mt-1 flex-shrink-0">
+                    +
+                  </span>
+                  {f}
+                </li>
+              ))}
+            </ul>
 
-              <div className="border border-border rounded-lg px-4 py-3 mb-8">
-                <p className="font-mono text-xs text-ladder-green">
-                  Unlimited scores on all surfaces
-                </p>
-              </div>
-
-              <ul className="space-y-3 mb-10 flex-1">
-                {[
-                  "Ladder score with coaching cards",
-                  "Per-dimension scoring breakdown",
-                  "Full score history + trend line",
-                  "Web and Claude access",
-                ].map((f: string) => (
-                  <li
-                    key={f}
-                    className="text-sm text-body flex items-start gap-2.5"
-                  >
-                    <span className="text-ladder-green text-xs mt-1 flex-shrink-0">
-                      +
-                    </span>
-                    {f}
-                  </li>
-                ))}
-              </ul>
-
-              <Link
-                href="/score"
-                className="text-center text-sm font-semibold py-3 rounded-full transition-colors border border-border text-foreground hover:bg-card-hover"
-              >
-                Start scoring
-              </Link>
-            </div>
-
-            {/* Teams */}
-            <div className="rounded-2xl p-8 flex flex-col border-2 border-ladder-green bg-ladder-green/5">
-              <span className="self-start text-[11px] font-mono uppercase tracking-widest px-3 py-1 mb-6 bg-ladder-green/15 text-ladder-green">
-                Full team
-              </span>
-              <h3 className="text-lg font-bold text-foreground mb-4">
-                {TIER.name}
-              </h3>
-
-              <div className="flex items-baseline gap-1.5 mb-1">
-                <span className="text-[2.5rem] font-bold text-foreground leading-none">
-                  {TIER.price}
-                </span>
-                <span className="text-sm text-muted">{TIER.period}</span>
-              </div>
-              <p className="text-xs text-muted mb-6">Everything your design org needs</p>
-
-              <div className="border border-border rounded-lg px-4 py-3 mb-8">
-                <p className="font-mono text-xs text-ladder-green">
-                  Unlimited scores on all surfaces
-                </p>
-              </div>
-
-              <ul className="space-y-3 mb-10 flex-1">
-                {TIER.features.map((f: string) => (
-                  <li
-                    key={f}
-                    className="text-sm text-body flex items-start gap-2.5"
-                  >
-                    <span className="text-ladder-green text-xs mt-1 flex-shrink-0">
-                      +
-                    </span>
-                    {f}
-                  </li>
-                ))}
-              </ul>
-
-              <Link
-                href="/contact"
-                className="text-center text-sm font-semibold py-3 rounded-full transition-colors bg-ladder-green text-background hover:bg-ladder-green/90"
-              >
-                Talk to us about Teams
-              </Link>
-            </div>
-          </div>
-
-          {/* Enterprise */}
-          <div className="mt-6 border border-border rounded-2xl p-10 bg-card max-w-3xl mx-auto">
-            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-8">
-              <div>
-                <h3 className="font-mono text-sm font-semibold text-foreground mb-3">
-                  Enterprise
-                </h3>
-                <p className="text-sm text-body max-w-lg leading-relaxed">
-                  25+ designers, SSO, multi-team dashboards, dedicated CSM,
-                  and custom integrations. Priced for your scale.
-                </p>
-              </div>
-              <Link
-                href="/contact"
-                className="shrink-0 text-center text-sm font-semibold border border-border text-foreground hover:bg-card-hover py-3 px-8 rounded-full transition-colors"
-              >
-                Talk to us
-              </Link>
-            </div>
+            <Link
+              href="/contact"
+              className="text-center text-sm font-semibold py-3 rounded-full transition-colors bg-ladder-green text-background hover:bg-ladder-green/90"
+            >
+              Talk to us about Teams
+            </Link>
           </div>
         </div>
       </section>
@@ -419,9 +315,9 @@ export default function TeamsPage() {
               },
               {
                 stat: "Day 1",
-                label: "onboarding",
+                label: "visibility",
                 detail:
-                  "New designers inherit your team's quality DNA from their very first score",
+                  "Every new designer's scores show up on your team dashboard from their first scan",
               },
             ].map((p) => (
               <div key={p.label} className="text-center">
@@ -444,13 +340,12 @@ export default function TeamsPage() {
       <section className="py-36 px-6 border-t border-border">
         <div className="max-w-2xl mx-auto text-center">
           <h2 className="text-[2.5rem] font-bold mb-6">
-            Make quality{" "}
-            <span className="text-ladder-green">your team's DNA.</span>
+            Stop guessing.{" "}
+            <span className="text-ladder-green">Start measuring.</span>
           </h2>
           <p className="text-body mb-10 leading-relaxed max-w-lg mx-auto">
-            Your brand standards. Your leadership's priorities. Baked
-            into every score, every coaching card, every designer's
-            workflow. From day one.
+            Every score, every designer, every surface, in one feed.
+            Manage who&rsquo;s on the team. Watch quality move.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link

--- a/src/lib/team-auth.ts
+++ b/src/lib/team-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * Team auth helpers for /api/team/* routes.
+ *
+ * `requireTeamMember()` resolves the current Clerk user, looks up their
+ * team membership, and returns either an OK result with team context or
+ * an Err result with a ready-to-return NextResponse.
+ *
+ * `requireTeamAdmin()` is the same but additionally enforces
+ * `membership.role === "admin"`.
+ */
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getMember, getTeam, getUserTeamId, type Membership, type Team } from "@/lib/teams";
+
+export type TeamAuthOk = {
+  ok: true;
+  userId: string;
+  team: Team;
+  membership: Membership;
+};
+
+export type TeamAuthErr = {
+  ok: false;
+  response: NextResponse;
+};
+
+export async function requireTeamMember(): Promise<TeamAuthOk | TeamAuthErr> {
+  const { userId } = await auth();
+  if (!userId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Sign in required" },
+        { status: 401 },
+      ),
+    };
+  }
+
+  const teamId = await getUserTeamId(userId);
+  if (!teamId) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Not on a team" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  const team = await getTeam(teamId);
+  const membership = await getMember(teamId, userId);
+  if (!team || !membership) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Team or membership not found" },
+        { status: 404 },
+      ),
+    };
+  }
+
+  if (membership.status === "archived") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Membership is archived" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return { ok: true, userId, team, membership };
+}
+
+export async function requireTeamAdmin(): Promise<TeamAuthOk | TeamAuthErr> {
+  const result = await requireTeamMember();
+  if (!result.ok) return result;
+
+  if (result.membership.role !== "admin") {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Team admin role required" },
+        { status: 403 },
+      ),
+    };
+  }
+
+  return result;
+}

--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -21,10 +21,12 @@
  *   team:{teamId}:usage:{YYYY-MM}        Counter, monthly pooled query count
  *   team:{teamId}:invites                Hash, token -> JSON Invite
  *   invite:{token}                       String, teamId (TTL'd lookup helper)
+ *   team-invite-by-email:{email}         String, JSON {teamId, token} (auto-claim index)
  *   user:{userId}:team                   String, teamId (one team per user)
  */
 import { randomBytes } from "crypto";
 import { redis } from "@/lib/redis";
+import { setUserSubscription } from "@/lib/tier";
 
 /* ── Types ──────────────────────────────────────────────────────── */
 
@@ -104,6 +106,8 @@ const teamUsageKey = (teamId: string, yearMonth: string) =>
   `team:${teamId}:usage:${yearMonth}`;
 const teamInvitesKey = (teamId: string) => `team:${teamId}:invites`;
 const inviteLookupKey = (token: string) => `invite:${token}`;
+const inviteByEmailKey = (email: string) =>
+  `team-invite-by-email:${email.toLowerCase().trim()}`;
 const userTeamKey = (userId: string) => `user:${userId}:team`;
 
 /* ── Internal helpers ───────────────────────────────────────────── */
@@ -439,6 +443,13 @@ export async function createInvite(args: {
   await redis.set(inviteLookupKey(token), args.teamId, {
     ex: INVITE_TTL_DAYS * 24 * 60 * 60,
   });
+  // By-email index so the invitee gets auto-claimed on first sign-in
+  // even if they never clicked the magic link.
+  await redis.set(
+    inviteByEmailKey(invite.email),
+    JSON.stringify({ teamId: args.teamId, token }),
+    { ex: INVITE_TTL_DAYS * 24 * 60 * 60 },
+  );
   return invite;
 }
 
@@ -469,6 +480,117 @@ export async function deleteInvite(
   teamId: string,
   token: string,
 ): Promise<void> {
+  // Look up the invite first so we can clear the by-email index too.
+  const raw = await redis.hget(teamInvitesKey(teamId), token);
+  const invite = parseMaybeJson<Invite>(raw);
   await redis.hdel(teamInvitesKey(teamId), token);
   await redis.del(inviteLookupKey(token));
+  if (invite?.email) {
+    // Only clear if the email index still points at this token. Avoids
+    // a race where a newer invite to the same email is stomped by an
+    // older invite being revoked.
+    const idxRaw = await redis.get(inviteByEmailKey(invite.email));
+    const idx = parseMaybeJson<{ teamId: string; token: string }>(idxRaw);
+    if (idx?.token === token) {
+      await redis.del(inviteByEmailKey(invite.email));
+    }
+  }
+}
+
+/**
+ * Look up a pending invite by email — used by /api/dashboard and /api/me
+ * to auto-claim invites when a user signs in without clicking the magic
+ * link. Returns null if no invite exists for this email.
+ *
+ * Fast path: read the by-email index. Slow-path fallback for invites that
+ * predate the index — scan every team's invite hash. The fallback is
+ * O(teams × invites) but only fires when the index is missing, and we
+ * lazily backfill the index when the fallback finds a match.
+ */
+export async function findPendingInviteByEmail(
+  email: string,
+): Promise<Invite | null> {
+  const normalized = email.toLowerCase().trim();
+
+  // Fast path
+  const idxRaw = await redis.get(inviteByEmailKey(normalized));
+  const idx = parseMaybeJson<{ teamId: string; token: string }>(idxRaw);
+  if (idx) {
+    const raw = await redis.hget(teamInvitesKey(idx.teamId), idx.token);
+    const invite = parseMaybeJson<Invite>(raw);
+    if (invite && invite.expiresAt > Date.now()) {
+      return invite;
+    }
+  }
+
+  // Fallback: scan every team for a matching pending invite.
+  const teamIds = (await redis.smembers(teamsAllKey())) as string[];
+  for (const teamId of teamIds || []) {
+    const all = (await redis.hgetall(teamInvitesKey(teamId))) as Record<
+      string,
+      unknown
+    > | null;
+    if (!all) continue;
+    for (const raw of Object.values(all)) {
+      const invite = parseMaybeJson<Invite>(raw);
+      if (!invite) continue;
+      if (invite.email.toLowerCase() !== normalized) continue;
+      if (invite.expiresAt < Date.now()) continue;
+      // Lazily backfill the index so the next lookup is a single read.
+      const ttlSeconds = Math.max(
+        60,
+        Math.floor((invite.expiresAt - Date.now()) / 1000),
+      );
+      await redis.set(
+        inviteByEmailKey(normalized),
+        JSON.stringify({ teamId: invite.teamId, token: invite.token }),
+        { ex: ttlSeconds },
+      );
+      return invite;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Auto-claim any pending team invite for any of the user's verified emails.
+ * Idempotent: if the user is already on a team, returns that team. If no
+ * pending invite exists for any email, returns null.
+ *
+ * Side effects on successful claim:
+ *   - Adds the user as a member of the team (role from the invite)
+ *   - Stamps `tier: "team"` on Clerk publicMetadata
+ *   - Deletes the invite + by-email index + token lookup
+ */
+export async function claimPendingTeamInviteForEmails(
+  userId: string,
+  emails: string[],
+): Promise<{ teamId: string; role: TeamRole } | null> {
+  // Already on a team — return that.
+  const existing = await getUserTeamId(userId);
+  if (existing) {
+    const m = await getMember(existing, userId);
+    return m ? { teamId: existing, role: m.role } : null;
+  }
+
+  // Find a pending invite for any of this user's emails.
+  for (const email of emails) {
+    if (!email) continue;
+    const invite = await findPendingInviteByEmail(email);
+    if (!invite) continue;
+    // Verify the team still exists before we promote.
+    const team = await getTeam(invite.teamId);
+    if (!team) continue;
+
+    await addMember(invite.teamId, userId, invite.role, invite.invitedBy);
+    // Stamp team tier on Clerk publicMetadata so paid-tier checks pass
+    // across every surface (web, Skill, MCP, plugin).
+    await setUserSubscription(userId, { tier: "team" });
+    await deleteInvite(invite.teamId, invite.token);
+
+    return { teamId: invite.teamId, role: invite.role };
+  }
+
+  return null;
 }

--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -1,0 +1,474 @@
+/**
+ * Ladder for Teams — data model and helpers.
+ *
+ * One team per user. Teams are provisioned by Ladder admins (Drawbackwards)
+ * via /admin/teams; members are invited by team admins through their own
+ * /dashboard/team UI. Tier "team" gets stamped on every member's Clerk
+ * publicMetadata so paid-tier checks across the codebase keep working
+ * unchanged.
+ *
+ * Pricing model:
+ *   - 10 active seats included (the team admin/owner counts as one of the 10)
+ *   - Each active member beyond 10 = $250/mo overage (invoiced via MSA)
+ *   - Paused or archived members do NOT count as active
+ *   - Pooled queries: 25,000/mo across the whole team
+ *
+ * Redis key schema:
+ *   teams:all                            Set of team IDs
+ *   team:{teamId}                        Hash, team metadata (see Team type)
+ *   team:{teamId}:members                Hash, userId -> JSON Membership
+ *   team:{teamId}:activity               Sorted set, timestamp -> JSON event
+ *   team:{teamId}:usage:{YYYY-MM}        Counter, monthly pooled query count
+ *   team:{teamId}:invites                Hash, token -> JSON Invite
+ *   invite:{token}                       String, teamId (TTL'd lookup helper)
+ *   user:{userId}:team                   String, teamId (one team per user)
+ */
+import { randomBytes } from "crypto";
+import { redis } from "@/lib/redis";
+
+/* ── Types ──────────────────────────────────────────────────────── */
+
+export type TeamRole = "admin" | "member";
+export type MemberStatus = "active" | "paused" | "archived";
+export type TeamStatus = "active" | "paused" | "archived";
+
+export type Team = {
+  id: string;
+  name: string;
+  ownerUserId: string;
+  status: TeamStatus;
+  /** Included active seats. Active members beyond this cap incur overage. */
+  seatCap: number;
+  /** Dollars per month per overage seat. */
+  perOverageSeatPrice: number;
+  /** Pooled scoring queries per calendar month across all members. */
+  queryPool: number;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type Membership = {
+  userId: string;
+  role: TeamRole;
+  status: MemberStatus;
+  joinedAt: number;
+  invitedBy?: string;
+};
+
+export type TeamActivityEvent = {
+  type: "score";
+  timestamp: number;
+  userId: string;
+  scoreId: string;
+  score: number;
+  label: string;
+  screenName?: string;
+  source: string;
+  thumbnail?: string;
+};
+
+export type Invite = {
+  token: string;
+  teamId: string;
+  email: string;
+  role: TeamRole;
+  invitedBy: string;
+  createdAt: number;
+  expiresAt: number;
+};
+
+export type BillingSummary = {
+  active: number;
+  paused: number;
+  archived: number;
+  included: number;
+  overageSeats: number;
+  overagePrice: number;
+};
+
+/* ── Defaults ───────────────────────────────────────────────────── */
+
+export const DEFAULT_SEAT_CAP = 10;
+export const DEFAULT_OVERAGE_PRICE = 250;
+export const DEFAULT_QUERY_POOL = 25_000;
+const INVITE_TTL_DAYS = 14;
+const USAGE_KEY_TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days, post-month buffer
+
+/* ── Keys ───────────────────────────────────────────────────────── */
+
+const teamsAllKey = () => "teams:all";
+const teamKey = (teamId: string) => `team:${teamId}`;
+const teamMembersKey = (teamId: string) => `team:${teamId}:members`;
+const teamActivityKey = (teamId: string) => `team:${teamId}:activity`;
+const teamUsageKey = (teamId: string, yearMonth: string) =>
+  `team:${teamId}:usage:${yearMonth}`;
+const teamInvitesKey = (teamId: string) => `team:${teamId}:invites`;
+const inviteLookupKey = (token: string) => `invite:${token}`;
+const userTeamKey = (userId: string) => `user:${userId}:team`;
+
+/* ── Internal helpers ───────────────────────────────────────────── */
+
+function newId(prefix: string, bytes = 8): string {
+  return `${prefix}_${randomBytes(bytes).toString("hex")}`;
+}
+
+function newToken(): string {
+  return randomBytes(24).toString("hex");
+}
+
+function currentYearMonth(): string {
+  const d = new Date();
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/**
+ * Upstash returns hash values either as parsed JSON objects or as JSON
+ * strings, depending on the value's shape. Normalize both.
+ */
+function parseMaybeJson<T>(value: unknown): T | null {
+  if (value == null) return null;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return null;
+    }
+  }
+  return value as T;
+}
+
+function teamFromHash(data: Record<string, unknown> | null): Team | null {
+  if (!data || !data.id) return null;
+  return {
+    id: String(data.id),
+    name: String(data.name ?? ""),
+    ownerUserId: String(data.ownerUserId ?? ""),
+    status: (data.status as TeamStatus) || "active",
+    seatCap: Number(data.seatCap) || DEFAULT_SEAT_CAP,
+    perOverageSeatPrice:
+      Number(data.perOverageSeatPrice) || DEFAULT_OVERAGE_PRICE,
+    queryPool: Number(data.queryPool) || DEFAULT_QUERY_POOL,
+    createdAt: Number(data.createdAt) || 0,
+    updatedAt: Number(data.updatedAt) || 0,
+  };
+}
+
+/* ── Teams ──────────────────────────────────────────────────────── */
+
+export async function createTeam(args: {
+  name: string;
+  ownerUserId: string;
+  seatCap?: number;
+  perOverageSeatPrice?: number;
+  queryPool?: number;
+}): Promise<Team> {
+  const id = newId("team");
+  const now = Date.now();
+  const team: Team = {
+    id,
+    name: args.name.trim(),
+    ownerUserId: args.ownerUserId,
+    status: "active",
+    seatCap: args.seatCap ?? DEFAULT_SEAT_CAP,
+    perOverageSeatPrice: args.perOverageSeatPrice ?? DEFAULT_OVERAGE_PRICE,
+    queryPool: args.queryPool ?? DEFAULT_QUERY_POOL,
+    createdAt: now,
+    updatedAt: now,
+  };
+  await redis.hset(teamKey(id), team as unknown as Record<string, unknown>);
+  await redis.sadd(teamsAllKey(), id);
+  await addMember(id, args.ownerUserId, "admin");
+  return team;
+}
+
+export async function getTeam(teamId: string): Promise<Team | null> {
+  const data = await redis.hgetall<Record<string, unknown>>(teamKey(teamId));
+  return teamFromHash(data);
+}
+
+export async function listTeams(): Promise<Team[]> {
+  const ids = (await redis.smembers(teamsAllKey())) as string[];
+  if (!ids || ids.length === 0) return [];
+  const teams = await Promise.all(ids.map((id) => getTeam(id)));
+  return teams.filter((t): t is Team => t !== null);
+}
+
+export async function updateTeam(
+  teamId: string,
+  patch: Partial<
+    Pick<
+      Team,
+      "name" | "status" | "seatCap" | "perOverageSeatPrice" | "queryPool"
+    >
+  >,
+): Promise<Team | null> {
+  const existing = await getTeam(teamId);
+  if (!existing) return null;
+  const next: Team = { ...existing, ...patch, updatedAt: Date.now() };
+  await redis.hset(teamKey(teamId), next as unknown as Record<string, unknown>);
+  return next;
+}
+
+/* ── Members ────────────────────────────────────────────────────── */
+
+export async function addMember(
+  teamId: string,
+  userId: string,
+  role: TeamRole,
+  invitedBy?: string,
+): Promise<Membership> {
+  const membership: Membership = {
+    userId,
+    role,
+    status: "active",
+    joinedAt: Date.now(),
+    invitedBy,
+  };
+  await redis.hset(teamMembersKey(teamId), {
+    [userId]: JSON.stringify(membership),
+  });
+  await redis.set(userTeamKey(userId), teamId);
+  return membership;
+}
+
+export async function getMember(
+  teamId: string,
+  userId: string,
+): Promise<Membership | null> {
+  const raw = await redis.hget(teamMembersKey(teamId), userId);
+  return parseMaybeJson<Membership>(raw);
+}
+
+export async function listMembers(teamId: string): Promise<Membership[]> {
+  const all = (await redis.hgetall(teamMembersKey(teamId))) as Record<
+    string,
+    unknown
+  > | null;
+  if (!all) return [];
+  return Object.values(all)
+    .map((raw) => parseMaybeJson<Membership>(raw))
+    .filter((m): m is Membership => m !== null);
+}
+
+export async function setMemberStatus(
+  teamId: string,
+  userId: string,
+  status: MemberStatus,
+): Promise<Membership | null> {
+  const m = await getMember(teamId, userId);
+  if (!m) return null;
+  const next: Membership = { ...m, status };
+  await redis.hset(teamMembersKey(teamId), {
+    [userId]: JSON.stringify(next),
+  });
+  return next;
+}
+
+export async function setMemberRole(
+  teamId: string,
+  userId: string,
+  role: TeamRole,
+): Promise<Membership | null> {
+  const m = await getMember(teamId, userId);
+  if (!m) return null;
+  const next: Membership = { ...m, role };
+  await redis.hset(teamMembersKey(teamId), {
+    [userId]: JSON.stringify(next),
+  });
+  return next;
+}
+
+export async function removeMember(
+  teamId: string,
+  userId: string,
+): Promise<void> {
+  await redis.hdel(teamMembersKey(teamId), userId);
+  const current = await redis.get<string>(userTeamKey(userId));
+  if (current === teamId) {
+    await redis.del(userTeamKey(userId));
+  }
+}
+
+export async function getUserTeamId(userId: string): Promise<string | null> {
+  const id = await redis.get<string>(userTeamKey(userId));
+  return id ?? null;
+}
+
+/* ── Seat math ──────────────────────────────────────────────────── */
+
+export async function getBillingSummary(
+  teamId: string,
+): Promise<BillingSummary> {
+  const team = await getTeam(teamId);
+  if (!team) {
+    return {
+      active: 0,
+      paused: 0,
+      archived: 0,
+      included: 0,
+      overageSeats: 0,
+      overagePrice: 0,
+    };
+  }
+  const members = await listMembers(teamId);
+  const active = members.filter((m) => m.status === "active").length;
+  const paused = members.filter((m) => m.status === "paused").length;
+  const archived = members.filter((m) => m.status === "archived").length;
+  const overageSeats = Math.max(0, active - team.seatCap);
+  return {
+    active,
+    paused,
+    archived,
+    included: team.seatCap,
+    overageSeats,
+    overagePrice: overageSeats * team.perOverageSeatPrice,
+  };
+}
+
+/* ── Activity ───────────────────────────────────────────────────── */
+
+export async function recordTeamActivity(
+  teamId: string,
+  event: TeamActivityEvent,
+): Promise<void> {
+  await redis.zadd(teamActivityKey(teamId), {
+    score: event.timestamp,
+    member: JSON.stringify(event),
+  });
+}
+
+export async function getTeamActivity(
+  teamId: string,
+  limit = 50,
+): Promise<TeamActivityEvent[]> {
+  const items = (await redis.zrange(teamActivityKey(teamId), 0, limit - 1, {
+    rev: true,
+  })) as unknown[];
+  if (!items) return [];
+  return items
+    .map((raw) => parseMaybeJson<TeamActivityEvent>(raw))
+    .filter((e): e is TeamActivityEvent => e !== null);
+}
+
+/* ── Pooled usage ───────────────────────────────────────────────── */
+
+export async function incrementTeamUsage(teamId: string): Promise<number> {
+  const ym = currentYearMonth();
+  const key = teamUsageKey(teamId, ym);
+  const next = await redis.incr(key);
+  if (next === 1) {
+    await redis.expire(key, USAGE_KEY_TTL_SECONDS);
+  }
+  return next;
+}
+
+export async function getTeamUsage(teamId: string): Promise<number> {
+  const ym = currentYearMonth();
+  return (await redis.get<number>(teamUsageKey(teamId, ym))) ?? 0;
+}
+
+/**
+ * Resolve a user's team pool status — used by score routes before they hit
+ * the scoring engine, so we can enforce the monthly pooled query cap.
+ *
+ * Returns `null` if the user is not on a team. Otherwise returns the
+ * monthly usage and pool with a derived `exceeded` flag.
+ */
+export async function getTeamPoolStatus(userId: string): Promise<{
+  teamId: string;
+  used: number;
+  pool: number;
+  exceeded: boolean;
+} | null> {
+  const teamId = await getUserTeamId(userId);
+  if (!teamId) return null;
+  const team = await getTeam(teamId);
+  if (!team) return null;
+  const used = await getTeamUsage(teamId);
+  return {
+    teamId,
+    used,
+    pool: team.queryPool,
+    exceeded: used >= team.queryPool,
+  };
+}
+
+/**
+ * Record a successful score against a user's team — appends to the team's
+ * activity feed and increments the monthly pool usage counter. No-op if
+ * the user is not on a team. Best-effort: callers should not gate on this.
+ */
+export async function recordScoreForTeam(
+  userId: string,
+  event: Omit<TeamActivityEvent, "type" | "userId">,
+): Promise<void> {
+  const teamId = await getUserTeamId(userId);
+  if (!teamId) return;
+  await Promise.all([
+    recordTeamActivity(teamId, {
+      type: "score",
+      userId,
+      ...event,
+    }),
+    incrementTeamUsage(teamId),
+  ]);
+}
+
+/* ── Invites ────────────────────────────────────────────────────── */
+
+export async function createInvite(args: {
+  teamId: string;
+  email: string;
+  role: TeamRole;
+  invitedBy: string;
+}): Promise<Invite> {
+  const token = newToken();
+  const now = Date.now();
+  const invite: Invite = {
+    token,
+    teamId: args.teamId,
+    email: args.email.toLowerCase().trim(),
+    role: args.role,
+    invitedBy: args.invitedBy,
+    createdAt: now,
+    expiresAt: now + INVITE_TTL_DAYS * 24 * 60 * 60 * 1000,
+  };
+  await redis.hset(teamInvitesKey(args.teamId), {
+    [token]: JSON.stringify(invite),
+  });
+  await redis.set(inviteLookupKey(token), args.teamId, {
+    ex: INVITE_TTL_DAYS * 24 * 60 * 60,
+  });
+  return invite;
+}
+
+export async function getInviteByToken(token: string): Promise<Invite | null> {
+  const teamId = await redis.get<string>(inviteLookupKey(token));
+  if (!teamId) return null;
+  const raw = await redis.hget(teamInvitesKey(teamId), token);
+  const invite = parseMaybeJson<Invite>(raw);
+  if (!invite) return null;
+  if (invite.expiresAt < Date.now()) return null;
+  return invite;
+}
+
+export async function listInvites(teamId: string): Promise<Invite[]> {
+  const all = (await redis.hgetall(teamInvitesKey(teamId))) as Record<
+    string,
+    unknown
+  > | null;
+  if (!all) return [];
+  return Object.values(all)
+    .map((raw) => parseMaybeJson<Invite>(raw))
+    .filter(
+      (i): i is Invite => i !== null && i.expiresAt > Date.now(),
+    );
+}
+
+export async function deleteInvite(
+  teamId: string,
+  token: string,
+): Promise<void> {
+  await redis.hdel(teamInvitesKey(teamId), token);
+  await redis.del(inviteLookupKey(token));
+}


### PR DESCRIPTION
## Summary

Ladder for Teams — the minimum offering. Drawbackwards admins provision team accounts; design leaders run their team at `/dashboard/team`; designers keep using `/score`, Figma, and the Skill exactly as today, and their scores roll up automatically.

- **`/admin/teams`** — provision new teams (name, owner email, seat cap, overage price, pool), list + edit existing teams, see active seats and overage at a glance
- **`/dashboard/team`** — live activity feed, stat tiles (active seats / overage / pool / member count), invite form, pending invites with revoke, member management (pause, reactivate, archive, promote, demote, remove)
- **Invite flow** — admin sends email via Resend with magic accept link; recipient signs in, accepts at `/team/join/[token]`, gets `tier: "team"` stamped on Clerk metadata
- **Pricing model** — 10 active seats included (admin counted as one), $250/mo per overage seat (invoiced via MSA), 25,000 pooled queries/month
- **Score wiring** — web, Skill, and Figma plugin score routes mirror every score into the team activity feed and tick the pooled monthly counter; web + Skill enforce a 429 when pool is exceeded
- **Marketing trim** — `/teams` reflects what we actually ship: Team Dashboard, Designer Management, Pooled Scoring. Stripped brand-standards / leadership-lens / calibration copy and the broken "$29/mo One Designer" tile and the public "$12,000/year" number

## Architecture notes

- Built on Redis (same pattern as votes, scores, lifetime usage) — no Clerk Organizations dependency
- Stripe stays for self-serve Pro only. Teams skips Stripe entirely; tier is stamped manually after provisioning
- Owner is protected at the API layer from demotion or removal (UI also hides self-actions)
- A user can belong to one team at a time — invites and provisioning both validate this

## Test plan

- [ ] Sign in as admin email; visit `/admin/teams` and provision a team for `ward@drawbackwards.com` with defaults (10 seats, $250 overage, 25K pool)
- [ ] As Ward, visit `/dashboard/team`; verify stat tiles, member tile shows you as admin, no activity yet
- [ ] Invite a designer by email; verify the invite email lands and contains a magic accept link
- [ ] Open the link in another browser, sign in as the invitee; verify auto-redirect to `/dashboard/team` with their tile present
- [ ] Score a screen on `/score`; verify activity feed updates and pool counter ticks up
- [ ] Pause the invitee; verify their status flips and they lose team-tier access (`/score` rate-limits to free)
- [ ] Reactivate; verify access restored
- [ ] Try removing yourself or demoting yourself — verify 400 error
- [ ] Visit `/teams` marketing page; verify new copy, no leftover "brand standards" or "$12,000" references

🤖 Generated with [Claude Code](https://claude.com/claude-code)