### PR TITLE
Scores: soft-delete so team admins keep an audit trail of deleted scans

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -55,7 +55,13 @@ export async function GET() {
       }
     }
     return entry;
-  }).filter(Boolean);
+  })
+    .filter(Boolean)
+    // Soft-deleted scores stay in Redis so team admins keep the audit
+    // trail, but the score's owner should never see them on their own
+    // dashboard. /api/dashboard/scores DELETE flips deletedAt; this is
+    // the read-side filter.
+    .filter((s: { deletedAt?: number } | null) => s && !s.deletedAt);
 
   return NextResponse.json({
     scores: parsedScores,

--- a/src/app/api/dashboard/scores/[id]/route.ts
+++ b/src/app/api/dashboard/scores/[id]/route.ts
@@ -19,9 +19,15 @@ export async function GET(
   for (const entry of scores as string[]) {
     try {
       const parsed = typeof entry === "string" ? JSON.parse(entry) : entry;
-      if (parsed.id === id) {
-        return NextResponse.json(parsed);
+      if (parsed.id !== id) continue;
+      // Soft-deleted scores are invisible to the owner. Team admins
+      // view another member's history via /api/dashboard/team/members/
+      // [userId], not this endpoint, so the auth user IS always the
+      // score owner here — 404 is correct.
+      if (parsed.deletedAt) {
+        return NextResponse.json({ error: "Score not found" }, { status: 404 });
       }
+      return NextResponse.json(parsed);
     } catch {
       continue;
     }

--- a/src/app/api/dashboard/scores/route.ts
+++ b/src/app/api/dashboard/scores/route.ts
@@ -2,9 +2,29 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { redis } from "@/lib/redis";
 
+/**
+ * Soft-delete a score the signed-in user owns.
+ *
+ * Why soft instead of hard delete: team leads need an audit trail —
+ * "this member's screen was scored at 2.4, then deleted three days
+ * later" is information a manager should be able to see. Hard delete
+ * threw away that signal.
+ *
+ * Mechanism:
+ *   - Find the entry by id in the user's sorted set.
+ *   - zrem the original member string, then zadd a copy that adds
+ *     deletedAt = Date.now() while preserving the original timestamp
+ *     score (so the entry's chronological position stays put).
+ *   - Already-deleted entries return 400. Missing entries return 404.
+ *
+ * Visibility rules (enforced elsewhere — this endpoint just marks):
+ *   - Member views (/api/dashboard, score detail) filter deletedAt out.
+ *   - Team-admin views (/api/dashboard/team, member detail) pass it
+ *     through so the manager can see the entry tagged as deleted.
+ *   - Aggregations (avg, weakest rung, etc.) exclude deleted.
+ */
 export async function DELETE(req: NextRequest) {
   const { userId } = await auth();
-
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
@@ -14,20 +34,37 @@ export async function DELETE(req: NextRequest) {
     return NextResponse.json({ error: "scoreId required" }, { status: 400 });
   }
 
-  // Find and remove the score entry from the sorted set
-  const scores = await redis.zrange(`user:${userId}:scores`, 0, -1);
+  const key = `user:${userId}:scores`;
+  const entries = (await redis.zrange(key, 0, -1)) as Array<string | object>;
 
-  for (const entry of scores) {
+  for (const entry of entries) {
     const str = typeof entry === "string" ? entry : JSON.stringify(entry);
+    let parsed: Record<string, unknown>;
     try {
-      const parsed = JSON.parse(str);
-      if (parsed.id === scoreId) {
-        await redis.zrem(`user:${userId}:scores`, str);
-        return NextResponse.json({ success: true });
-      }
+      parsed = JSON.parse(str);
     } catch {
       continue;
     }
+    if (parsed.id !== scoreId) continue;
+
+    if (parsed.deletedAt) {
+      return NextResponse.json(
+        { error: "Score already deleted" },
+        { status: 400 },
+      );
+    }
+
+    const updated = { ...parsed, deletedAt: Date.now(), deletedBy: userId };
+    const updatedStr = JSON.stringify(updated);
+    const timestamp = Number(parsed.timestamp) || Date.now();
+
+    await redis.zrem(key, str);
+    await redis.zadd(key, {
+      score: timestamp,
+      member: updatedStr,
+    });
+
+    return NextResponse.json({ success: true, deletedAt: updated.deletedAt });
   }
 
   return NextResponse.json({ error: "Score not found" }, { status: 404 });

--- a/src/app/api/dashboard/team/members/[userId]/route.ts
+++ b/src/app/api/dashboard/team/members/[userId]/route.ts
@@ -34,6 +34,14 @@ type RawScore = {
   uplift?: number | null;
   previousScore?: number | null;
   sessionType?: "design" | "evaluation";
+  /**
+   * Soft-delete metadata. Set by /api/dashboard/scores DELETE when the
+   * score's owner deletes it. Team admins receive deleted entries so
+   * they keep the audit trail; aggregations (stats, activity heatmap)
+   * exclude them so manager numbers reflect what's actually live.
+   */
+  deletedAt?: number;
+  deletedBy?: string;
 };
 
 /** Grandfather pre-bucket scores as design (per Ward's call). */
@@ -179,14 +187,24 @@ export async function GET(
     (s) => effectiveSessionType(s) === "evaluation",
   );
 
-  const designInWindow = designScores.filter(
+  // Aggregations (stats, heatmap) exclude soft-deleted scores so manager
+  // numbers reflect what's actually live. Deleted entries still flow
+  // through in `scores` below so the UI can render them with a tag.
+  const designLive = designScores.filter((s) => !s.deletedAt);
+  const evaluationLive = evaluationScores.filter((s) => !s.deletedAt);
+
+  const designInWindow = designLive.filter(
     (s) =>
       typeof s.timestamp === "number" && s.timestamp >= activityWindowStart,
   );
-  const evaluationInWindow = evaluationScores.filter(
+  const evaluationInWindow = evaluationLive.filter(
     (s) =>
       typeof s.timestamp === "number" && s.timestamp >= activityWindowStart,
   );
+
+  // Count of deleted entries surfaced so the UI can show "X deleted"
+  // chip without re-scanning the scores array.
+  const deletedCount = scores.filter((s) => !!s.deletedAt).length;
 
   return NextResponse.json({
     member: {
@@ -202,22 +220,26 @@ export async function GET(
     stats,
     /**
      * Design-session scores. Drives the manager's "performance" section
-     * (craft trends, design rhythm, personal records).
+     * (craft trends, design rhythm, personal records). `scores` includes
+     * soft-deleted entries with deletedAt set; `stats` and `activity`
+     * are computed on the live subset only.
      */
     design: {
-      stats: statsFromScores(designScores),
+      stats: statsFromScores(designLive),
       scores: designScores,
       activity: bucketActivity(designInWindow, ACTIVITY_WINDOW_DAYS),
     },
     /**
-     * Evaluation/audit scores. Drives the manager's "audit" section
-     * (research, competitor work, deliverables).
+     * Evaluation/audit scores. Same shape: deleted entries visible in
+     * `scores` for audit; stats / activity exclude them.
      */
     evaluation: {
-      stats: statsFromScores(evaluationScores),
+      stats: statsFromScores(evaluationLive),
       scores: evaluationScores,
       activity: bucketActivity(evaluationInWindow, ACTIVITY_WINDOW_DAYS),
     },
     activityWindowDays: ACTIVITY_WINDOW_DAYS,
+    /** Count of soft-deleted scores across all session types. */
+    deletedCount,
   });
 }

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -30,6 +30,13 @@ type RawScore = {
   timestamp?: number;
   rungs?: unknown;
   sessionType?: "design" | "evaluation";
+  /**
+   * Soft-delete tombstone. Set by /api/dashboard/scores DELETE. Read
+   * by team aggregations to exclude from manager stats (so a deleted
+   * 1.4 doesn't drag the team average) while still surfacing the
+   * entry in the audit feed via the member-detail endpoint.
+   */
+  deletedAt?: number;
 };
 
 /**
@@ -81,7 +88,12 @@ async function readRecentScores(
       }
       return entry;
     })
-    .filter((s): s is RawScore => s !== null);
+    .filter((s): s is RawScore => s !== null)
+    // Team-level aggregations (avg, weakest rung, design rhythm,
+    // heatmap) read this. Excluding soft-deleted entries here keeps
+    // the numbers honest. The full audit trail (including deleted)
+    // is exposed via the member-detail endpoint, not the team rollup.
+    .filter((s) => !s.deletedAt);
 }
 
 /**

--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -23,6 +23,11 @@ type ScoreEntry = {
   timestamp: number;
   uplift?: number | null;
   sessionType?: "design" | "evaluation";
+  /**
+   * Set when the member soft-deleted this score. Managers see deleted
+   * entries in the audit feed with a tag; stats / heatmap exclude them.
+   */
+  deletedAt?: number;
 };
 
 type Member = {
@@ -140,11 +145,24 @@ function TabButton({
 }
 
 function ScoreRow({ entry }: { entry: ScoreEntry }) {
+  const isDeleted = typeof entry.deletedAt === "number";
   return (
-    <div className="border border-[#2a2a2a] bg-[#1a1a1a] hover:bg-[#1f1f1f] hover:border-[#3a3a3a] transition-colors">
+    <div
+      className={`border transition-colors ${
+        isDeleted
+          ? // Faded + dashed border for audit-only entries the member
+            // has removed from their own view.
+            "border-dashed border-[#3a2a2a] bg-[#1a1414] opacity-70 hover:opacity-100 hover:bg-[#1f1818]"
+          : "border-[#2a2a2a] bg-[#1a1a1a] hover:bg-[#1f1f1f] hover:border-[#3a3a3a]"
+      }`}
+    >
       <div className="px-4 py-3 flex items-center gap-4">
         {entry.thumbnail ? (
-          <div className="flex-shrink-0 w-12 h-12 border border-[#2a2a2a] bg-[#111] overflow-hidden">
+          <div
+            className={`flex-shrink-0 w-12 h-12 border border-[#2a2a2a] bg-[#111] overflow-hidden ${
+              isDeleted ? "grayscale" : ""
+            }`}
+          >
             {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={entry.thumbnail}
@@ -158,7 +176,9 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
 
         <div className="flex-shrink-0 w-12 text-center">
           <span
-            className="text-xl font-bold tabular-nums"
+            className={`text-xl font-bold tabular-nums ${
+              isDeleted ? "line-through decoration-from-font" : ""
+            }`}
             style={{ color: getScoreColor(entry.score) }}
           >
             {entry.score.toFixed(1)}
@@ -167,9 +187,28 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
 
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <p className="text-sm text-foreground font-sans truncate">
+            <p
+              className={`text-sm font-sans truncate ${
+                isDeleted
+                  ? "text-muted line-through decoration-from-font"
+                  : "text-foreground"
+              }`}
+            >
               {entry.screenName || entry.source}
             </p>
+            {isDeleted && (
+              <span
+                className="text-[8px] uppercase tracking-widest border px-1.5 py-0.5 flex-shrink-0"
+                style={{
+                  color: "#ef4444",
+                  borderColor: "rgba(239,68,68,0.4)",
+                  backgroundColor: "rgba(239,68,68,0.06)",
+                }}
+                title={`Deleted by member on ${fmtDate(entry.deletedAt)}. Visible to admins only.`}
+              >
+                Deleted
+              </span>
+            )}
             {entry.isPublic === false && (
               <span className="text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5 flex-shrink-0">
                 Private
@@ -182,6 +221,14 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
             </span>
             <span className="text-[#444] mx-1.5">·</span>
             {timeAgo(entry.timestamp)}
+            {isDeleted && entry.deletedAt && (
+              <>
+                <span className="text-[#444] mx-1.5">·</span>
+                <span className="text-ladder-red/80">
+                  deleted {timeAgo(entry.deletedAt)}
+                </span>
+              </>
+            )}
             {entry.source && (
               <>
                 <span className="text-[#444] mx-1.5">·</span>
@@ -415,13 +462,30 @@ export default function TeamMemberDetailPage() {
           />
         </div>
 
-        <div className="mb-3 flex items-baseline justify-between">
+        <div className="mb-3 flex items-baseline justify-between gap-3 flex-wrap">
           <span className="text-[10px] text-muted uppercase tracking-widest">
             Score history
           </span>
           <span className="text-[10px] text-muted">
-            {bucket.scores.length} score
-            {bucket.scores.length !== 1 ? "s" : ""}
+            {(() => {
+              const total = bucket.scores.length;
+              const deleted = bucket.scores.filter((s) => !!s.deletedAt).length;
+              if (deleted === 0) {
+                return (
+                  <>
+                    {total} score{total !== 1 ? "s" : ""}
+                  </>
+                );
+              }
+              return (
+                <>
+                  {total} score{total !== 1 ? "s" : ""} ·{" "}
+                  <span className="text-ladder-red/80">
+                    {deleted} deleted
+                  </span>
+                </>
+              );
+            })()}
           </span>
         </div>
 


### PR DESCRIPTION
A team member should be able to clean up their own dashboard without erasing the manager's audit trail. Today's hard delete made deleted scores invisible to everyone — including admins who need to see "this member scored 2.4 then deleted it three days later".

## Behavior

**Member's own view** — deleted scores are invisible. Same as before from their POV. \`/api/dashboard\` filters them out; the score-detail GET 404s for the owner.

**Team admin view** (\`/dashboard/team/members/[userId]\`) — deleted scores are visible in the audit list with:
- Red "Deleted" chip
- Dashed maroon border, 70% opacity, grayscale thumbnail
- Strike-through screen name + score
- "deleted N days ago" line
- Hover restores full opacity
- Section header chip "N scores · M deleted"

**Aggregations** — every stat (avg score, weakest rung, design rhythm, activity heatmap) excludes deleted entries on BOTH sides. Manager numbers stay honest; member numbers don't include scores they removed.

## Mechanism

\`/api/dashboard/scores\` DELETE marks \`deletedAt = Date.now()\` and \`deletedBy = userId\` on the entry — zrem the original string, zadd back with the same timestamp score so chronological position is preserved.

## Files

- \`src/app/api/dashboard/scores/route.ts\` — DELETE marks instead of removes
- \`src/app/api/dashboard/route.ts\` — filter deletedAt
- \`src/app/api/dashboard/scores/[id]/route.ts\` — 404 deleted to owner
- \`src/app/api/dashboard/team/members/[userId]/route.ts\` — include deleted in \`scores\`, exclude from stats/activity; add \`deletedCount\`
- \`src/app/api/dashboard/team/route.ts\` — exclude deleted from team-level aggregations
- \`src/app/dashboard/team/members/[userId]/page.tsx\` — render deleted UI

## Test plan

- [ ] As a team member, delete a score. It disappears from /dashboard. /dashboard/scores/[id] for that score returns 404.
- [ ] As the team admin, view /dashboard/team/members/[that-member]. The deleted score appears with the red "Deleted" chip, faded styling, "deleted N ago" note.
- [ ] Stats on both sides don't include the deleted entry. Team aggregations exclude it.
- [ ] All 94 vitest tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)