### PR TITLE
Score UX bundle: team banner, recent scores, neutral bars, login crop, methodology promo

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { redis, lifetimeScansKey } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
-import { getUserSubscription } from "@/lib/tier";
+import { getUserSubscription, grantComp } from "@/lib/tier";
 import { getUserStats } from "@/lib/scores";
 
 export async function GET() {
@@ -10,6 +10,33 @@ export async function GET() {
 
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  // Self-healing fallback: if the user belongs to any Clerk organization
+  // but doesn't yet have a team-tier comp (the webhook missed, the user
+  // pre-dates the webhook, or the secret is unconfigured), grant the comp
+  // here so the dashboard banner doesn't lie to them. Idempotent.
+  try {
+    const client = await clerkClient();
+    const sub = await getUserSubscription(userId);
+    if (sub.tier === "free" || (sub.tier !== "team" && !sub.comp)) {
+      const memberships = await client.users.getOrganizationMembershipList({
+        userId,
+      });
+      const firstOrg = memberships.data[0];
+      if (firstOrg) {
+        await grantComp(userId, {
+          tier: "team",
+          reason: firstOrg.organization?.name
+            ? `Member of ${firstOrg.organization.name}`
+            : "Team member",
+        });
+      }
+    }
+  } catch {
+    // Fallback is best-effort. If Clerk read fails, fall through to the
+    // normal subscription read below — the user still gets correct data
+    // if their tier was already set.
   }
 
   const [scores, used, sub, stats] = await Promise.all([

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { ContactForm } from "./ContactForm";
 
 export const metadata: Metadata = {
@@ -30,9 +31,15 @@ export default function ContactPage() {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-[1fr_380px] gap-16">
-          {/* Left: form */}
+          {/* Left: form.
+              Wrapped in Suspense because ContactForm calls
+              useSearchParams() — Next.js 16 fails the build if that
+              hook isn't inside a Suspense boundary during static
+              generation. */}
           <div>
-            <ContactForm />
+            <Suspense fallback={null}>
+              <ContactForm />
+            </Suspense>
           </div>
 
           {/* Right: what you get */}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -500,11 +500,18 @@ export default function DashboardPage() {
                   {scores.map((entry) => (
                     <div
                       key={entry.id}
-                      className="border border-[#2a2a2a] bg-[#1a1a1a] hover:bg-[#1f1f1f] hover:border-[#3a3a3a] transition-colors group relative"
+                      className="border border-[#2a2a2a] bg-[#1a1a1a] hover:bg-[#1f1f1f] hover:border-[#3a3a3a] transition-colors group relative flex items-stretch"
                     >
+                      {/*
+                        Card click target is everything EXCEPT the delete
+                        button. Previously the delete button lived inside the
+                        Link and used preventDefault; that's the dangerous
+                        overlap Ward flagged. Now the click areas are mutually
+                        exclusive: row Link → detail page, button → delete.
+                      */}
                       <Link
                         href={`/dashboard/scores/${entry.id}`}
-                        className="block px-4 py-3"
+                        className="block flex-1 min-w-0 px-4 py-3"
                       >
                         <div className="flex items-center gap-4">
                           {entry.thumbnail ? (
@@ -553,30 +560,26 @@ export default function DashboardPage() {
                               <UpliftBadge uplift={entry.uplift} />
                             </div>
                           )}
-
-                          <button
-                            onClick={(e) => {
-                              e.preventDefault();
-                              deleteScore(entry.id);
-                            }}
-                            disabled={deleting === entry.id}
-                            className="flex-shrink-0 text-[#3a3a3a] hover:text-ladder-red transition-all disabled:opacity-30 opacity-0 group-hover:opacity-100"
-                            title="Delete score"
-                            aria-label="Delete score"
-                          >
-                            <svg
-                              width="14"
-                              height="14"
-                              viewBox="0 0 24 24"
-                              fill="none"
-                              stroke="currentColor"
-                              strokeWidth="2"
-                            >
-                              <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14" />
-                            </svg>
-                          </button>
                         </div>
                       </Link>
+                      <button
+                        onClick={() => deleteScore(entry.id)}
+                        disabled={deleting === entry.id}
+                        className="flex-shrink-0 text-[#3a3a3a] hover:text-ladder-red transition-all disabled:opacity-30 opacity-0 group-hover:opacity-100 px-4 flex items-center"
+                        title="Delete score"
+                        aria-label="Delete score"
+                      >
+                        <svg
+                          width="14"
+                          height="14"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                        >
+                          <path d="M3 6h18M8 6V4a2 2 0 012-2h4a2 2 0 012 2v2m3 0v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6h14" />
+                        </svg>
+                      </button>
                     </div>
                   ))}
                 </div>

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -63,12 +63,23 @@ function timeAgo(ts: number): string {
   return `${months}mo ago`;
 }
 
+type RecentScore = {
+  id: string;
+  score: number;
+  label: string;
+  screenName?: string;
+  thumbnail?: string;
+  timestamp: number;
+  source?: string;
+};
+
 export default function ScoreDetailPage() {
   const { isSignedIn, isLoaded } = useAuth();
   const params = useParams();
   const [data, setData] = useState<ScoreDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [recent, setRecent] = useState<RecentScore[]>([]);
 
   useEffect(() => {
     if (!isSignedIn) return;
@@ -86,7 +97,21 @@ export default function ScoreDetailPage() {
       }
     }
 
+    async function fetchRecent() {
+      try {
+        const res = await fetch("/api/dashboard");
+        if (!res.ok) return;
+        const json = await res.json();
+        if (Array.isArray(json.scores)) {
+          setRecent(json.scores);
+        }
+      } catch {
+        // Silent — recent strip is a nice-to-have, not critical.
+      }
+    }
+
     fetchScore();
+    fetchRecent();
   }, [isSignedIn, params.id]);
 
   if (!isLoaded) return null;
@@ -127,11 +152,14 @@ export default function ScoreDetailPage() {
       <div className="max-w-5xl mx-auto px-6 py-12">
 
         {/* Back + meta */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center justify-between mb-8 gap-4 flex-wrap">
           <Link href="/dashboard" className="text-[11px] text-muted uppercase tracking-widest hover:text-foreground transition-colors">
             &larr; Dashboard
           </Link>
           <div className="flex items-center gap-3">
+            <span className="text-[10px] uppercase tracking-widest text-ladder-green border border-ladder-green/30 bg-ladder-green/5 px-2 py-0.5">
+              ✓ Saved to your dashboard
+            </span>
             <span className={`text-[9px] uppercase tracking-widest px-2 py-0.5 border ${
               data.isPublic
                 ? "text-ladder-green border-ladder-green/30"
@@ -336,6 +364,111 @@ export default function ScoreDetailPage() {
             />
           </div>
         )}
+
+        {/* ── Methodology note + Drawbackwards moderated usability promo ──
+            Some screens (date pickers, multi-step flows, hover-states) need
+            to be experienced live to evaluate fairly. Ladder scores the
+            static frame; Drawbackwards offers 1:1 moderated sessions where
+            that gap matters. */}
+        <div className="mt-10 border border-[#333] bg-[#161616] p-6 md:p-8">
+          <p className="text-[10px] text-muted uppercase tracking-widest mb-3">
+            Methodology note
+          </p>
+          <p className="text-sm text-body leading-relaxed mb-4">
+            Ladder evaluates a screen as it sits. Some experiences — date
+            pickers, multi-step flows, hover states, anything that only
+            reveals itself in motion — read fairly only with a real user in
+            front of the live product.
+          </p>
+          <div className="border-t border-[#2a2a2a] pt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <p className="font-mono text-[10px] text-ladder-green uppercase tracking-widest mb-1">
+                Need the moving picture?
+              </p>
+              <p className="text-sm text-foreground font-sans">
+                Drawbackwards runs 1:1 moderated usability interviews to
+                surface what static scoring can&rsquo;t see.
+              </p>
+            </div>
+            <a
+              href="https://drawbackwards.com/contact?subject=Moderated%20usability%20interviews"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="shrink-0 inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-5 py-2.5 rounded-full hover:bg-ladder-green/90 transition-colors"
+            >
+              Talk to Drawbackwards <span aria-hidden>→</span>
+            </a>
+          </div>
+        </div>
+
+        {/* ── Recent scores strip ── */}
+        {recent.filter((r) => r.id !== data.id).length > 0 && (
+          <div className="mt-10">
+            <div className="flex items-baseline justify-between mb-4">
+              <span className="text-[10px] text-muted uppercase tracking-widest">
+                Your recent scores
+              </span>
+              <Link
+                href="/dashboard"
+                className="text-[10px] text-ladder-green uppercase tracking-widest hover:text-ladder-green/80 transition-colors"
+              >
+                View all →
+              </Link>
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+              {recent
+                .filter((r) => r.id !== data.id)
+                .slice(0, 4)
+                .map((r) => (
+                  <Link
+                    key={r.id}
+                    href={`/dashboard/scores/${r.id}`}
+                    className="border border-[#333] bg-[#1e1e1e] p-3 hover:border-muted transition-colors flex flex-col gap-2"
+                  >
+                    <div className="flex items-baseline justify-between">
+                      <span
+                        className="font-mono text-xl font-bold tabular-nums"
+                        style={{ color: getScoreColor(r.score) }}
+                      >
+                        {r.score.toFixed(1)}
+                      </span>
+                      <span className="text-[9px] text-[#555] uppercase tracking-widest">
+                        {timeAgo(r.timestamp)}
+                      </span>
+                    </div>
+                    <span className="text-[11px] text-foreground truncate">
+                      {r.screenName || r.source || "Screen"}
+                    </span>
+                  </Link>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* ── Next action CTA ──
+            Reassures the user this score is saved before they kick off
+            another analysis. "Score another" lives next to a clear path
+            back to the dashboard. */}
+        <div className="mt-10 border-t border-[#2a2a2a] pt-8 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <p className="text-xs text-muted font-sans">
+            This score is saved to your dashboard. You can come back to it any
+            time — analyzing another screen won&rsquo;t replace it.
+          </p>
+          <div className="flex items-center gap-3 shrink-0">
+            <Link
+              href="/dashboard"
+              className="text-[11px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Back to dashboard
+            </Link>
+            <Link
+              href="/score"
+              className="text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-5 py-2.5 rounded-full hover:bg-ladder-green/90 transition-colors"
+            >
+              Score another screen →
+            </Link>
+          </div>
+        </div>
 
         <div className="mt-6">
           <AnalysisFeedback scoreId={data.id} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -435,3 +435,26 @@ h1, h2, h3, h4, h5, h6 {
 .user-menu-pop {
   animation: user-menu-pop 120ms ease-out;
 }
+
+/* ── Global interactive cursor rule ──
+   Every native button, role=button, and links that resolve to an href get the
+   pointer cursor. Without this, Tailwind's reset leaves <button> with default
+   arrow which reads as inert. Disabled controls stay default. */
+button:not([disabled]),
+[role="button"]:not([aria-disabled="true"]),
+a[href],
+label[for],
+summary,
+input[type="button"]:not(:disabled),
+input[type="submit"]:not(:disabled),
+input[type="reset"]:not(:disabled) {
+  cursor: pointer;
+}
+
+button[disabled],
+[role="button"][aria-disabled="true"],
+input[type="button"]:disabled,
+input[type="submit"]:disabled,
+input[type="reset"]:disabled {
+  cursor: not-allowed;
+}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -503,6 +503,42 @@ export default function ScorePage() {
               </p>
             </div>
 
+            {/* Informational callouts — above the drop zone (Ward feedback).
+                Public/private toggle for signed-in users, terms note for anon. */}
+            {isLoaded && isSignedIn ? (
+              <div className="mb-4 flex items-center justify-center gap-3">
+                <button
+                  type="button"
+                  onClick={() => setIsPublic(!isPublic)}
+                  className={`relative w-8 h-[18px] rounded-full transition-colors cursor-pointer ${
+                    isPublic ? "bg-ladder-green" : "bg-[#333]"
+                  }`}
+                  aria-label="Toggle public score"
+                >
+                  <span
+                    className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${
+                      isPublic ? "left-[16px]" : "left-[2px]"
+                    }`}
+                  />
+                </button>
+                <span className="text-[11px] text-muted">
+                  {isPublic
+                    ? "Public score — saved to your dashboard and visible on runladder.com"
+                    : "Private score — saved to your dashboard, only you can see it"}
+                </span>
+              </div>
+            ) : (
+              <p className="mb-4 text-[11px] text-muted leading-relaxed text-center max-w-md mx-auto">
+                By scoring, you agree to our{" "}
+                <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Terms</a>{" "}
+                and{" "}
+                <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Privacy Policy</a>.
+                Free scores may be published on runladder.com.{" "}
+                <a href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Sign in</a>{" "}
+                for private scoring.
+              </p>
+            )}
+
             {/* Drop zone */}
             <div
               onDrop={handleDrop}
@@ -511,8 +547,8 @@ export default function ScorePage() {
               onClick={() => fileRef.current?.click()}
               className={`relative border cursor-pointer transition-all duration-200 ${
                 isDragOver
-                  ? "border-ladder-green bg-ladder-green/5"
-                  : "border-[#333] hover:border-muted bg-[#1e1e1e]"
+                  ? "border-ladder-green bg-ladder-green/10 shadow-[0_0_0_4px_rgba(106,200,155,0.15)] scale-[1.01]"
+                  : "border-[#333] hover:border-ladder-green/60 hover:bg-ladder-green/[0.03] bg-[#1e1e1e]"
               }`}
             >
               <ScannerCorners />
@@ -530,39 +566,6 @@ export default function ScorePage() {
                 <p className="text-[11px] text-muted tracking-wide">
                   PNG / JPG / WebP &middot; up to 10MB
                 </p>
-                {isLoaded && isSignedIn ? (
-                  <div className="mt-4 max-w-sm mx-auto">
-                    <div className="flex items-center justify-center gap-3 mb-2">
-                      <button
-                        onClick={(e) => { e.stopPropagation(); setIsPublic(!isPublic); }}
-                        className={`relative w-8 h-[18px] rounded-full transition-colors ${
-                          isPublic ? "bg-ladder-green" : "bg-[#333]"
-                        }`}
-                      >
-                        <span className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${
-                          isPublic ? "left-[16px]" : "left-[2px]"
-                        }`} />
-                      </button>
-                      <span className="text-[10px] text-[#555]">
-                        {isPublic ? "Public score — visible on runladder.com" : "Private score — only you can see this"}
-                      </span>
-                    </div>
-                    <p className="text-[10px] text-[#444] leading-relaxed text-center">
-                      Signed in. Scores saved to your{" "}
-                      <a href="/dashboard" className="text-ladder-green hover:text-ladder-green/80 transition-colors">dashboard</a>.
-                    </p>
-                  </div>
-                ) : (
-                  <p className="text-[10px] text-[#555] mt-4 max-w-xs mx-auto leading-relaxed">
-                    By scoring, you agree to our{" "}
-                    <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Terms</a>{" "}
-                    and{" "}
-                    <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Privacy Policy</a>.
-                    Free scores may be published on runladder.com.{" "}
-                    <a href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors">Sign in</a>{" "}
-                    for private scoring.
-                  </p>
-                )}
               </div>
               <input
                 ref={fileRef}
@@ -592,16 +595,30 @@ export default function ScorePage() {
               </button>
             </div>
 
-            {/* ── Past scores ── */}
-            {pastScores.length > 0 && (
+            {/* ── Past scores (signed-in only) ──
+                For signed-in users, link to the real backend-persisted score
+                detail. For anon users we suppress this section entirely —
+                their localStorage entries used random IDs that don't match
+                anything in /dashboard/scores and would 404 (Michael's bug). */}
+            {isLoaded && isSignedIn && pastScores.length > 0 && (
               <div className="mt-12 border-t border-[#333] pt-8">
-                <span className="text-[10px] text-muted uppercase tracking-widest">Recent public scores</span>
-                <div className="mt-4 space-y-2">
+                <div className="flex items-baseline justify-between mb-4">
+                  <span className="text-[10px] text-muted uppercase tracking-widest">
+                    Your recent scores
+                  </span>
+                  <Link
+                    href="/dashboard"
+                    className="text-[10px] text-ladder-green uppercase tracking-widest hover:text-ladder-green/80 transition-colors cursor-pointer"
+                  >
+                    View all →
+                  </Link>
+                </div>
+                <div className="space-y-2">
                   {pastScores.slice(0, 8).map((ps) => (
                     <Link
                       key={ps.id}
                       href={`/dashboard/scores/${ps.id}`}
-                      className="flex items-center gap-4 border border-[#333] bg-[#1e1e1e] p-3 hover:border-muted transition-colors"
+                      className="flex items-center gap-4 border border-[#333] bg-[#1e1e1e] p-3 hover:border-muted transition-colors cursor-pointer"
                     >
                       <span
                         className="text-lg font-bold tabular-nums w-12 text-center"

--- a/src/components/AuthShell.tsx
+++ b/src/components/AuthShell.tsx
@@ -9,17 +9,22 @@ export function AuthShell({
   footer: React.ReactNode;
 }) {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center px-6 pt-28 pb-16 relative overflow-hidden">
+    // Drops `justify-center` + `overflow-hidden` so tall Clerk forms
+    // (OTP grid, verification step, social buttons) scroll naturally
+    // instead of clipping at the bottom of the viewport. Widens the
+    // container slightly so focus rings and password reveal buttons
+    // have breathing room.
+    <div className="min-h-screen flex flex-col items-center px-6 pt-20 pb-16 relative">
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0"
+        className="pointer-events-none absolute inset-0 -z-10"
         style={{
           background:
             "radial-gradient(ellipse at 50% 0%, rgba(106, 200, 155, 0.06) 0%, transparent 55%)",
         }}
       />
-      <div className="relative w-full max-w-[26rem] flex flex-col items-center">
-        <Link href="/" aria-label="Ladder home" className="mb-10">
+      <div className="relative w-full max-w-[28rem] flex flex-col items-center my-auto">
+        <Link href="/" aria-label="Ladder home" className="mb-10 mt-4">
           <LadderLogo height={26} className="text-white" />
         </Link>
         <div className="w-full">{children}</div>

--- a/src/components/RungBreakdown.tsx
+++ b/src/components/RungBreakdown.tsx
@@ -3,6 +3,13 @@
 import { RUNG_DISPLAY_ORDER, getRungLevel, analyzeRungs } from "@/lib/ladder";
 import type { RungScores, RungName } from "@/lib/ladder";
 
+/**
+ * Per-rung breakdown bars. Bars are intentionally neutral (no rung color
+ * fill) so the color doesn't imply judgment — a screen scoring 4.8 on the
+ * Functional rung shouldn't read as "red/bad" just because the rung name
+ * is red. The rung label keeps its color as framework identity; the score
+ * number is shown in neutral foreground so the value itself speaks.
+ */
 function RungBar({
   rung,
   score,
@@ -40,18 +47,15 @@ function RungBar({
             </span>
           )}
         </div>
-        <span
-          className="font-mono text-sm font-bold tabular-nums"
-          style={{ color: level.color }}
-        >
+        <span className="font-mono text-sm font-bold tabular-nums text-foreground">
           {score.toFixed(1)}
         </span>
       </div>
 
       <div className="h-2 bg-[#333] rounded-sm overflow-hidden mb-1.5">
         <div
-          className="h-full rounded-sm transition-all duration-700 ease-out"
-          style={{ width: `${pct}%`, background: level.color }}
+          className="h-full rounded-sm bg-foreground/80 transition-all duration-700 ease-out"
+          style={{ width: `${pct}%` }}
         />
       </div>
 
@@ -87,7 +91,10 @@ export function RungBreakdown({ rungs }: { rungs: RungScores }) {
   );
 }
 
-/** Compact version for list views — just bars, no summaries */
+/**
+ * Compact version for list views — bars-only, no summaries. Same neutral
+ * treatment so list rows don't read as judgmental about each rung.
+ */
 export function RungBars({ rungs }: { rungs: RungScores }) {
   return (
     <div className="space-y-1.5">
@@ -101,14 +108,11 @@ export function RungBars({ rungs }: { rungs: RungScores }) {
             </span>
             <div className="flex-1 h-1.5 bg-[#333] rounded-sm overflow-hidden">
               <div
-                className="h-full rounded-sm"
-                style={{ width: `${pct}%`, background: level.color }}
+                className="h-full rounded-sm bg-foreground/80"
+                style={{ width: `${pct}%` }}
               />
             </div>
-            <span
-              className="text-[10px] font-bold tabular-nums w-6 text-right"
-              style={{ color: level.color }}
-            >
+            <span className="text-[10px] font-bold tabular-nums w-6 text-right text-foreground">
               {rungs[rung].score.toFixed(1)}
             </span>
           </div>

--- a/src/components/SessionTypePrompt.tsx
+++ b/src/components/SessionTypePrompt.tsx
@@ -141,7 +141,9 @@ export function SessionTypePill({
 }) {
   return (
     <div className="inline-flex items-center gap-2 text-[11px] font-mono border border-[#2a2a2a] bg-[#1a1a1a] px-3 py-1.5">
-      <span className="text-muted">In a</span>
+      <span className="text-muted">
+        {type === "evaluation" ? "In an" : "In a"}
+      </span>
       <span className="font-semibold text-ladder-green">
         {type === "design" ? "Design Session" : "Evaluation Session"}
       </span>

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -32,7 +32,7 @@ export const authAppearance = {
     formFieldLabel:
       "!text-body !text-xs !uppercase !tracking-wider !mb-2 !font-medium",
     formFieldInput:
-      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green !ring-0 !px-4 !py-3 !text-sm placeholder:!text-muted",
+      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green !ring-0 !px-4 !py-3 !text-sm placeholder:!text-muted !min-h-[44px] !leading-normal !box-border",
     formButtonPrimary:
       "!bg-ladder-green hover:!bg-[#5ab88b] !text-black !font-semibold !rounded-full !normal-case !text-sm !py-3 !shadow-none !border-0 [&_*]:!text-black",
     formFieldAction: "!text-ladder-green hover:!text-[#5ab88b] !text-xs",
@@ -43,7 +43,7 @@ export const authAppearance = {
     identityPreviewText: "!text-foreground !text-sm",
     identityPreviewEditButton: "!text-ladder-green hover:!text-[#5ab88b]",
     otpCodeFieldInput:
-      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green",
+      "!bg-card !border !border-border !text-foreground !rounded-lg focus:!border-ladder-green !min-h-[44px] !leading-normal !box-border",
     alternativeMethodsBlockButton:
       "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !text-sm !py-3",
     alternativeMethodsBlockButtonText: "!text-foreground !font-medium",


### PR DESCRIPTION
Addresses Ward's full list of bugs and UX issues from the Michael test.

## Bug fixes

- **"5 of 5 free scores" for team members.** `/api/dashboard` now self-heals: if the Clerk user belongs to any organization but doesn't have a team comp yet (webhook missed, secret unconfigured, pre-dates webhook), we grant the comp on the next dashboard load. Idempotent.
- **Recent Scores 404.** The `/score` "Recent public scores" section used localStorage entries with random IDs that didn't match the backend, so clicks went to `/dashboard/scores/[id]` and 404'd. Now hidden for anon; signed-in users see backend-IDed entries labeled "Your recent scores".

## Visual + interaction

- Per-rung breakdown bars neutralized site-wide (RungBreakdown + RungBars). Rung label keeps its color as framework identity; score number drops the rung tint so a 4.8 on Functional doesn't read as "red bad".
- Drop zone has a real drag-over state: green border, soft glow ring, scale lift.
- Cursor pointer globally on `button`, `[role=button]`, links, labels, summary. Disabled gets `not-allowed`.
- Dashboard score history: delete button moved outside the row Link so click targets don't overlap.
- Public/private toggle and dashboard-saved note moved above the drop zone.
- "In a Evaluation Session" → "In an Evaluation Session" grammar.

## Score-flow refinement

- "Saved to your dashboard" badge in the score detail header.
- Recent scores strip at the bottom of the detail page.
- "Score another / Back to dashboard" CTA with reassurance: "This score is saved... analyzing another screen won't replace it."

## Methodology + Drawbackwards promo

- New methodology note on the score detail explaining what static scoring can't see, paired with a "Talk to Drawbackwards" CTA pitching 1:1 moderated usability interviews. Lands the agency promo where the gap is most visible.

## Login form polish

- AuthShell drops `justify-center` + `overflow-hidden` so tall Clerk forms scroll instead of clipping on mid-height browsers. Container widened 26rem → 28rem.
- Clerk formFieldInput + otpCodeFieldInput get a 44px min-height + box-border so inputs render predictably.

## Test plan

- [ ] As a signed-in Clerk Org member, visit `/dashboard`. Banner reads "Complimentary Team — Member of [Org]" (no "5 of 5").
- [ ] On `/score`, drag a file over the drop zone. See green border + soft glow.
- [ ] Hover any button. See the pointer cursor.
- [ ] On the dashboard, hover a score row. Click the trash icon — only deletes, no navigation. Click anywhere else — navigates to detail.
- [ ] Score a screen. After analysis, land on `/dashboard/scores/[id]`. See "✓ Saved to your dashboard" badge. Scroll down to find methodology note, Drawbackwards CTA, recent scores strip, and Score another CTA bar.
- [ ] In a session set to evaluation, see "In an Evaluation Session" (correct grammar).
- [ ] Open `/login` on a 500px-tall viewport. Form scrolls cleanly, no field clipping.
- [ ] In RungBreakdown on a score detail, bars are white/neutral. Rung labels keep their color. Score number is white.

🤖 Generated with [Claude Code](https://claude.com/claude-code)