### PR TITLE
Score: gate session-type prompt on active Clerk org (Teams only)

### DIFF
--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -9,13 +9,13 @@
  * Every test in this file is safe to run against any environment, in
  * any order, repeatedly. Read-only, no mutations.
  */
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 /**
  * Asserts a page navigates, returns sub-400, and has non-trivial body
  * content (so we know it didn't render a blank error page).
  */
-async function expectPageRenders(page, url: string, minBodyChars = 200) {
+async function expectPageRenders(page: Page, url: string, minBodyChars = 200) {
   const response = await page.goto(url, { waitUntil: "domcontentloaded" });
   const status = response?.status() ?? 0;
   expect(status, `${url} status`).toBeLessThan(400);

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth } from "@clerk/nextjs";
+import { useAuth, useOrganization } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
@@ -226,6 +226,12 @@ function timeAgo(ts: number): string {
 export default function ScorePage() {
   const router = useRouter();
   const { isSignedIn, isLoaded } = useAuth();
+  // Active Clerk organization = the user is currently scoring in a team
+  // context. Only team members ever see the design/evaluation session
+  // prompt — for free/Pro users the bucketing has no surface to show up
+  // in, so the prompt is pure friction.
+  const { organization, isLoaded: orgLoaded } = useOrganization();
+  const onTeam = orgLoaded && !!organization;
   const { sessionType, ready: sessionTypeReady, pick: pickSessionType, clear: clearSessionType } =
     useSessionType();
   const [image, setImage] = useState<string | null>(null);
@@ -431,11 +437,17 @@ export default function ScorePage() {
   const hasInput = image || urlScreenshots.length > 0;
   const showUploadUI = !result && !loading && !capturing;
 
-  // Signed-in users must declare intent before scoring so the score lands
-  // in the right bucket (design vs evaluation). Anon users skip this:
-  // their score isn't saved to history anyway.
+  // Session-type prompt is a Teams-only feature: design vs evaluation
+  // bucketing only matters when a manager view groups scores by type.
+  // Free, Pro, and Pulse users scoring outside a team context don't
+  // need to declare intent. The pill that lets you change session
+  // type is gated on the same condition below.
   const showSessionTypePrompt =
-    isLoaded && isSignedIn && sessionTypeReady && !sessionType;
+    isLoaded &&
+    isSignedIn &&
+    onTeam &&
+    sessionTypeReady &&
+    !sessionType;
 
   // After a successful analysis, signed-in users are routed to the full
   // score detail in their dashboard. This screen reassures them while the
@@ -469,7 +481,7 @@ export default function ScorePage() {
       )}
       <div className="relative z-10 max-w-5xl mx-auto px-6 py-12">
 
-        {isLoaded && isSignedIn && sessionType && !result && !loading && !capturing && (
+        {isLoaded && isSignedIn && onTeam && sessionType && !result && !loading && !capturing && (
           <div className="flex justify-end mb-4">
             <SessionTypePill type={sessionType} onChange={clearSessionType} />
           </div>


### PR DESCRIPTION
The "What kind of session is this? Design vs Evaluation" modal was firing for **every signed-in user** when it's actually a Teams-only feature — the bucketing only matters when a manager view groups scores by session type. Free, Pro, and Pulse users scoring outside a team context were seeing pure friction.

## Fix

\`useOrganization()\` from @clerk/nextjs to check the active Clerk org. \`onTeam = orgLoaded && !!organization\`.

- **Modal** (\`SessionTypeModal\`) — gated on \`onTeam\`
- **Pill** (\`SessionTypePill\`, the change-session-type chip) — gated on \`onTeam\`

Switching to your personal context inside Clerk silently drops the prompt. Correct — there's no manager view to bucket against when you're not in an org.

## Also fixed

Pre-existing TS implicit-any on the \`expectPageRenders(page)\` helper in \`e2e/smoke.spec.ts\` (used \`Page\` type from \`@playwright/test\`). \`tsc --noEmit\` is now clean.

## Test plan

- [ ] As a free signed-in user (not in any Clerk org), visit \`/score\` — modal does NOT appear
- [ ] As a Drawbackwards team member with active org context, visit \`/score\` — modal DOES appear, picks session type, persists for the session
- [ ] Switch from personal account to org in the UserMenu — modal appears after switch
- [ ] All 94 vitest tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)