### PR TITLE
Score flow: hide marketing nav on /score, route to full score after analysis

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -85,14 +85,16 @@ export async function POST(req: NextRequest) {
     }
 
     /* ── Persist score + increment usage ── */
+    let persistedScoreId: string | null = null;
     if (userId) {
       const thumbnail = await makeThumbnail(
         Buffer.from(parsed.base64Data, "base64"),
         parsed.mediaType,
       );
 
+      const scoreId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
       await persistScoreEntry(userId, {
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        id: scoreId,
         score: result.score,
         label: result.label,
         screenName: result.screenName || source || "upload",
@@ -106,6 +108,7 @@ export async function POST(req: NextRequest) {
         timestamp: Date.now(),
         sessionType,
       });
+      persistedScoreId = scoreId;
     } else {
       const anonKey = `rate:anon:${ip}`;
       await redis.incr(anonKey);
@@ -118,6 +121,9 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({
       ...result,
       screenName: result.screenName || source || "Screen",
+      // Echo the persisted score's id so the client can route the user
+      // straight to /dashboard/scores/[id] after analysis. Null for anon.
+      scoreId: persistedScoreId,
     });
   } catch (err) {
     console.error("[LADDER:ERROR] Score endpoint:", err);

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import type { RungName, RungScores } from "@/lib/ladder";
@@ -222,6 +223,7 @@ function timeAgo(ts: number): string {
 }
 
 export default function ScorePage() {
+  const router = useRouter();
   const { isSignedIn, isLoaded } = useAuth();
   const { sessionType, ready: sessionTypeReady, pick: pickSessionType, clear: clearSessionType } =
     useSessionType();
@@ -238,6 +240,12 @@ export default function ScorePage() {
   const [isDragOver, setIsDragOver] = useState(false);
   const [pastScores, setPastScores] = useState<PastScore[]>([]);
   const [isPublic, setIsPublic] = useState(true);
+  // When set, the inline result is suppressed and a reassurance card is
+  // shown while we route the user to /dashboard/scores/[id] for the full
+  // detail view. Signed-in users never see the inline result.
+  const [redirectingScoreId, setRedirectingScoreId] = useState<string | null>(
+    null,
+  );
   const fileRef = useRef<HTMLInputElement>(null);
 
   // Load past scores on mount
@@ -370,16 +378,14 @@ export default function ScorePage() {
         if (data.signup) {
           throw new Error("Sign up for free to get 5 Ladder scores. Log in at runladder.com/login");
         }
-        if (data.upgrade) {
-          throw new Error("You've used all 15 free scores this month. Upgrade at runladder.com/pricing for unlimited scoring.");
-        }
+        // The server's error string is already tier-aware (free cap vs
+        // team pool exceeded) — prefer it over any local hardcoded copy.
         throw new Error(data.error || "Scoring failed");
       }
-      setResult(data);
 
-      // Save to past scores
+      // Save to local past scores (used by anon users for in-session history).
       const entry: PastScore = {
-        id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        id: data.scoreId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         score: data.score,
         label: data.label,
         summary: data.summary,
@@ -389,6 +395,17 @@ export default function ScorePage() {
       };
       savePastScore(entry);
       setPastScores(loadPastScores());
+
+      // Signed-in users go to the full score detail in their dashboard.
+      // Anon users have nowhere to go — keep the inline result for them.
+      if (data.scoreId) {
+        setRedirectingScoreId(data.scoreId);
+        setTimeout(() => {
+          router.push(`/dashboard/scores/${data.scoreId}`);
+        }, 1200);
+      } else {
+        setResult(data);
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
@@ -418,6 +435,31 @@ export default function ScorePage() {
   // their score isn't saved to history anyway.
   const showSessionTypePrompt =
     isLoaded && isSignedIn && sessionTypeReady && !sessionType;
+
+  // After a successful analysis, signed-in users are routed to the full
+  // score detail in their dashboard. This screen reassures them while the
+  // navigation lands.
+  if (redirectingScoreId) {
+    return (
+      <div className="pt-32 font-mono">
+        <div className="max-w-md mx-auto px-6 py-20 text-center">
+          <p className="font-mono text-[10px] text-ladder-green uppercase tracking-widest mb-6">
+            Analysis complete
+          </p>
+          <h1 className="text-2xl font-bold text-foreground mb-3 font-sans">
+            Going to your full score…
+          </h1>
+          <p className="text-sm text-body font-sans leading-relaxed mb-8">
+            Findings, fixes, and trend live on your dashboard.
+          </p>
+          <div className="flex items-center justify-center gap-3 text-[10px] text-muted uppercase tracking-widest">
+            <span className="inline-block w-2 h-2 rounded-full bg-ladder-green animate-pulse" />
+            Loading
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="analysis-grid pt-20 font-mono">

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,7 +9,13 @@ import { UserMenu } from "./UserMenu";
 export function Nav() {
   const { isSignedIn, isLoaded } = useAuth();
   const pathname = usePathname();
-  const onDashboard = pathname?.startsWith("/dashboard") ?? false;
+  // Hide marketing nav inside product surfaces (dashboard, score). Keeps
+  // the user focused on the task and out of the marketing site once they
+  // are working in Ladder.
+  const inProduct =
+    pathname?.startsWith("/dashboard") ||
+    pathname?.startsWith("/score") ||
+    false;
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-border bg-background/90 backdrop-blur-md">
@@ -18,7 +24,7 @@ export function Nav() {
           <LadderLogo height={22} className="text-white" />
         </Link>
 
-        {!onDashboard && (
+        {!inProduct && (
           <div className="hidden md:flex items-center gap-10 text-sm font-bold text-body">
             <Link href="/framework" className="hover:text-foreground transition-colors">
               Framework


### PR DESCRIPTION
## Summary

Two related fixes for the post-analysis experience on \`/score\`:

- **Hide marketing nav on \`/score\`.** The existing \`onDashboard\` rule in \`Nav.tsx\` already dropped the marketing links when the user was inside \`/dashboard\`. This extends the same rule to \`/score\` so the user stays focused on the task once they're working in Ladder.
- **Route signed-in users to their full score after analysis.** \`/api/score\` now echoes the persisted score id. On the client, when analysis succeeds and we have a \`scoreId\`, we show a brief "Going to your full score…" reassurance screen and \`router.push\` to \`/dashboard/scores/[id]\`. Anonymous scorers (no scoreId) keep the existing inline result since they have no dashboard to land in.

Also drops the stale "15 free scores this month" hardcoded client error — the server's tier-aware message (free lifetime cap vs team pool exceeded) flows through unchanged now.

## Files

- \`src/components/Nav.tsx\` — \`onDashboard\` → \`inProduct\` (covers \`/dashboard\` + \`/score\`)
- \`src/app/api/score/route.ts\` — captures the score id used by \`persistScoreEntry\` and returns it as \`scoreId\` (null for anon)
- \`src/app/score/page.tsx\` — \`useRouter\`, new \`redirectingScoreId\` state, reassurance screen, \`router.push\` to \`/dashboard/scores/[id]\` on success

## Test plan

- [ ] Sign in, score a screen on \`/score\`. Confirm: marketing nav links absent in the top bar, reassurance card appears after analysis, page routes to \`/dashboard/scores/[id]\` with the full detail.
- [ ] Score anonymously (no auth). Confirm: inline result still renders on \`/score\` since there's no dashboard target.
- [ ] Visit \`/\` (home). Confirm: full marketing nav still renders.
- [ ] Visit \`/dashboard\`. Confirm: marketing nav still hidden (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)