### PR TITLE
Auth shell: clip horizontal overflow so Clerk step transitions stay in-bounds

### DIFF
--- a/src/components/AuthShell.tsx
+++ b/src/components/AuthShell.tsx
@@ -9,12 +9,14 @@ export function AuthShell({
   footer: React.ReactNode;
 }) {
   return (
-    // Drops `justify-center` + `overflow-hidden` so tall Clerk forms
-    // (OTP grid, verification step, social buttons) scroll naturally
-    // instead of clipping at the bottom of the viewport. Widens the
-    // container slightly so focus rings and password reveal buttons
-    // have breathing room.
-    <div className="min-h-screen flex flex-col items-center px-6 pt-20 pb-16 relative">
+    // Clerk slides its form left/right between steps (email → code).
+    // We need horizontal overflow clipped so a mid-transition form
+    // doesn't visually slide off the left edge of the viewport (Ward
+    // saw this when focusing the email field — the form half-appeared
+    // mid-slide). We still want VERTICAL overflow scrollable so tall
+    // forms (OTP grid, verification step, social buttons) don't clip
+    // at the bottom on short viewports.
+    <div className="min-h-screen flex flex-col items-center px-6 pt-20 pb-16 relative overflow-x-hidden">
       <div
         aria-hidden
         className="pointer-events-none absolute inset-0 -z-10"
@@ -23,7 +25,7 @@ export function AuthShell({
             "radial-gradient(ellipse at 50% 0%, rgba(106, 200, 155, 0.06) 0%, transparent 55%)",
         }}
       />
-      <div className="relative w-full max-w-[28rem] flex flex-col items-center my-auto">
+      <div className="relative w-full max-w-[28rem] flex flex-col items-center my-auto overflow-x-hidden">
         <Link href="/" aria-label="Ladder home" className="mb-10 mt-4">
           <LadderLogo height={26} className="text-white" />
         </Link>


### PR DESCRIPTION
When Clerk slides between auth steps (email entry → code verification), the inner form briefly translates horizontally. The shell wasn't clipping the x-axis, so a mid-slide form half-appeared off the left edge of the viewport — visible when focusing the email field on /login.

## Fix

Add \`overflow-x-hidden\` to BOTH the outer page shell and the \`max-w-[28rem]\` inner container in \`AuthShell\`. Horizontal-only — vertical scrolling is preserved so tall forms (OTP grid, verification, social buttons) still scroll cleanly on short viewports.

## Why this regressed

My earlier "drop \`overflow-hidden\` so vertical content scrolls" fix removed x-axis protection too. This restores x-clip without clipping y.

## Test plan

- [ ] /login on a desktop viewport — focus the email input, hit Enter to advance to the code step. No horizontal shift past the form container.
- [ ] /login on a narrow viewport (375px) — form still fits and scrolls vertically if needed, no horizontal scroll.
- [ ] /sign-up same.

🤖 Generated with [Claude Code](https://claude.com/claude-code)