### PR TITLE
Teams beta: orgs, invite flow, manager insights, analysis feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.3.0 / api 1.0.0 — 2026-05-05
+
+**Teams beta — invite, manage, measure, learn.**
+
+- **Team management page.** New `/dashboard/team` lets a team manager (Clerk Org admin) invite designers by email, see members and pending invites, and remove or revoke as needed. Custom dark-themed UI matching the rest of the dashboard.
+- **Auto-comp on accept.** When an invitee accepts and lands in the org, the new `/api/webhooks/clerk` handler grants them a `tier: "team"` complimentary subscription with a reason naming the org. Removal revokes the comp only when the user has no remaining org memberships.
+- **Clerk Organizations as the primitive.** Manager and member roles, invite emails, and acceptance flow handled natively by Clerk. Custom super-admin protection on `SUPER_ADMIN_EMAILS` lives alongside (see `src/lib/admin.ts`).
+- **Designer letter grades.** Each member gets an A-F grade based on the percentage of their last-30-day scores that hit Comfortable+ (3.0). Grade color echoes the Ladder rung the designer typically reaches: A=Meaningful white, B=Delightful green, C=Comfortable yellow, D=Usable orange, F=Functional red.
+- **Team performance insights.** The team dashboard shows total scans, team average, and the team's strongest and weakest rung over the window. Lets a manager see at a glance what to coach toward.
+- **Per-member activity.** Members list shows letter grade, total scans, average score, and last-active relative time per designer. Manager sees everyone; non-admin members see only the roster.
+- **Analysis-quality feedback widget.** New `<AnalysisFeedback>` component on `/dashboard/scores/[id]` lets users mark each analysis Helpful or Off-base with an optional note. Backed by `/api/feedback/score` (GET/POST). Anonymous viewers see no widget.
+- **Admin feedback console.** New `/admin/feedback` aggregates ratings and notes across all users, enriched with email, org name, and underlying score data. Helpful/off-base totals at the top so QA can scan trends. Admin-allowlist gated.
+
+---
+
 ## app 0.2.0 / api 1.0.0 — 2026-04-19
 
 **Scoring engine alignment across the suite.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "runladder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "runladder",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.79.0",
         "@clerk/nextjs": "^7.0.8",
@@ -17,7 +17,8 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "sharp": "^0.34.5",
-        "stripe": "^22.1.0"
+        "stripe": "^22.1.0",
+        "svix": "^1.92.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -6981,6 +6982,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.92.2",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.92.2.tgz",
+      "integrity": "sha512-ZmuA3UVvlnF9EgxlzmPtF7CKjQb64Z6OFlyfdDfU0sdcC7dJa+3aOYX5B9mA+RS6ch1AxBa4UP/l6KmqfGtWBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",
@@ -20,7 +20,8 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "sharp": "^0.34.5",
-    "stripe": "^22.1.0"
+    "stripe": "^22.1.0",
+    "svix": "^1.92.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",

--- a/src/app/admin/feedback/page.tsx
+++ b/src/app/admin/feedback/page.tsx
@@ -1,0 +1,232 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
+import { getScoreColor } from "@/lib/ladder";
+
+type FeedbackEntry = {
+  scoreId: string;
+  userId: string;
+  orgId: string | null;
+  rating: "up" | "down";
+  note: string;
+  ts: number;
+  userEmail: string | null;
+  userName: string | null;
+  orgName: string | null;
+  score: number | null;
+  scoreLabel: string | null;
+  screenName: string | null;
+};
+
+function fmtTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const d = new Date(ts);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export default function AdminFeedbackPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [entries, setEntries] = useState<FeedbackEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch("/api/admin/feedback?limit=200");
+        if (res.status === 403) {
+          if (!cancelled) setAuthorized(false);
+          return;
+        }
+        if (!res.ok) {
+          throw new Error(`status ${res.status}`);
+        }
+        const json = await res.json();
+        if (!cancelled) {
+          setAuthorized(true);
+          setEntries(json.feedback ?? []);
+        }
+      } catch (e) {
+        if (!cancelled) setErr(e instanceof Error ? e.message : "Failed to load");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [isSignedIn]);
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (authorized === false) {
+    return (
+      <div className="pt-20 max-w-2xl mx-auto px-6 py-20">
+        <h1 className="text-xl font-bold font-sans mb-3">Admin access required</h1>
+        <p className="text-sm text-muted font-sans">
+          Your Clerk account is signed in but not on the admin allowlist.
+        </p>
+      </div>
+    );
+  }
+
+  const helpful = entries.filter((e) => e.rating === "up").length;
+  const offBase = entries.filter((e) => e.rating === "down").length;
+  const noted = entries.filter((e) => e.note.trim().length > 0).length;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8 flex items-baseline justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-xl text-foreground font-sans">Analysis feedback</h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              Score-by-score feedback from authenticated users.
+            </p>
+          </div>
+          <Link
+            href="/admin"
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+          >
+            ← Admin
+          </Link>
+        </div>
+
+        {err && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {err}
+          </div>
+        )}
+
+        <div className="grid grid-cols-3 gap-2 mb-8">
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Total
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-foreground">
+              {entries.length}
+            </p>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Helpful
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-ladder-green">
+              {helpful}
+            </p>
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e] p-4">
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Off-base
+            </p>
+            <p className="text-2xl font-bold tabular-nums text-ladder-red">
+              {offBase}
+            </p>
+          </div>
+        </div>
+
+        <div className="mb-3 flex items-baseline justify-between">
+          <span className="text-[10px] text-muted uppercase tracking-widest">
+            Recent feedback
+          </span>
+          <span className="text-[10px] text-muted">
+            {noted} with note · {entries.length - noted} rating only
+          </span>
+        </div>
+
+        <div className="border border-[#333] bg-[#1e1e1e]">
+          {loading && entries.length === 0 ? (
+            <div className="p-8 text-center text-muted font-sans text-sm">
+              Loading…
+            </div>
+          ) : entries.length === 0 ? (
+            <div className="p-8 text-center text-muted font-sans text-sm">
+              No feedback yet.
+            </div>
+          ) : (
+            <ul>
+              {entries.map((e) => (
+                <li
+                  key={`${e.scoreId}:${e.userId}:${e.ts}`}
+                  className="border-b border-[#222] last:border-0 p-4"
+                >
+                  <div className="flex items-start gap-4 flex-wrap">
+                    <div
+                      className={`flex-shrink-0 px-2.5 py-1 text-[10px] uppercase tracking-widest border ${
+                        e.rating === "up"
+                          ? "border-ladder-green/40 text-ladder-green bg-ladder-green/5"
+                          : "border-ladder-red/40 text-ladder-red bg-ladder-red/5"
+                      }`}
+                    >
+                      {e.rating === "up" ? "Helpful" : "Off-base"}
+                    </div>
+                    <div className="flex-shrink-0 text-center min-w-[60px]">
+                      <p
+                        className="text-lg font-bold tabular-nums"
+                        style={{
+                          color: e.score !== null ? getScoreColor(e.score) : "#444",
+                        }}
+                      >
+                        {e.score !== null ? e.score.toFixed(1) : "—"}
+                      </p>
+                      <p
+                        className="text-[9px] uppercase tracking-widest"
+                        style={{
+                          color: e.score !== null ? getScoreColor(e.score) : "#444",
+                        }}
+                      >
+                        {e.scoreLabel ?? "—"}
+                      </p>
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-foreground font-sans truncate">
+                        {e.screenName || "Untitled screen"}
+                      </p>
+                      <p className="text-xs text-muted font-sans truncate">
+                        {e.userName ?? "—"} · {e.userEmail ?? "—"}
+                        {e.orgName && (
+                          <>
+                            {" · "}
+                            <span className="text-ladder-green">{e.orgName}</span>
+                          </>
+                        )}
+                      </p>
+                    </div>
+                    <span className="text-[10px] text-muted flex-shrink-0">
+                      {fmtTime(e.ts)}
+                    </span>
+                  </div>
+                  {e.note.trim().length > 0 && (
+                    <div className="mt-3 pl-2 border-l-2 border-[#333]">
+                      <p className="text-sm text-muted font-sans whitespace-pre-wrap">
+                        {e.note}
+                      </p>
+                    </div>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -373,6 +373,12 @@ export default function AdminPage() {
             >
               Evaluations
             </Link>
+            <Link
+              href="/admin/feedback"
+              className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
+            >
+              Feedback
+            </Link>
             <button
               onClick={refresh}
               className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"

--- a/src/app/api/admin/feedback/route.ts
+++ b/src/app/api/admin/feedback/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { getAdminEmail } from "@/lib/admin";
+import { redis } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+/**
+ * Admin feedback aggregation — surfaces every analysis-quality rating users
+ * have submitted via /api/feedback/score, enriched with the user's email
+ * and the underlying score (so QA can quickly see what was rated).
+ *
+ * GET /api/admin/feedback?limit=50
+ *   → { feedback: EnrichedFeedback[] } most-recent-first
+ *
+ * Gated by the runladder admin-email allowlist (getAdminEmail).
+ */
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+const FEEDBACK_INDEX_KEY = "score-feedback:index";
+
+type StoredFeedback = {
+  scoreId: string;
+  userId: string;
+  orgId: string | null;
+  rating: "up" | "down";
+  note: string;
+  ts: number;
+};
+
+type EnrichedFeedback = StoredFeedback & {
+  userEmail: string | null;
+  userName: string | null;
+  orgName: string | null;
+  score: number | null;
+  scoreLabel: string | null;
+  screenName: string | null;
+};
+
+type ScoreSnapshot = {
+  id?: string;
+  score?: number;
+  label?: string;
+  screenName?: string;
+};
+
+function recordKey(scoreId: string, userId: string): string {
+  return `score-feedback:${scoreId}:${userId}`;
+}
+
+export async function GET(req: NextRequest) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json(
+      { error: "Admin access required" },
+      { status: 403, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const url = new URL(req.url);
+  const limitRaw = Number(url.searchParams.get("limit") ?? "50");
+  const limit = Math.min(Math.max(Number.isFinite(limitRaw) ? limitRaw : 50, 1), 200);
+
+  const indexEntries = (await redis.zrange(
+    FEEDBACK_INDEX_KEY,
+    0,
+    limit - 1,
+    { rev: true },
+  )) as string[];
+
+  const records: StoredFeedback[] = (
+    await Promise.all(
+      indexEntries.map(async (member) => {
+        const sep = member.indexOf(":");
+        if (sep === -1) return null;
+        const scoreId = member.slice(0, sep);
+        const userId = member.slice(sep + 1);
+        if (!scoreId || !userId) return null;
+        const raw = await redis.get<string | StoredFeedback>(
+          recordKey(scoreId, userId),
+        );
+        if (!raw) return null;
+        if (typeof raw === "string") {
+          try {
+            return JSON.parse(raw) as StoredFeedback;
+          } catch {
+            return null;
+          }
+        }
+        return raw;
+      }),
+    )
+  ).filter((r): r is StoredFeedback => r !== null);
+
+  const client = await clerkClient();
+
+  const enriched: EnrichedFeedback[] = await Promise.all(
+    records.map(async (fb): Promise<EnrichedFeedback> => {
+      const base: EnrichedFeedback = {
+        ...fb,
+        userEmail: null,
+        userName: null,
+        orgName: null,
+        score: null,
+        scoreLabel: null,
+        screenName: null,
+      };
+
+      try {
+        const user = await client.users.getUser(fb.userId);
+        base.userEmail = user.primaryEmailAddress?.emailAddress ?? null;
+        base.userName =
+          [user.firstName, user.lastName].filter(Boolean).join(" ") || null;
+      } catch {
+        // user may have been deleted
+      }
+
+      if (fb.orgId) {
+        try {
+          const org = await client.organizations.getOrganization({
+            organizationId: fb.orgId,
+          });
+          base.orgName = org.name ?? null;
+        } catch {
+          // org may have been deleted
+        }
+      }
+
+      try {
+        const scores = (await redis.zrange(
+          `user:${fb.userId}:scores`,
+          0,
+          -1,
+          { rev: true },
+        )) as Array<string | ScoreSnapshot>;
+        for (const entry of scores) {
+          let parsed: ScoreSnapshot | null = null;
+          if (typeof entry === "string") {
+            try {
+              parsed = JSON.parse(entry) as ScoreSnapshot;
+            } catch {
+              continue;
+            }
+          } else {
+            parsed = entry;
+          }
+          if (parsed && parsed.id === fb.scoreId) {
+            base.score = typeof parsed.score === "number" ? parsed.score : null;
+            base.scoreLabel =
+              typeof parsed.label === "string" ? parsed.label : null;
+            base.screenName =
+              typeof parsed.screenName === "string" ? parsed.screenName : null;
+            break;
+          }
+        }
+      } catch {
+        // score history unreadable
+      }
+
+      return base;
+    }),
+  );
+
+  return NextResponse.json(
+    { feedback: enriched },
+    { headers: API_VERSION_HEADERS },
+  );
+}

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -1,0 +1,229 @@
+import { NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { redis } from "@/lib/redis";
+import { getUserStats, type UserStats } from "@/lib/scores";
+import {
+  computeLetterGrade,
+  LETTER_GRADE_THRESHOLD,
+  LETTER_GRADE_WINDOW_DAYS,
+  type LetterGrade,
+} from "@/lib/letter-grade";
+import { RUNG_NAMES, type RungName } from "@/lib/ladder";
+
+/**
+ * Team dashboard data — manager view.
+ *
+ * GET /api/dashboard/team
+ * Returns the active org's roster with per-member stats and a letter grade,
+ * plus team-wide insights (rung-level averages, weakest/strongest rung).
+ *
+ * Auth:
+ *   - Requires signed-in user with an active org (orgId from auth()).
+ *   - Manager-only data (stats, grades, insights) is gated on orgRole === "org:admin".
+ *   - Non-admin members get the roster only — no per-person stats.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+type RawScore = {
+  id?: string;
+  score?: number;
+  timestamp?: number;
+  rungs?: unknown;
+};
+
+type RungOnly = Record<RungName, { score: number }>;
+
+function parseRungScores(raw: unknown): RungOnly | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const out = {} as RungOnly;
+  for (const name of RUNG_NAMES) {
+    const r = obj[name];
+    if (!r || typeof r !== "object") return null;
+    const score = (r as { score?: unknown }).score;
+    if (typeof score !== "number" || !Number.isFinite(score)) return null;
+    out[name] = { score };
+  }
+  return out;
+}
+
+async function readRecentScores(
+  userId: string,
+  sinceTs: number,
+): Promise<RawScore[]> {
+  const raw = await redis.zrange(
+    `user:${userId}:scores`,
+    sinceTs,
+    "+inf",
+    { byScore: true },
+  );
+  return (raw as Array<string | RawScore>)
+    .map((entry) => {
+      if (typeof entry === "string") {
+        try {
+          return JSON.parse(entry) as RawScore;
+        } catch {
+          return null;
+        }
+      }
+      return entry;
+    })
+    .filter((s): s is RawScore => s !== null);
+}
+
+type MemberSummary = {
+  membershipId: string;
+  userId: string | null;
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  role: string;
+  joinedAt: number;
+  stats: UserStats | null;
+  recentScans: number;
+  letterGrade: LetterGrade | null;
+};
+
+type RungAverage = {
+  rung: RungName;
+  avg: number | null;
+  count: number;
+};
+
+type Insights = {
+  windowDays: number;
+  threshold: number;
+  totalScores: number;
+  teamAvg: number | null;
+  rungAverages: RungAverage[];
+  weakestRung: { rung: RungName; avg: number; count: number } | null;
+  strongestRung: { rung: RungName; avg: number; count: number } | null;
+};
+
+export async function GET() {
+  const { userId, orgId, orgRole } = await auth();
+
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  if (!orgId) {
+    return NextResponse.json({ error: "No active team" }, { status: 404 });
+  }
+
+  const isManager = orgRole === "org:admin";
+
+  const client = await clerkClient();
+  const memberships = await client.organizations.getOrganizationMembershipList({
+    organizationId: orgId,
+    limit: 100,
+  });
+
+  const windowStart = Date.now() - LETTER_GRADE_WINDOW_DAYS * DAY_MS;
+
+  const rungSums: Record<RungName, number> = {
+    functional: 0,
+    usable: 0,
+    comfortable: 0,
+    delightful: 0,
+    meaningful: 0,
+  };
+  const rungCounts: Record<RungName, number> = {
+    functional: 0,
+    usable: 0,
+    comfortable: 0,
+    delightful: 0,
+    meaningful: 0,
+  };
+  let totalScores = 0;
+  let totalScoreSum = 0;
+
+  const members: MemberSummary[] = await Promise.all(
+    memberships.data.map(async (m): Promise<MemberSummary> => {
+      const memberUserId = m.publicUserData?.userId ?? null;
+      const base = {
+        membershipId: m.id,
+        userId: memberUserId,
+        email: m.publicUserData?.identifier ?? null,
+        firstName: m.publicUserData?.firstName ?? null,
+        lastName: m.publicUserData?.lastName ?? null,
+        role: m.role,
+        joinedAt: m.createdAt,
+      };
+
+      if (!memberUserId || !isManager) {
+        return {
+          ...base,
+          stats: null,
+          recentScans: 0,
+          letterGrade: null,
+        };
+      }
+
+      const [stats, recent] = await Promise.all([
+        getUserStats(memberUserId),
+        readRecentScores(memberUserId, windowStart),
+      ]);
+
+      const recentScoreNums: number[] = [];
+      for (const s of recent) {
+        if (typeof s.score === "number" && Number.isFinite(s.score)) {
+          recentScoreNums.push(s.score);
+          totalScores += 1;
+          totalScoreSum += s.score;
+        }
+        const rs = parseRungScores(s.rungs);
+        if (rs) {
+          for (const name of RUNG_NAMES) {
+            rungSums[name] += rs[name].score;
+            rungCounts[name] += 1;
+          }
+        }
+      }
+
+      return {
+        ...base,
+        stats,
+        recentScans: recentScoreNums.length,
+        letterGrade: computeLetterGrade(recentScoreNums),
+      };
+    }),
+  );
+
+  let insights: Insights | null = null;
+  if (isManager) {
+    const rungAverages: RungAverage[] = RUNG_NAMES.map((name) => ({
+      rung: name,
+      avg:
+        rungCounts[name] > 0
+          ? Math.round((rungSums[name] / rungCounts[name]) * 10) / 10
+          : null,
+      count: rungCounts[name],
+    }));
+    const ranked = rungAverages
+      .filter(
+        (r): r is { rung: RungName; avg: number; count: number } =>
+          r.avg !== null,
+      )
+      .sort((a, b) => a.avg - b.avg);
+
+    insights = {
+      windowDays: LETTER_GRADE_WINDOW_DAYS,
+      threshold: LETTER_GRADE_THRESHOLD,
+      totalScores,
+      teamAvg:
+        totalScores > 0
+          ? Math.round((totalScoreSum / totalScores) * 10) / 10
+          : null,
+      rungAverages,
+      weakestRung: ranked[0] ?? null,
+      strongestRung: ranked[ranked.length - 1] ?? null,
+    };
+  }
+
+  return NextResponse.json({
+    isManager,
+    members,
+    insights,
+  });
+}

--- a/src/app/api/feedback/score/route.ts
+++ b/src/app/api/feedback/score/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { redis } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+/**
+ * Score-analysis feedback — per-score thumbs from authenticated users.
+ *
+ * GET  ?scoreId=X        → current user's existing feedback for that score
+ * POST { scoreId, rating, note? }  → upsert this user's feedback
+ *
+ * Storage:
+ *   score-feedback:{scoreId}:{userId} → JSON record
+ *   score-feedback:index              → zset (ts → "{scoreId}:{userId}")
+ *
+ * Anonymous viewers get 401 and the client hides the widget.
+ */
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+const FEEDBACK_INDEX_KEY = "score-feedback:index";
+
+function recordKey(scoreId: string, userId: string): string {
+  return `score-feedback:${scoreId}:${userId}`;
+}
+
+function indexMember(scoreId: string, userId: string): string {
+  return `${scoreId}:${userId}`;
+}
+
+type StoredFeedback = {
+  scoreId: string;
+  userId: string;
+  orgId: string | null;
+  rating: "up" | "down";
+  note: string;
+  ts: number;
+};
+
+export async function GET(req: NextRequest) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const url = new URL(req.url);
+  const scoreId = url.searchParams.get("scoreId");
+  if (!scoreId) {
+    return NextResponse.json(
+      { error: "scoreId required" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const raw = await redis.get<string | StoredFeedback>(
+    recordKey(scoreId, userId),
+  );
+  let feedback: StoredFeedback | null = null;
+  if (raw) {
+    if (typeof raw === "string") {
+      try {
+        feedback = JSON.parse(raw) as StoredFeedback;
+      } catch {
+        feedback = null;
+      }
+    } else {
+      feedback = raw;
+    }
+  }
+
+  return NextResponse.json(
+    { feedback },
+    { headers: API_VERSION_HEADERS },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  const { userId, orgId } = await auth();
+  if (!userId) {
+    return NextResponse.json(
+      { error: "Unauthorized" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: { scoreId?: string; rating?: string; note?: string } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  if (!body.scoreId) {
+    return NextResponse.json(
+      { error: "scoreId required" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (body.rating !== "up" && body.rating !== "down") {
+    return NextResponse.json(
+      { error: "rating must be 'up' or 'down'" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const note =
+    typeof body.note === "string" ? body.note.slice(0, 1000) : "";
+  const ts = Date.now();
+  const feedback: StoredFeedback = {
+    scoreId: body.scoreId,
+    userId,
+    orgId: orgId ?? null,
+    rating: body.rating,
+    note,
+    ts,
+  };
+
+  await Promise.all([
+    redis.set(recordKey(body.scoreId, userId), JSON.stringify(feedback)),
+    redis.zadd(FEEDBACK_INDEX_KEY, {
+      score: ts,
+      member: indexMember(body.scoreId, userId),
+    }),
+  ]);
+
+  return NextResponse.json(
+    { ok: true, feedback },
+    { headers: API_VERSION_HEADERS },
+  );
+}

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -1,0 +1,99 @@
+import { NextRequest, NextResponse } from "next/server";
+import { Webhook } from "svix";
+import { clerkClient } from "@clerk/nextjs/server";
+import { grantComp, revokeComp } from "@/lib/tier";
+
+/**
+ * Clerk webhook handler — drives team-tier comping off Clerk Org events.
+ *
+ * Configure in Clerk Dashboard → Webhooks → Add endpoint:
+ *   URL: https://runladder.com/api/webhooks/clerk
+ *   Events: organizationMembership.created, organizationMembership.deleted
+ *   Signing secret → CLERK_WEBHOOK_SECRET (Vercel env)
+ *
+ * On organizationMembership.created we grant tier "team" with a reason
+ * that names the org. On deletion we revoke only if the user is no longer
+ * in any organization (so leaving one team doesn't drop tier when the
+ * user still belongs to another).
+ */
+
+type ClerkOrgMembershipEvent = {
+  type: string;
+  data: {
+    public_user_data?: {
+      user_id?: string;
+    };
+    organization?: {
+      id?: string;
+      name?: string;
+    };
+  };
+};
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.CLERK_WEBHOOK_SECRET;
+  if (!secret) {
+    console.error("CLERK_WEBHOOK_SECRET is not set");
+    return NextResponse.json(
+      { error: "Webhook not configured" },
+      { status: 500 },
+    );
+  }
+
+  const svixId = req.headers.get("svix-id");
+  const svixTimestamp = req.headers.get("svix-timestamp");
+  const svixSignature = req.headers.get("svix-signature");
+
+  if (!svixId || !svixTimestamp || !svixSignature) {
+    return NextResponse.json(
+      { error: "Missing svix headers" },
+      { status: 400 },
+    );
+  }
+
+  const body = await req.text();
+  const wh = new Webhook(secret);
+
+  let event: ClerkOrgMembershipEvent;
+  try {
+    event = wh.verify(body, {
+      "svix-id": svixId,
+      "svix-timestamp": svixTimestamp,
+      "svix-signature": svixSignature,
+    }) as ClerkOrgMembershipEvent;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid signature" },
+      { status: 401 },
+    );
+  }
+
+  const userId = event.data.public_user_data?.user_id;
+  const orgName = event.data.organization?.name;
+
+  if (!userId) {
+    return NextResponse.json({ ok: true, skipped: "no userId" });
+  }
+
+  if (event.type === "organizationMembership.created") {
+    await grantComp(userId, {
+      tier: "team",
+      reason: orgName ? `Member of ${orgName}` : "Team member",
+    });
+    return NextResponse.json({ ok: true, action: "granted" });
+  }
+
+  if (event.type === "organizationMembership.deleted") {
+    const client = await clerkClient();
+    const remaining = await client.users.getOrganizationMembershipList({
+      userId,
+    });
+    if (remaining.totalCount === 0) {
+      await revokeComp(userId);
+      return NextResponse.json({ ok: true, action: "revoked" });
+    }
+    return NextResponse.json({ ok: true, action: "kept", reason: "in other org" });
+  }
+
+  return NextResponse.json({ ok: true, skipped: event.type });
+}

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
+import { AnalysisFeedback } from "@/components/AnalysisFeedback";
 
 type Finding = {
   title: string;
@@ -323,6 +324,10 @@ export default function ScoreDetailPage() {
             </Link>
           </div>
         )}
+
+        <div className="mt-6">
+          <AnalysisFeedback scoreId={data.id} />
+        </div>
       </div>
     </div>
   );

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,0 +1,602 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  useAuth,
+  useOrganization,
+  useOrganizationList,
+  CreateOrganization,
+  RedirectToSignIn,
+} from "@clerk/nextjs";
+import Link from "next/link";
+import { getScoreColor } from "@/lib/ladder";
+import {
+  letterGradeColor,
+  LETTER_GRADE_THRESHOLD,
+  type LetterGrade,
+} from "@/lib/letter-grade";
+
+type MemberStats = {
+  totalScans: number;
+  avgScore: number | null;
+  bestScore: number | null;
+  lastScoreAt: number | null;
+};
+
+type TeamMember = {
+  membershipId: string;
+  userId: string | null;
+  email: string | null;
+  firstName: string | null;
+  lastName: string | null;
+  role: string;
+  joinedAt: number;
+  stats: MemberStats | null;
+  recentScans: number;
+  letterGrade: LetterGrade | null;
+};
+
+type RungAverage = {
+  rung: string;
+  avg: number | null;
+  count: number;
+};
+
+type Insights = {
+  windowDays: number;
+  threshold: number;
+  totalScores: number;
+  teamAvg: number | null;
+  rungAverages: RungAverage[];
+  weakestRung: { rung: string; avg: number; count: number } | null;
+  strongestRung: { rung: string; avg: number; count: number } | null;
+};
+
+type TeamData = {
+  isManager: boolean;
+  members: TeamMember[];
+  insights: Insights | null;
+};
+
+function fmtDate(input: number | string | Date | null | undefined): string {
+  if (!input) return "—";
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function fmtRelative(ts: number | null | undefined): string {
+  if (!ts) return "no activity";
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+function InviteForm({
+  onInvite,
+}: {
+  onInvite: (email: string) => Promise<void>;
+}) {
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!email.trim() || busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      await onInvite(email.trim());
+      setEmail("");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Invite failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="border border-[#333] bg-[#1e1e1e] p-4">
+      <div className="flex items-center gap-3 flex-wrap">
+        <input
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="teammate@example.com"
+          className="flex-1 min-w-[240px] bg-[#111] border border-[#333] text-sm text-foreground px-3 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+        />
+        <button
+          type="submit"
+          disabled={busy || !email.trim()}
+          className="text-xs font-semibold bg-ladder-green text-background px-4 py-2 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+        >
+          {busy ? "Sending…" : "Invite"}
+        </button>
+      </div>
+      {err && <p className="mt-2 text-xs text-ladder-red font-sans">{err}</p>}
+      <p className="mt-2 text-[10px] text-muted font-sans">
+        They&apos;ll get an email from Clerk with a sign-in link. On accept, they&apos;re comped to team tier automatically.
+      </p>
+    </form>
+  );
+}
+
+function NoOrgPanel() {
+  return (
+    <div className="border border-[#333] bg-[#1e1e1e] p-8">
+      <h2 className="text-base font-sans text-foreground mb-2">
+        Start your team
+      </h2>
+      <p className="text-sm text-muted font-sans mb-6">
+        Create a team to invite your designers and see how they&apos;re scoring.
+      </p>
+      <CreateOrganization
+        afterCreateOrganizationUrl="/dashboard/team"
+        appearance={{
+          elements: {
+            rootBox: "w-full",
+            card: "bg-transparent shadow-none border-0 p-0",
+          },
+        }}
+      />
+    </div>
+  );
+}
+
+function LetterGradeBadge({ grade }: { grade: LetterGrade | null }) {
+  if (!grade) {
+    return (
+      <div
+        className="flex-shrink-0 w-14 h-14 border border-[#333] bg-[#111] flex items-center justify-center"
+        title="No scores in window"
+      >
+        <span className="text-2xl font-bold tabular-nums text-[#444]">—</span>
+      </div>
+    );
+  }
+  const color = letterGradeColor(grade);
+  return (
+    <div
+      className="flex-shrink-0 w-14 h-14 border flex items-center justify-center"
+      style={{
+        borderColor: `${color}40`,
+        backgroundColor: `${color}0d`,
+      }}
+      title={`Grade ${grade}`}
+    >
+      <span
+        className="text-2xl font-bold tabular-nums"
+        style={{ color }}
+      >
+        {grade}
+      </span>
+    </div>
+  );
+}
+
+function StatPill({
+  label,
+  value,
+  color,
+}: {
+  label: string;
+  value: string;
+  color?: string;
+}) {
+  return (
+    <div className="border border-[#333] bg-[#1e1e1e] p-4">
+      <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+        {label}
+      </p>
+      <p
+        className="text-2xl font-bold tabular-nums"
+        style={{ color: color ?? "var(--foreground)" }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}
+
+function InsightsPanel({ insights }: { insights: Insights }) {
+  const { totalScores, teamAvg, weakestRung, strongestRung, windowDays } =
+    insights;
+
+  if (totalScores === 0) {
+    return (
+      <div className="border border-[#333] bg-[#1e1e1e] p-6 mb-6">
+        <p className="text-sm text-muted font-sans">
+          No scores from your team in the last {windowDays} days. Once members
+          start scoring, performance insights show up here.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-baseline justify-between mb-3">
+        <h2 className="text-[10px] text-muted uppercase tracking-widest">
+          Team performance
+        </h2>
+        <span className="text-[10px] text-muted">
+          Last {windowDays} days
+        </span>
+      </div>
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+        <StatPill
+          label="Team scans"
+          value={String(totalScores)}
+        />
+        <StatPill
+          label="Team avg"
+          value={teamAvg !== null ? teamAvg.toFixed(1) : "—"}
+          color={teamAvg !== null ? getScoreColor(teamAvg) : undefined}
+        />
+        <StatPill
+          label="Strongest rung"
+          value={
+            strongestRung
+              ? `${capitalize(strongestRung.rung)} ${strongestRung.avg.toFixed(1)}`
+              : "—"
+          }
+          color={
+            strongestRung ? getScoreColor(strongestRung.avg) : undefined
+          }
+        />
+        <StatPill
+          label="Weakest rung"
+          value={
+            weakestRung
+              ? `${capitalize(weakestRung.rung)} ${weakestRung.avg.toFixed(1)}`
+              : "—"
+          }
+          color={weakestRung ? getScoreColor(weakestRung.avg) : undefined}
+        />
+      </div>
+      {weakestRung && (
+        <p className="mt-3 text-xs text-muted font-sans">
+          Your team&apos;s weakest rung is{" "}
+          <span className="text-foreground">
+            {capitalize(weakestRung.rung)}
+          </span>
+          . Designers typically miss this — coach toward it first.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function MemberRow({
+  member,
+  isAdmin,
+  isSelf,
+  onRemove,
+}: {
+  member: TeamMember;
+  isAdmin: boolean;
+  isSelf: boolean;
+  onRemove: () => void;
+}) {
+  const name =
+    [member.firstName, member.lastName].filter(Boolean).join(" ") ||
+    member.email ||
+    "—";
+  const stats = member.stats;
+  const avg = stats?.avgScore ?? null;
+  const lastAt = stats?.lastScoreAt ?? null;
+
+  return (
+    <li className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4 flex-wrap">
+      <LetterGradeBadge grade={member.letterGrade} />
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-foreground font-sans">
+          {name}
+          {isSelf && (
+            <span className="text-[10px] text-muted ml-2">(you)</span>
+          )}
+        </p>
+        <p className="text-xs text-muted font-sans truncate">
+          {member.email ?? "—"}
+        </p>
+        <p className="text-[10px] text-muted font-sans mt-1">
+          Joined {fmtDate(member.joinedAt)} · {member.role.replace("org:", "")}
+        </p>
+      </div>
+      <div className="flex items-center gap-5 flex-shrink-0">
+        <div className="text-right min-w-[60px]">
+          <p
+            className="text-lg font-bold tabular-nums"
+            style={{
+              color: avg !== null ? getScoreColor(avg) : "#444",
+            }}
+          >
+            {avg !== null ? avg.toFixed(1) : "—"}
+          </p>
+          <p className="text-[9px] text-muted uppercase tracking-widest">
+            Avg
+          </p>
+        </div>
+        <div className="text-right min-w-[60px]">
+          <p className="text-lg font-bold tabular-nums text-foreground">
+            {stats?.totalScans ?? 0}
+          </p>
+          <p className="text-[9px] text-muted uppercase tracking-widest">
+            Scans
+          </p>
+        </div>
+        <div className="text-right min-w-[80px] hidden sm:block">
+          <p className="text-xs font-mono text-muted">{fmtRelative(lastAt)}</p>
+          <p className="text-[9px] text-muted uppercase tracking-widest">
+            Last
+          </p>
+        </div>
+        {isAdmin && !isSelf && (
+          <button
+            onClick={onRemove}
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors"
+          >
+            Remove
+          </button>
+        )}
+      </div>
+    </li>
+  );
+}
+
+export default function TeamPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const { isLoaded: orgListLoaded, userMemberships } = useOrganizationList({
+    userMemberships: { infinite: true },
+  });
+  const {
+    organization,
+    membership,
+    memberships,
+    invitations,
+  } = useOrganization({
+    memberships: { infinite: true },
+    invitations: { infinite: true, status: ["pending"] },
+  });
+
+  const [teamData, setTeamData] = useState<TeamData | null>(null);
+  const [teamErr, setTeamErr] = useState<string | null>(null);
+  const [teamLoading, setTeamLoading] = useState(false);
+
+  const refreshTeamData = useCallback(async () => {
+    setTeamLoading(true);
+    setTeamErr(null);
+    try {
+      const res = await fetch("/api/dashboard/team");
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Team fetch failed (${res.status})`);
+      }
+      const json = (await res.json()) as TeamData;
+      setTeamData(json);
+    } catch (e) {
+      setTeamErr(e instanceof Error ? e.message : "Failed to load team");
+    } finally {
+      setTeamLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (organization?.id) {
+      refreshTeamData();
+    }
+  }, [organization?.id, refreshTeamData]);
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  const hasAnyOrg =
+    !!organization || (orgListLoaded && (userMemberships?.count ?? 0) > 0);
+
+  if (!hasAnyOrg) {
+    return (
+      <div className="pt-20 font-mono">
+        <div className="max-w-2xl mx-auto px-6 py-10">
+          <div className="mb-8">
+            <h1 className="text-xl text-foreground font-sans">Team</h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              Invite your designers, see how they&apos;re scoring.
+            </p>
+          </div>
+          <NoOrgPanel />
+        </div>
+      </div>
+    );
+  }
+
+  if (!organization) {
+    return (
+      <div className="pt-20 font-mono">
+        <div className="max-w-2xl mx-auto px-6 py-10">
+          <p className="text-sm text-muted font-sans">Loading your team…</p>
+        </div>
+      </div>
+    );
+  }
+
+  const isAdmin = membership?.role === "org:admin";
+  const inviteList = invitations?.data ?? [];
+  const memberList = teamData?.members ?? [];
+  const selfUserId = membership?.publicUserData?.userId;
+
+  async function handleInvite(email: string) {
+    if (!organization) throw new Error("No active team");
+    await organization.inviteMember({
+      emailAddress: email,
+      role: "org:member",
+    });
+    await invitations?.revalidate?.();
+  }
+
+  async function handleRevoke(invitationId: string) {
+    if (!organization) return;
+    const inv = inviteList.find((i) => i.id === invitationId);
+    if (!inv) return;
+    try {
+      await inv.revoke();
+      await invitations?.revalidate?.();
+    } catch {
+      // noop
+    }
+  }
+
+  async function handleRemoveMember(userId: string) {
+    if (!organization) return;
+    if (!confirm("Remove this member from the team?")) return;
+    try {
+      await organization.removeMember(userId);
+      await Promise.all([
+        memberships?.revalidate?.(),
+        refreshTeamData(),
+      ]);
+    } catch {
+      // noop
+    }
+  }
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8 flex items-baseline justify-between gap-4 flex-wrap">
+          <div>
+            <h1 className="text-xl text-foreground font-sans">
+              {organization.name}
+            </h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              {memberList.length} member{memberList.length !== 1 ? "s" : ""}
+              {inviteList.length > 0 &&
+                ` · ${inviteList.length} pending invite${inviteList.length !== 1 ? "s" : ""}`}
+              {isAdmin && (
+                <>
+                  {" · "}
+                  <span className="text-ladder-green">manager</span>
+                </>
+              )}
+            </p>
+          </div>
+          <Link
+            href="/dashboard"
+            className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+          >
+            ← Personal dashboard
+          </Link>
+        </div>
+
+        {teamErr && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {teamErr}
+          </div>
+        )}
+
+        {isAdmin && teamData?.insights && (
+          <InsightsPanel insights={teamData.insights} />
+        )}
+
+        {isAdmin && (
+          <section className="mb-10">
+            <h2 className="text-[10px] text-muted uppercase tracking-widest mb-3">
+              Invite a designer
+            </h2>
+            <InviteForm onInvite={handleInvite} />
+          </section>
+        )}
+
+        <section className="mb-10">
+          <div className="flex items-baseline justify-between mb-3">
+            <h2 className="text-[10px] text-muted uppercase tracking-widest">
+              Members
+            </h2>
+            {teamData && (
+              <span className="text-[10px] text-muted">
+                Grades from last 30 days, threshold {LETTER_GRADE_THRESHOLD.toFixed(1)}
+              </span>
+            )}
+          </div>
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            {teamLoading && memberList.length === 0 ? (
+              <div className="p-8 text-center text-muted font-sans text-sm">
+                Loading members…
+              </div>
+            ) : memberList.length === 0 ? (
+              <div className="p-8 text-center text-muted font-sans text-sm">
+                No members yet.
+              </div>
+            ) : (
+              <ul>
+                {memberList.map((m) => (
+                  <MemberRow
+                    key={m.membershipId}
+                    member={m}
+                    isAdmin={isAdmin}
+                    isSelf={!!m.userId && m.userId === selfUserId}
+                    onRemove={() => m.userId && handleRemoveMember(m.userId)}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </section>
+
+        {inviteList.length > 0 && (
+          <section>
+            <h2 className="text-[10px] text-muted uppercase tracking-widest mb-3">
+              Pending invitations
+            </h2>
+            <div className="border border-[#333] bg-[#1e1e1e]">
+              <ul>
+                {inviteList.map((inv) => (
+                  <li
+                    key={inv.id}
+                    className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-foreground font-sans truncate">
+                        {inv.emailAddress}
+                      </p>
+                      <p className="text-[10px] text-muted font-sans mt-1">
+                        Invited {fmtDate(inv.createdAt)}
+                      </p>
+                    </div>
+                    <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+                      Pending
+                    </span>
+                    {isAdmin && (
+                      <button
+                        onClick={() => handleRevoke(inv.id)}
+                        className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AnalysisFeedback.tsx
+++ b/src/components/AnalysisFeedback.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Rating = "up" | "down";
+
+type Feedback = {
+  rating: Rating;
+  note: string;
+  ts: number;
+};
+
+/**
+ * Inline rating widget shown beneath a score result. Lets the user mark
+ * the analysis as helpful or off-base, with an optional follow-up note.
+ * Posts to /api/feedback/score; super admins can aggregate at
+ * /api/admin/feedback.
+ */
+export function AnalysisFeedback({ scoreId }: { scoreId: string }) {
+  const [loading, setLoading] = useState(true);
+  const [existing, setExisting] = useState<Feedback | null>(null);
+  const [rating, setRating] = useState<Rating | null>(null);
+  const [note, setNote] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      try {
+        const res = await fetch(
+          `/api/feedback/score?scoreId=${encodeURIComponent(scoreId)}`,
+        );
+        if (!res.ok) {
+          if (res.status === 401) {
+            // Anonymous viewer — hide widget entirely.
+            if (!cancelled) setLoading(false);
+            return;
+          }
+          throw new Error(`status ${res.status}`);
+        }
+        const json = await res.json();
+        if (cancelled) return;
+        if (json.feedback) {
+          setExisting(json.feedback);
+          setRating(json.feedback.rating);
+          setNote(json.feedback.note ?? "");
+        }
+      } catch {
+        // Silent — feedback is optional UX.
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [scoreId]);
+
+  async function persist(nextRating: Rating, nextNote: string) {
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/feedback/score", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          scoreId,
+          rating: nextRating,
+          note: nextNote,
+        }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Save failed (${res.status})`);
+      }
+      const json = await res.json();
+      setExisting(json.feedback);
+      setRating(json.feedback.rating);
+      setNote(json.feedback.note ?? "");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loading) return null;
+
+  const submitted = !!existing;
+
+  return (
+    <div className="border border-[#333] bg-[#1e1e1e] p-4">
+      <div className="flex items-baseline justify-between mb-3">
+        <p className="text-[10px] text-muted uppercase tracking-widest">
+          Analysis quality
+        </p>
+        {submitted && (
+          <span className="text-[10px] text-muted">
+            You marked this {rating === "up" ? "helpful" : "off-base"}
+          </span>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2 mb-3 flex-wrap">
+        <button
+          onClick={() => persist("up", note)}
+          disabled={busy}
+          className={`text-xs font-semibold border px-4 py-2 rounded-sm transition-colors disabled:opacity-40 ${
+            rating === "up"
+              ? "border-ladder-green text-ladder-green bg-ladder-green/10"
+              : "border-[#333] text-muted hover:text-foreground hover:border-muted"
+          }`}
+        >
+          Helpful
+        </button>
+        <button
+          onClick={() => persist("down", note)}
+          disabled={busy}
+          className={`text-xs font-semibold border px-4 py-2 rounded-sm transition-colors disabled:opacity-40 ${
+            rating === "down"
+              ? "border-ladder-red text-ladder-red bg-ladder-red/10"
+              : "border-[#333] text-muted hover:text-foreground hover:border-muted"
+          }`}
+        >
+          Off-base
+        </button>
+      </div>
+
+      {rating && (
+        <div className="space-y-2">
+          <textarea
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder={
+              rating === "down"
+                ? "What was off about the analysis?"
+                : "What worked well? Anything we should keep doing?"
+            }
+            rows={2}
+            maxLength={1000}
+            className="w-full bg-[#111] border border-[#333] text-sm text-foreground p-2 focus:outline-none focus:border-muted placeholder:text-[#555] resize-y font-sans"
+          />
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => persist(rating, note)}
+              disabled={busy || note === (existing?.note ?? "")}
+              className="text-xs font-semibold bg-ladder-green text-background px-3 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+            >
+              {busy ? "Saving…" : submitted ? "Update note" : "Save note"}
+            </button>
+            <span className="text-[10px] text-muted font-sans">
+              Optional. Your note goes to the team that tunes the scoring engine.
+            </span>
+          </div>
+        </div>
+      )}
+
+      {err && (
+        <p className="mt-2 text-xs text-ladder-red font-sans">{err}</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -3,19 +3,36 @@
  * plus a typed proxy for the plugin backend (ai-design-assistant) admin
  * endpoints while plugin data still lives there.
  *
+ * Auth model:
+ *   SUPER_ADMIN_EMAILS — hardcoded, always admin, never removable via UI.
+ *                        Editing this list is privileged: PR + merge + deploy
+ *                        in production, plus an out-of-band passphrase
+ *                        confirmation by Ward.
+ *   ADMIN_EMAILS env   — comma-separated regular admin allowlist (Vercel).
+ *                        Super admins are merged in regardless of this value.
+ *
  * Env vars (runladder project):
  *   PLUGIN_BACKEND_URL   — e.g. https://ai-design-assistant-ebon.vercel.app
  *   PLUGIN_ADMIN_KEY     — same value as ai-design-assistant's ADMIN_KEY env var
- *   ADMIN_EMAILS         — comma-separated allowlist. Defaults to Ward's emails.
+ *   ADMIN_EMAILS         — comma-separated regular admin allowlist
  */
 import { auth, clerkClient } from "@clerk/nextjs/server";
 
-const ADMIN_EMAILS = (
-  process.env.ADMIN_EMAILS || "ward@drawbackwards.com,ward.andrews@gmail.com"
+const SUPER_ADMIN_EMAILS = [
+  "ward@drawbackwards.com",
+  "ward.andrews@gmail.com",
+] as const;
+
+const ENV_ADMIN_EMAILS = (
+  process.env.ADMIN_EMAILS || "jordan@drawbackwards.com,michael@drawbackwards.com"
 )
   .split(",")
   .map((e) => e.trim().toLowerCase())
   .filter(Boolean);
+
+const ADMIN_EMAILS = Array.from(
+  new Set([...SUPER_ADMIN_EMAILS.map((e) => e.toLowerCase()), ...ENV_ADMIN_EMAILS]),
+);
 
 /**
  * Returns the authenticated admin's email, or null if unauthorized.
@@ -31,6 +48,24 @@ export async function getAdminEmail(): Promise<string | null> {
   if (!email) return null;
   if (!ADMIN_EMAILS.includes(email)) return null;
   return email;
+}
+
+/**
+ * True if the email is a super admin (hardcoded, removal-protected).
+ * Any future admin-removal UI must reject when this returns true.
+ */
+export function isSuperAdmin(email: string | null | undefined): boolean {
+  if (!email) return false;
+  const normalized = email.toLowerCase();
+  return SUPER_ADMIN_EMAILS.some((e) => e.toLowerCase() === normalized);
+}
+
+/**
+ * True if the target admin can be removed via the (future) admin UI.
+ * Always false for super admins.
+ */
+export function canRemoveAdmin(email: string): boolean {
+  return !isSuperAdmin(email);
 }
 
 /* ── Plugin backend proxy ────────────────────────────────────────────── */

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.2.0";
+export const CURRENT_APP_VERSION = "0.3.0";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/letter-grade.ts
+++ b/src/lib/letter-grade.ts
@@ -1,0 +1,65 @@
+import { LEVELS, type LadderLevel } from "@/lib/ladder";
+
+/**
+ * Designer letter grade — derived from the percentage of recent scores
+ * that hit a Ladder threshold. Default threshold is Comfortable (3.0+),
+ * which is the modern minimum.
+ *
+ * Bands (proportion of scores ≥ threshold):
+ *   A: 90%+
+ *   B: 75-89%
+ *   C: 60-74%
+ *   D: 40-59%
+ *   F: <40%
+ *   —: no scores in window
+ */
+
+export type LetterGrade = "A" | "B" | "C" | "D" | "F" | "—";
+
+export const LETTER_GRADE_THRESHOLD = 3.0;
+export const LETTER_GRADE_WINDOW_DAYS = 30;
+
+export function computeLetterGrade(
+  scores: number[],
+  threshold: number = LETTER_GRADE_THRESHOLD,
+): LetterGrade {
+  if (scores.length === 0) return "—";
+  const passing = scores.filter((s) => s >= threshold).length;
+  const pct = passing / scores.length;
+  if (pct >= 0.9) return "A";
+  if (pct >= 0.75) return "B";
+  if (pct >= 0.6) return "C";
+  if (pct >= 0.4) return "D";
+  return "F";
+}
+
+/**
+ * Map a letter grade to a Ladder level so the grade's color treatment
+ * echoes the rung level the designer typically reaches.
+ *
+ *   A → Meaningful (white)
+ *   B → Delightful (green)
+ *   C → Comfortable (yellow)
+ *   D → Usable (orange)
+ *   F → Functional (red)
+ */
+export function letterGradeLevel(grade: LetterGrade): LadderLevel | null {
+  switch (grade) {
+    case "A":
+      return LEVELS[4];
+    case "B":
+      return LEVELS[3];
+    case "C":
+      return LEVELS[2];
+    case "D":
+      return LEVELS[1];
+    case "F":
+      return LEVELS[0];
+    default:
+      return null;
+  }
+}
+
+export function letterGradeColor(grade: LetterGrade): string {
+  return letterGradeLevel(grade)?.color ?? "#666666";
+}


### PR DESCRIPTION
## Summary

- Clerk Org-backed team primitive at `/dashboard/team`. Manager invites by email, members auto-comped to `tier: "team"` via `/api/webhooks/clerk` on org join (svix-verified). Removal revokes only when user is in no other org.
- Designer letter grades (A-F based on % of last-30-day scores hitting Comfortable+ / 3.0). Color echoes the Ladder rung the designer typically reaches.
- Team performance insights for managers: total scans, team avg, strongest rung, weakest rung over the window.
- Analysis-quality feedback widget on `/dashboard/scores/[id]` (Helpful / Off-base + optional note). Anonymous viewers see nothing.
- Super-admin QA console at `/admin/feedback` aggregating ratings with email, org, score, and notes.
- Super-admin protection in `src/lib/admin.ts`: hardcoded `SUPER_ADMIN_EMAILS`, removable only via PR + merge + deploy. Jordan and Michael added to default `ADMIN_EMAILS`.
- Versions bumped to app 0.3.0.

## Setup required after merge

1. Clerk Dashboard -> Configure -> Organizations -> Enable, "Membership optional".
2. Vercel env -> set `CLERK_WEBHOOK_SECRET` (Production + Preview + Development).
3. Clerk Dashboard -> Webhooks -> Add endpoint at `https://runladder.com/api/webhooks/clerk` for `organizationMembership.created` and `organizationMembership.deleted`.

## Test plan

- [ ] Enable Clerk Organizations and add the webhook + secret per setup above.
- [ ] Sign in as Ward, visit `/dashboard/team`, create the Drawbackwards org.
- [ ] Invite a test email and confirm Clerk delivers the invite.
- [ ] Accept from the invitee account; verify their tier becomes "team" with comp reason "Member of Drawbackwards".
- [ ] Score a screen from the invitee account; confirm it appears in the manager's team dashboard with a letter grade.
- [ ] Submit Helpful and Off-base feedback on a score; confirm both surface at `/admin/feedback` with email, org, and score data.
- [ ] Verify SUPER_ADMIN_EMAILS still resolve to admin even if the `ADMIN_EMAILS` env var is empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)