### PR TITLE
Levels: neutralize color coding site-wide, add five-segment ScoreBar

### DIFF
--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
+import { ScoreBar } from "@/components/ScoreBar";
 import { AnalysisFeedback } from "@/components/AnalysisFeedback";
 import { ScoreAnnotations } from "@/components/ScoreAnnotations";
 
@@ -192,10 +193,10 @@ export default function ScoreDetailPage() {
             <p className="text-sm text-foreground font-sans mb-6">{data.screenName}</p>
 
             <div className="flex-1 flex flex-col items-start justify-center">
-              <span className="font-mono font-bold text-[4rem] leading-none tabular-nums" style={{ color: getScoreColor(data.score) }}>
+              <span className="font-mono font-bold text-[4rem] leading-none tabular-nums text-foreground">
                 {data.score.toFixed(1)}
               </span>
-              <span className="text-sm font-bold uppercase tracking-widest mt-1" style={{ color: getScoreColor(data.score) }}>
+              <span className="text-sm font-bold uppercase tracking-widest mt-1 text-foreground">
                 {data.label}
               </span>
 
@@ -224,18 +225,13 @@ export default function ScoreDetailPage() {
               <div className="mt-6 pt-4 border-t border-[#333] w-full">
                 <span className="text-[10px] text-muted uppercase tracking-widest">Gap to {nextLevel}</span>
                 <div className="flex items-baseline gap-2 mt-1">
-                  <span className="text-lg font-bold" style={{ color: getLevelColor(nextLevel) }}>+{gap}</span>
+                  <span className="text-lg font-bold text-foreground">+{gap}</span>
                   <span className="text-[11px] text-muted">points</span>
                 </div>
               </div>
 
               <div className="mt-6 w-full">
-                <div className="h-1.5 bg-[#333] w-full">
-                  <div
-                    className="h-full transition-all duration-700 ease-out"
-                    style={{ width: `${(data.score / 5) * 100}%`, background: getScoreColor(data.score) }}
-                  />
-                </div>
+                <ScoreBar score={data.score} size="md" />
                 <div className="flex justify-between mt-2 text-[10px] text-[#444]">
                   <span>1.0</span><span>2.0</span><span>3.0</span><span>4.0</span><span>5.0</span>
                 </div>

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -198,11 +198,14 @@ export default function FrameworkPage() {
             </div>
             <div className="space-y-3">
               {[
-                { score: "5", label: "Meaningful", color: "text-ladder-white", border: "border-white/20", desc: "Irreplaceable" },
-                { score: "4", label: "Delightful", color: "text-ladder-delightful", border: "border-ladder-delightful/20", desc: "Anticipates user needs" },
-                { score: "3", label: "Comfortable", color: "text-ladder-yellow", border: "border-ladder-yellow/20", desc: "The modern minimum bar" },
-                { score: "2", label: "Usable", color: "text-ladder-orange", border: "border-ladder-orange/20", desc: "Tasks complete with effort" },
-                { score: "1", label: "Functional", color: "text-ladder-red", border: "border-ladder-red/20", desc: "User fights the product" },
+                // Level color coding removed (Ward, 2026-05-11). Each level
+                // renders neutral white — the level NAME conveys identity,
+                // not color.
+                { score: "5", label: "Meaningful", color: "text-foreground", border: "border-border", desc: "Irreplaceable" },
+                { score: "4", label: "Delightful", color: "text-foreground", border: "border-border", desc: "Anticipates user needs" },
+                { score: "3", label: "Comfortable", color: "text-foreground", border: "border-border", desc: "The modern minimum bar" },
+                { score: "2", label: "Usable", color: "text-foreground", border: "border-border", desc: "Tasks complete with effort" },
+                { score: "1", label: "Functional", color: "text-foreground", border: "border-border", desc: "User fights the product" },
               ].map((level) => (
                 <div
                   key={level.score}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,41 +1,44 @@
 import Link from "next/link";
 import { LadderScore } from "@/components/LadderScore";
 
+// Level color coding removed across marketing site, product, and plugin
+// (Ward, 2026-05-11). Each level renders neutral white; the level NAME
+// conveys identity, the score number on the page conveys judgment.
 const LEVELS = [
   {
     score: "5",
     label: "Meaningful",
     desc: "Irreplaceable. Changed how they think, work, or live.",
-    color: "text-ladder-white",
-    border: "border-white/20",
+    color: "text-foreground",
+    border: "border-border",
   },
   {
     score: "4",
     label: "Delightful",
     desc: "Anticipates needs. Right help at right moment. Users refer others.",
-    color: "text-ladder-delightful",
-    border: "border-ladder-delightful/20",
+    color: "text-foreground",
+    border: "border-border",
   },
   {
     score: "3",
     label: "Comfortable",
     desc: "No thinking required. Everything where expected. The modern minimum.",
-    color: "text-ladder-yellow",
-    border: "border-ladder-yellow/20",
+    color: "text-foreground",
+    border: "border-border",
   },
   {
     score: "2",
     label: "Usable",
     desc: "Tasks complete with effort. User tolerates it but would switch.",
-    color: "text-ladder-orange",
-    border: "border-ladder-orange/20",
+    color: "text-foreground",
+    border: "border-border",
   },
   {
     score: "1",
     label: "Functional",
     desc: "User fights the product. Trial, error, frustration.",
-    color: "text-ladder-red",
-    border: "border-ladder-red/20",
+    color: "text-foreground",
+    border: "border-border",
   },
 ];
 

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
+import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
 import {
@@ -843,25 +844,20 @@ export default function ScorePage() {
                 <span className="text-[10px] text-muted uppercase tracking-widest mb-6">Screen Score</span>
                 <div className="flex-1 flex flex-col items-start justify-center">
                   <AnimatedScore target={result.score} />
-                  <span className="text-sm font-bold uppercase tracking-widest mt-1" style={{ color: getScoreColor(result.score) }}>
+                  <span className="text-sm font-bold uppercase tracking-widest mt-1 text-foreground">
                     {result.label}
                   </span>
 
                   <div className="mt-6 pt-4 border-t border-[#333] w-full">
                     <span className="text-[10px] text-muted uppercase tracking-widest">Gap to {nextLevel}</span>
                     <div className="flex items-baseline gap-2 mt-1">
-                      <span className="text-lg font-bold" style={{ color: getLevelColor(nextLevel) }}>+{gap}</span>
+                      <span className="text-lg font-bold text-foreground">+{gap}</span>
                       <span className="text-[11px] text-muted">points</span>
                     </div>
                   </div>
 
                   <div className="mt-6 w-full">
-                    <div className="h-1.5 bg-[#333] w-full">
-                      <div
-                        className="h-full transition-all duration-700 ease-out"
-                        style={{ width: `${(result.score / 5) * 100}%`, background: getScoreColor(result.score) }}
-                      />
-                    </div>
+                    <ScoreBar score={result.score} size="md" />
                     <div className="flex justify-between mt-2 text-[10px] text-[#444]">
                       <span>1.0</span><span>2.0</span><span>3.0</span><span>4.0</span><span>5.0</span>
                     </div>

--- a/src/components/RungBreakdown.tsx
+++ b/src/components/RungBreakdown.tsx
@@ -2,13 +2,13 @@
 
 import { RUNG_DISPLAY_ORDER, getRungLevel, analyzeRungs } from "@/lib/ladder";
 import type { RungScores, RungName } from "@/lib/ladder";
+import { ScoreBar } from "./ScoreBar";
 
 /**
- * Per-rung breakdown bars. Bars are intentionally neutral (no rung color
- * fill) so the color doesn't imply judgment — a screen scoring 4.8 on the
- * Functional rung shouldn't read as "red/bad" just because the rung name
- * is red. The rung label keeps its color as framework identity; the score
- * number is shown in neutral foreground so the value itself speaks.
+ * Per-rung breakdown bars. Bars are five-segmented white indicators
+ * (see ScoreBar). Rung label and score number both render neutral —
+ * level color coding is gone (Ward, 2026-05-11). The number itself
+ * is what conveys judgment.
  */
 function RungBar({
   rung,
@@ -24,25 +24,21 @@ function RungBar({
   isWeakest: boolean;
 }) {
   const level = getRungLevel(rung);
-  const pct = Math.max(2, (score / 5) * 100); // min 2% so bar is always visible
 
   return (
     <div className="group">
       <div className="flex items-baseline justify-between mb-1.5">
         <div className="flex items-center gap-2">
-          <span
-            className="font-mono text-[11px] font-bold uppercase tracking-wider"
-            style={{ color: level.color }}
-          >
+          <span className="font-mono text-[11px] font-bold uppercase tracking-wider text-foreground">
             {level.label}
           </span>
           {isStrongest && (
-            <span className="text-[9px] text-green-400 uppercase tracking-widest">
+            <span className="text-[9px] text-muted uppercase tracking-widest">
               Strongest
             </span>
           )}
           {isWeakest && (
-            <span className="text-[9px] text-red-400 uppercase tracking-widest">
+            <span className="text-[9px] text-muted uppercase tracking-widest">
               Focus here
             </span>
           )}
@@ -52,16 +48,9 @@ function RungBar({
         </span>
       </div>
 
-      <div className="h-2 bg-[#333] rounded-sm overflow-hidden mb-1.5">
-        <div
-          className="h-full rounded-sm bg-foreground/80 transition-all duration-700 ease-out"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
+      <ScoreBar score={score} size="md" className="mb-1.5" />
 
-      <p className="text-[11px] text-muted leading-relaxed">
-        {summary}
-      </p>
+      <p className="text-[11px] text-muted leading-relaxed">{summary}</p>
     </div>
   );
 }
@@ -92,26 +81,20 @@ export function RungBreakdown({ rungs }: { rungs: RungScores }) {
 }
 
 /**
- * Compact version for list views — bars-only, no summaries. Same neutral
- * treatment so list rows don't read as judgmental about each rung.
+ * Compact version for list views — bars-only, no per-rung summaries.
+ * Same neutral five-segment treatment.
  */
 export function RungBars({ rungs }: { rungs: RungScores }) {
   return (
     <div className="space-y-1.5">
       {RUNG_DISPLAY_ORDER.map((rung) => {
         const level = getRungLevel(rung);
-        const pct = Math.max(2, (rungs[rung].score / 5) * 100);
         return (
           <div key={rung} className="flex items-center gap-2">
             <span className="text-[9px] text-muted w-20 text-right uppercase tracking-wider truncate">
               {level.label}
             </span>
-            <div className="flex-1 h-1.5 bg-[#333] rounded-sm overflow-hidden">
-              <div
-                className="h-full rounded-sm bg-foreground/80"
-                style={{ width: `${pct}%` }}
-              />
-            </div>
+            <ScoreBar score={rungs[rung].score} size="sm" className="flex-1" />
             <span className="text-[10px] font-bold tabular-nums w-6 text-right text-foreground">
               {rungs[rung].score.toFixed(1)}
             </span>

--- a/src/components/ScoreBar.tsx
+++ b/src/components/ScoreBar.tsx
@@ -1,0 +1,61 @@
+/**
+ * ScoreBar — the canonical Ladder score visualization.
+ *
+ * Five equal segments separated by thin gaps so the user always sees the
+ * 1–5 scale at a glance, even at a score of 0. Each segment fills
+ * proportionally with white as the score crosses it:
+ *
+ *   3.4 → [████][████][████][██░░][░░░░]
+ *
+ * Bars are intentionally white (no level color coding) — Ward, 2026-05-11.
+ * The score number on the page is what conveys judgment.
+ *
+ * Sizes default to the same height the per-rung breakdown has historically
+ * used (h-2). Pass `size="lg"` for the hero score panel or `size="sm"` for
+ * compact list rows.
+ */
+type Size = "sm" | "md" | "lg";
+
+const HEIGHT_BY_SIZE: Record<Size, string> = {
+  sm: "h-1.5",
+  md: "h-2",
+  lg: "h-2.5",
+};
+
+export function ScoreBar({
+  score,
+  size = "md",
+  className = "",
+  animate = true,
+}: {
+  /** 0.0–5.0. Values outside this range are clamped. */
+  score: number;
+  size?: Size;
+  className?: string;
+  animate?: boolean;
+}) {
+  const clamped = Math.max(0, Math.min(5, score));
+  const segments = [1, 2, 3, 4, 5];
+  const height = HEIGHT_BY_SIZE[size];
+
+  return (
+    <div className={`flex items-stretch gap-1 w-full ${height} ${className}`}>
+      {segments.map((seg) => {
+        const fillPct = Math.max(0, Math.min(1, clamped - (seg - 1))) * 100;
+        return (
+          <div
+            key={seg}
+            className="flex-1 bg-[#2a2a2a] rounded-sm overflow-hidden relative"
+          >
+            <div
+              className={`absolute inset-y-0 left-0 bg-foreground ${
+                animate ? "transition-all duration-700 ease-out" : ""
+              }`}
+              style={{ width: `${fillPct}%` }}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/ladder.ts
+++ b/src/lib/ladder.ts
@@ -21,15 +21,33 @@ export type LadderLevel = {
   experienceTest: string;
 };
 
+/**
+ * Level color palette — neutralized.
+ *
+ * Per Ward's direction (2026-05-11), the levels of the Ladder are no longer
+ * color-coded across the marketing site, product, or plugin. Bars are white,
+ * labels are neutral, and the score number on the page is what conveys
+ * judgment. The `color` / `cssText` / `cssBg` fields are intentionally
+ * uniform white so every existing consumer of `level.color`,
+ * `getScoreColor()`, `getLevelColor()`, etc. flips to neutral automatically.
+ *
+ * If the framework ever needs identity colors back (e.g. for a specific
+ * marketing surface), introduce a separate `accentColor` field rather than
+ * resurrecting per-level color encoding here.
+ */
+const NEUTRAL_COLOR = "#ffffff";
+const NEUTRAL_TEXT_CLASS = "text-foreground";
+const NEUTRAL_BG_CLASS = "bg-foreground";
+
 export const LEVELS: LadderLevel[] = [
   {
     level: 1,
     min: 0,
     max: 1.99,
     label: "Functional",
-    color: "#ef4444",
-    cssText: "text-ladder-red",
-    cssBg: "bg-ladder-red",
+    color: NEUTRAL_COLOR,
+    cssText: NEUTRAL_TEXT_CLASS,
+    cssBg: NEUTRAL_BG_CLASS,
     tagline: "It works. Barely.",
     description:
       "The user fights the product. Navigation is confusing, actions are unclear, and completing basic tasks requires trial and error. Built for engineering requirements, not human needs.",
@@ -41,9 +59,9 @@ export const LEVELS: LadderLevel[] = [
     min: 2,
     max: 2.99,
     label: "Usable",
-    color: "#f97316",
-    cssText: "text-ladder-orange",
-    cssBg: "bg-ladder-orange",
+    color: NEUTRAL_COLOR,
+    cssText: NEUTRAL_TEXT_CLASS,
+    cssBg: NEUTRAL_BG_CLASS,
     tagline: "Tasks complete with effort.",
     description:
       "Basic structure exists. Users can accomplish goals, but it takes more effort than it should. The interface doesn't guide, it presents. Users tolerate it but would switch.",
@@ -55,9 +73,9 @@ export const LEVELS: LadderLevel[] = [
     min: 3,
     max: 3.99,
     label: "Comfortable",
-    color: "#eab308",
-    cssText: "text-ladder-yellow",
-    cssBg: "bg-ladder-yellow",
+    color: NEUTRAL_COLOR,
+    cssText: NEUTRAL_TEXT_CLASS,
+    cssBg: NEUTRAL_BG_CLASS,
     tagline: "No thinking required. The modern minimum.",
     description:
       "Everything is where expected. The interface is intuitive. Users feel their way through without conscious thought. Friction is removed. This is the modern minimum bar.",
@@ -69,9 +87,9 @@ export const LEVELS: LadderLevel[] = [
     min: 4,
     max: 4.99,
     label: "Delightful",
-    color: "#22c55e",
-    cssText: "text-ladder-delightful",
-    cssBg: "bg-ladder-delightful",
+    color: NEUTRAL_COLOR,
+    cssText: NEUTRAL_TEXT_CLASS,
+    cssBg: NEUTRAL_BG_CLASS,
     tagline: "Anticipates needs. Users refer others.",
     description:
       "The product actively helps. It adapts to context, surfaces the right information at the right moment, and turns complexity into quick decisions. Users tell others about it.",
@@ -83,9 +101,9 @@ export const LEVELS: LadderLevel[] = [
     min: 5,
     max: 5,
     label: "Meaningful",
-    color: "#ffffff",
-    cssText: "text-ladder-white",
-    cssBg: "bg-ladder-white",
+    color: NEUTRAL_COLOR,
+    cssText: NEUTRAL_TEXT_CLASS,
+    cssBg: NEUTRAL_BG_CLASS,
     tagline: "Irreplaceable.",
     description:
       "The experience changed how the user thinks, works, or lives. Switching is unthinkable. The user can't imagine going back. Level 5 is the ceiling.",


### PR DESCRIPTION
Per your direction: remove level color coding across the marketing site + product, swap all bars to white five-segment indicators.

## Canonical lib (src/lib/ladder.ts)
- LEVELS[].color, .cssText, .cssBg uniformly neutral (#ffffff / text-foreground / bg-foreground)
- Every consumer of level.color, getScoreColor(), getLevelColor() flips to white automatically

## New canonical bar — ScoreBar
- Five equal segments separated by thin gaps so the 1–5 scale always reads at a glance, even at score 0
- Each segment fills proportionally: 3.4 → \`[████][████][████][██░░][░░░░]\`
- White fill, neutral track
- Three sizes (sm / md / lg)

## Swaps
- RungBreakdown + RungBars now use ScoreBar
- /dashboard/scores/[id] hero score bar swapped to ScoreBar
- /score result panel bar swapped to ScoreBar
- /framework local LEVELS array → neutral
- / (homepage) local LEVELS array → neutral
- /top-100 inherits via re-export from canonical lib

## Out of scope (separate repo)
- Figma plugin (drawbackwards/ai-design-assistant) carries its own palette. Needs a follow-up PR there.

## Test plan
- [ ] Visit /dashboard/scores/[id] for a score: bar shows 5 segments, white fill, no rung tint
- [ ] Open the per-rung breakdown: each rung label is neutral, each bar is five-segment white
- [ ] Visit /framework: each level row is neutral (no red/orange/yellow/green)
- [ ] Visit /: hero level cards neutral
- [ ] Visit /top-100: scores neutral
- [ ] Score a new screen: animated score number renders white

🤖 Generated with [Claude Code](https://claude.com/claude-code)