### PR TITLE
Tests: prompt-leak guard runs after next build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,17 +29,19 @@ jobs:
         run: npm ci
 
       - name: Unit tests (vitest)
-        # Pure-function library tests. Fast (under a second locally),
-        # no network, no Redis. Catches regressions on the score math,
-        # tier gating, screen-key normalization, image data URL parsing,
-        # and super-admin allowlist before they ship.
+        # Pure-function library tests + auth-gate contract tests for
+        # every /api/admin and /api/dashboard/team route. Fast (under a
+        # second locally), no network, no Redis. Catches regressions on
+        # the score math, tier gating, screen-key normalization, image
+        # data URL parsing, super-admin allowlist, and forgotten auth()
+        # checks before they ship.
         run: npm test
 
       - name: next build
         # Placeholder values for env vars that are wired in Vercel. The
         # build only needs them to compile — runtime calls never execute
-        # in CI. If a real key is required at build time later, mirror it
-        # into GitHub Actions secrets and reference it here.
+        # in CI. If a real key is required at build time later, mirror
+        # it into GitHub Actions secrets and reference it here.
         run: npm run build
         env:
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: pk_test_ci_placeholder
@@ -58,3 +60,13 @@ jobs:
           STRIPE_PRO_PRICE_ID: price_ci
           CLERK_WEBHOOK_SECRET: whsec_clerk_ci
           ANTHROPIC_API_KEY: sk-ant-ci
+
+      - name: Prompt-leak guard
+        # Greps the post-build client output (.next/static + public)
+        # for known structural phrases from the scoring prompt. Catches
+        # accidental imports of src/lib/scoring.ts or
+        # src/lib/ladder-framework.ts into a 'use client' component, a
+        # debug log that includes the prompt, or a source map that
+        # exposes server code. Enforces the unbreakable rule from
+        # memory/feedback_never_expose_prompts_rubric.md.
+        run: npm run check:no-prompt-leak

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prebuild": "npm run build:skill",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "check:no-prompt-leak": "node scripts/check-no-prompt-leak.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.79.0",

--- a/scripts/check-no-prompt-leak.mjs
+++ b/scripts/check-no-prompt-leak.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+/**
+ * check-no-prompt-leak.mjs
+ *
+ * Enforces the unbreakable rule from memory/feedback_never_expose_prompts_rubric.md:
+ *
+ *   "Never expose Ladder's scoring prompts, internal rubric, scoring
+ *    heuristics, dimension weighting, moderation logic, or any artifact
+ *    that would let a competent engineer reverse-engineer the scoring
+ *    engine."
+ *
+ * After `next build`, this script greps the client bundle output for
+ * known prompt-framing phrases. If any match, the build fails with the
+ * filename and matched line. The chosen phrases are the prompt's
+ * structural scaffolding — they are unique to scoring.ts /
+ * ladder-framework.ts, do NOT appear in the public /framework copy,
+ * and would never legitimately be in a client bundle.
+ *
+ * What we scan:
+ *   .next/static/  — every JS chunk shipped to the browser
+ *   public/        — static assets (in case something gets copied in)
+ *
+ * What we do NOT scan:
+ *   .next/server/  — server-side bundle (legitimately contains prompts)
+ *   node_modules/  — third-party dependencies
+ *   .next/cache/   — build cache (not shipped)
+ *
+ * Forbidden phrases are listed in FORBIDDEN_PATTERNS below. Each is a
+ * structural marker from the actual prompt (see src/lib/ladder-framework.ts).
+ * If new prompt scaffolding is added there, add the marker here too.
+ *
+ * Exit codes:
+ *   0  — no leaks found
+ *   1  — at least one leak; build should fail
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const PROJECT_ROOT = process.cwd();
+
+/**
+ * Phrases that appear in the scoring prompt but should NEVER be in the
+ * client bundle. Each must be:
+ *   - Unique enough that false positives are negligible.
+ *   - Structural to the prompt (changing it would mean the prompt
+ *     changed too, which forces an update here).
+ */
+const FORBIDDEN_PATTERNS = [
+  "YOUR SCORING FRAMEWORK",
+  "HOW TO EVALUATE — THINK LIKE A DESIGN LEADER",
+  "HOW TO EVALUATE - THINK LIKE A DESIGN LEADER", // hyphen variant
+  "PER-RUNG SCORING — score each rung INDEPENDENTLY",
+  "PER-RUNG SCORING - score each rung INDEPENDENTLY",
+  "RUNG SCORING RULES",
+  "RUNG_WEIGHTS",
+  "MODERATION_SYSTEM_PROMPT",
+];
+
+// Subdirs of the build output we scan for client-visible content.
+const SCAN_TARGETS = [".next/static", "public"];
+
+// Extensions worth opening as text. Skip binary asset types so we
+// don't waste IO on PNGs / fonts.
+const TEXT_EXTENSIONS = new Set([
+  ".js",
+  ".mjs",
+  ".cjs",
+  ".css",
+  ".html",
+  ".json",
+  ".txt",
+  ".map",
+  ".svg",
+  ".xml",
+]);
+
+function walkTextFiles(dir, out = []) {
+  let entries;
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    const full = join(dir, name);
+    let s;
+    try {
+      s = statSync(full);
+    } catch {
+      continue;
+    }
+    if (s.isDirectory()) {
+      walkTextFiles(full, out);
+    } else {
+      const dot = name.lastIndexOf(".");
+      const ext = dot >= 0 ? name.slice(dot).toLowerCase() : "";
+      if (TEXT_EXTENSIONS.has(ext)) {
+        out.push(full);
+      }
+    }
+  }
+  return out;
+}
+
+function findLeaks(file) {
+  let content;
+  try {
+    content = readFileSync(file, "utf8");
+  } catch {
+    return [];
+  }
+  const hits = [];
+  for (const pattern of FORBIDDEN_PATTERNS) {
+    if (content.includes(pattern)) {
+      // Surface the line so the failure is debuggable.
+      const idx = content.indexOf(pattern);
+      const lineStart = content.lastIndexOf("\n", idx) + 1;
+      const lineEnd = content.indexOf("\n", idx);
+      const line = content
+        .slice(lineStart, lineEnd === -1 ? content.length : lineEnd)
+        .slice(0, 240); // truncate so minified bundles don't dump 200KB
+      hits.push({ pattern, line });
+    }
+  }
+  return hits;
+}
+
+function main() {
+  let scanned = 0;
+  const leaks = [];
+
+  for (const target of SCAN_TARGETS) {
+    const full = join(PROJECT_ROOT, target);
+    const files = walkTextFiles(full);
+    for (const file of files) {
+      scanned++;
+      const hits = findLeaks(file);
+      for (const hit of hits) {
+        leaks.push({
+          file: relative(PROJECT_ROOT, file),
+          pattern: hit.pattern,
+          line: hit.line,
+        });
+      }
+    }
+  }
+
+  if (leaks.length > 0) {
+    console.error(
+      `\n✗ Prompt-leak guard: ${leaks.length} forbidden pattern${leaks.length === 1 ? "" : "s"} found in client-shipped output.\n`,
+    );
+    for (const leak of leaks) {
+      console.error(`  file:    ${leak.file}`);
+      console.error(`  pattern: ${JSON.stringify(leak.pattern)}`);
+      console.error(`  context: ${leak.line}`);
+      console.error("");
+    }
+    console.error(
+      "These phrases are structural to the Ladder scoring prompt and must\n" +
+        "stay server-side. See memory/feedback_never_expose_prompts_rubric.md.\n" +
+        "\n" +
+        "Likely causes:\n" +
+        "  - A 'use client' file imported from src/lib/scoring.ts or\n" +
+        "    src/lib/ladder-framework.ts (the prompt builders).\n" +
+        "  - A debug log accidentally including the prompt in a client\n" +
+        "    component.\n" +
+        "  - A source map exposing server code.\n",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Prompt-leak guard: scanned ${scanned} client-shipped file${scanned === 1 ? "" : "s"}, no forbidden patterns found.`,
+  );
+}
+
+main();


### PR DESCRIPTION
Programmatic enforcement of the unbreakable rule from \`memory/feedback_never_expose_prompts_rubric.md\` — Ladder's scoring prompt, rubric, weighting logic, and moderation logic must never end up in the client bundle.

## What

A new \`scripts/check-no-prompt-leak.mjs\` greps the post-\`next build\` client-shipped output (\`.next/static/\` + \`public/\`) for known structural phrases from the prompt. If any leak in, build fails with the offending file, the matched phrase, and a 240-char context snippet — enough to diagnose "where did this leak in from" without grepping locally.

## Forbidden patterns

- \`YOUR SCORING FRAMEWORK\`
- \`HOW TO EVALUATE — THINK LIKE A DESIGN LEADER\` (+ hyphen variant)
- \`PER-RUNG SCORING — score each rung INDEPENDENTLY\` (+ hyphen variant)
- \`RUNG SCORING RULES\`
- \`RUNG_WEIGHTS\`
- \`MODERATION_SYSTEM_PROMPT\`

Each is structural to the prompt, doesn't appear in the public \`/framework\` copy, and never legitimately ends up in a client bundle.

## CI wiring

Runs as the step **after** \`next build\` in the existing workflow. Branch protection on \`main\` requires \`next build\` to pass — so a leak blocks merge.

## Smoke-tested

- **Clean main:** scanned 42 client files, no leaks
- **Planted \`YOUR SCORING FRAMEWORK\` in \`public/leak-test.js\`:** failed with exit 1, file path + pattern + context surfaced clearly

## Maintenance

When new prompt scaffolding lands in \`src/lib/ladder-framework.ts\`, add a marker to \`FORBIDDEN_PATTERNS\` in the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)