### PR TITLE
Plugin: dashboard + in-plugin update notification

### DIFF
--- a/src/app/api/plugin/meta/route.ts
+++ b/src/app/api/plugin/meta/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { getPluginMeta } from "@/lib/plugin-meta";
+import { CURRENT_PLUGIN_VERSION } from "@/lib/plugin-version";
+
+/**
+ * GET /api/plugin/meta — Figma plugin install state for the dashboard.
+ *
+ * Returns whether the signed-in user has ever used the plugin, what
+ * version they have installed (from the last verify-token call), and
+ * the current published version. Used by FigmaPluginCard to show a
+ * "Connected" pill and an "Update available" banner when their
+ * installed version drifts behind.
+ *
+ * No mutation here — version stamping happens in /api/plugin/verify-token
+ * when the plugin's backend calls it on behalf of the user.
+ */
+export async function GET() {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  const meta = await getPluginMeta(userId);
+  return NextResponse.json({
+    hasUsed: !!meta?.lastUsedAt,
+    lastUsedAt: meta?.lastUsedAt,
+    installedVersion: meta?.installedVersion,
+    currentVersion: CURRENT_PLUGIN_VERSION,
+  });
+}

--- a/src/app/api/plugin/verify-token/route.ts
+++ b/src/app/api/plugin/verify-token/route.ts
@@ -5,6 +5,8 @@ import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription } from "@/lib/tier";
 import { redis, lifetimeScansKey } from "@/lib/redis";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
+import { CURRENT_PLUGIN_VERSION } from "@/lib/plugin-version";
+import { touchPluginMeta } from "@/lib/plugin-meta";
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
 
@@ -65,6 +67,18 @@ export async function POST(req: NextRequest) {
     const user = await clerk.users.getUser(userId);
     const paid = isPaidTier(sub.tier);
 
+    // Record the plugin version the user is running. The plugin's
+    // ai-design-assistant backend forwards X-Ladder-Plugin-Version from
+    // the plugin's fetch to here. Fire-and-forget so a failed write
+    // never blocks the verify response.
+    const installedPluginVersion =
+      req.headers.get("x-ladder-plugin-version")?.slice(0, 32) || undefined;
+    if (installedPluginVersion) {
+      touchPluginMeta(userId, installedPluginVersion).catch(() => {
+        // best-effort
+      });
+    }
+
     // Diagnostic: log every successful verify so we can correlate with persist
     try {
       await redis.lpush(
@@ -100,6 +114,17 @@ export async function POST(req: NextRequest) {
               expiresAt: sub.comp.expiresAt ?? null,
             }
           : null,
+        /**
+         * Plugin version state. The plugin compares its own embedded
+         * LADDER_PLUGIN_VERSION against `currentPluginVersion` to
+         * decide whether to render an in-canvas "Update available"
+         * banner. Returning it on every verify means the plugin gets
+         * fresh data on its first call per session — no extra request.
+         */
+        pluginVersion: {
+          current: CURRENT_PLUGIN_VERSION,
+          installed: installedPluginVersion ?? null,
+        },
       },
       { headers: API_VERSION_HEADERS },
     );

--- a/src/components/FigmaPluginCard.tsx
+++ b/src/components/FigmaPluginCard.tsx
@@ -1,28 +1,140 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 const FIGMA_PLUGIN_URL = "https://www.figma.com/community/plugin/1615455485903292828";
 
+type PluginMeta = {
+  hasUsed?: boolean;
+  lastUsedAt?: number;
+  installedVersion?: string;
+  currentVersion?: string;
+};
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(ts).toLocaleDateString();
+}
+
 /**
- * Compact dashboard install card for the Ladder for Figma plugin. Default
- * state is a one-line pitch with a primary CTA. The full install steps
- * live behind a "How to install" toggle so the dashboard right-rail
- * doesn't carry verbose copy by default.
+ * Dashboard card for the Ladder for Figma plugin.
+ *
+ * Three states, picked by what /api/plugin/meta returns:
+ *   - Never used: install pitch + Figma Community CTA, with a
+ *     collapsible "How to install" panel.
+ *   - Connected: "Connected" pill, last-used timestamp, version chip.
+ *   - Connected + outdated: same as Connected, plus an "Update
+ *     available: vX → vY" banner that links to the Figma plugin page.
+ *     Figma auto-updates plugins, so the action is really just "open
+ *     the page or restart Figma to pick it up."
  */
 export function FigmaPluginCard() {
+  const [meta, setMeta] = useState<PluginMeta | null>(null);
+  const [loading, setLoading] = useState(true);
   const [open, setOpen] = useState(false);
 
-  return (
-    <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
-      <div className="flex items-baseline justify-between gap-3 mb-1">
+  useEffect(() => {
+    fetch("/api/plugin/meta")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setMeta(data))
+      .catch(() => setMeta(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5 shimmer h-28" />;
+  }
+
+  const version = meta?.currentVersion;
+  const updateAvailable =
+    !!meta?.installedVersion &&
+    !!meta?.currentVersion &&
+    meta.installedVersion !== meta.currentVersion;
+
+  const showNewPill = !meta?.hasUsed;
+  const showConnectedPill = !!meta?.hasUsed;
+
+  const header = (
+    <div className="flex items-baseline justify-between gap-3 mb-1">
+      <div className="flex items-baseline gap-2 min-w-0">
         <h3 className="text-sm text-foreground font-sans font-semibold">
           Ladder for Figma
         </h3>
+        {version && (
+          <span className="text-[10px] font-mono text-muted">v{version}</span>
+        )}
+      </div>
+      {showNewPill && (
         <span className="text-[9px] text-ladder-green uppercase tracking-widest font-semibold">
           New
         </span>
+      )}
+      {showConnectedPill && (
+        <span className="text-[9px] text-ladder-green uppercase tracking-widest font-semibold">
+          Connected
+        </span>
+      )}
+    </div>
+  );
+
+  // ── State: connected ────────────────────────────────────────────────
+  if (meta?.hasUsed) {
+    return (
+      <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+        {header}
+        <p className="text-xs text-muted font-sans leading-relaxed mb-3">
+          Score frames inside Figma without leaving the canvas.
+        </p>
+        {meta.lastUsedAt && (
+          <p className="text-[11px] text-muted font-sans">
+            Last used {relativeTime(meta.lastUsedAt)}.
+          </p>
+        )}
+
+        {updateAvailable && (
+          <div className="mt-4 border border-ladder-green/30 bg-ladder-green/5 px-3 py-2.5 flex items-center justify-between gap-3 flex-wrap">
+            <span className="text-[11px] text-muted font-sans">
+              Update available:{" "}
+              <span className="font-mono text-foreground">v{meta.installedVersion}</span>
+              {" → "}
+              <span className="font-mono text-foreground">v{meta.currentVersion}</span>
+            </span>
+            <a
+              href={FIGMA_PLUGIN_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-[10px] uppercase tracking-widest text-ladder-green border border-ladder-green/40 px-3 py-1.5 hover:bg-ladder-green/10 transition-colors font-semibold"
+            >
+              Update
+            </a>
+          </div>
+        )}
+
+        {!updateAvailable && (
+          <a
+            href={FIGMA_PLUGIN_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-block text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+          >
+            Open in Figma Community →
+          </a>
+        )}
       </div>
+    );
+  }
+
+  // ── State: not used yet (install pitch) ─────────────────────────────
+  return (
+    <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+      {header}
       <p className="text-xs text-muted font-sans leading-relaxed mb-4">
         Score frames inside Figma without leaving the canvas.
       </p>

--- a/src/lib/plugin-meta.ts
+++ b/src/lib/plugin-meta.ts
@@ -1,0 +1,47 @@
+/**
+ * Figma plugin install metadata.
+ *
+ * The plugin authenticates with the user's Ladder personal token (the
+ * same one the Skill uses), so we don't store a separate token here.
+ * What we DO track per user is which plugin version they have running
+ * — used to:
+ *   - Show "Update available" banners on the dashboard
+ *   - Tell the plugin itself, on each verify-token call, what version
+ *     the user has so it can render an in-plugin banner
+ *
+ * Redis key:
+ *   user:{userId}:plugin  -> { installedVersion, lastUsedAt }
+ *
+ * Mirrors src/lib/skill-auth.ts conceptually but without any
+ * token/hash storage (the plugin reuses the skill token).
+ */
+import { redis } from "@/lib/redis";
+
+export type PluginMeta = {
+  installedVersion?: string;
+  lastUsedAt?: number;
+};
+
+const key = (userId: string) => `user:${userId}:plugin`;
+
+export async function getPluginMeta(userId: string): Promise<PluginMeta | null> {
+  return (await redis.get<PluginMeta>(key(userId))) ?? null;
+}
+
+/**
+ * Record the plugin version the user is running, plus a last-seen
+ * timestamp. Called on every verify-token request that carries an
+ * X-Ladder-Plugin-Version header. Fire-and-forget at call sites — a
+ * failed write should never block a verify response.
+ */
+export async function touchPluginMeta(
+  userId: string,
+  installedVersion?: string,
+): Promise<void> {
+  const existing = (await redis.get<PluginMeta>(key(userId))) ?? {};
+  await redis.set(key(userId), {
+    ...existing,
+    lastUsedAt: Date.now(),
+    ...(installedVersion ? { installedVersion } : {}),
+  });
+}

--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -13,4 +13,4 @@
  * time as LADDER_PLUGIN_VERSION in ai-design-assistant's plugin/ui.html
  * (they must match) and add a release note somewhere user-visible.
  */
-export const CURRENT_PLUGIN_VERSION = "1.10.4";
+export const CURRENT_PLUGIN_VERSION = "1.11.3";

--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -1,0 +1,16 @@
+/**
+ * Figma plugin bundle version — source of truth.
+ *
+ * Bump when publishing a new build of the Figma plugin to the
+ * marketplace. The plugin sends X-Ladder-Plugin-Version on its calls;
+ * runladder compares against this constant and surfaces an
+ * "Update available" banner on the dashboard + inside the plugin UI.
+ *
+ * Co-located with skill-version.ts and app-version.ts so all Ladder
+ * surface versions live next to each other.
+ *
+ * Bump cadence: every Figma-marketplace submission. Update at the same
+ * time as LADDER_PLUGIN_VERSION in ai-design-assistant's plugin/ui.html
+ * (they must match) and add a release note somewhere user-visible.
+ */
+export const CURRENT_PLUGIN_VERSION = "1.10.4";


### PR DESCRIPTION
## Summary
- Mirrors the Skill's update-banner pattern for the Figma plugin.
- New `/api/plugin/meta` feeds the dashboard `FigmaPluginCard`, which now shows Connected state, installed version, and an "Update available: vX → vY" banner when behind.
- Plugin's `verify-token` now reads `X-Ladder-Plugin-Version` and stamps `user:{id}:plugin` in Redis with the installed version + `lastUsedAt`. Returns `CURRENT_PLUGIN_VERSION` in the response so the plugin can self-check.
- Single source of truth: `src/lib/plugin-version.ts` → `CURRENT_PLUGIN_VERSION = "1.10.4"`.

## Why
When we ship a new plugin build, users may sit on the old one until Figma auto-updates. The dashboard card (web) and an in-plugin banner (canvas) both surface the gap so the user knows to restart Figma.

## Data flow
1. Plugin sends `X-Ladder-Plugin-Version` on every auth call.
2. ai-design-assistant's `_auth.js` forwards it to runladder `/api/plugin/verify-token`.
3. Runladder records installed version + returns current version.
4. ai-design-assistant's `/api/auth/me` echoes `pluginVersion` back to the plugin.
5. Plugin compares local `PLUGIN_VERSION_HEADER` to `pluginVersion.current` and renders the in-canvas banner.
6. Dashboard `FigmaPluginCard` reads `/api/plugin/meta` and renders its own banner.

Pairs with PR in ai-design-assistant repo (next).

## Test plan
- [x] `npm run build` clean
- [x] `npm test` (94 tests) passes
- [ ] Manual after deploy: visit /dashboard, FigmaPluginCard renders. After plugin restart, "Connected" pill appears.
- [ ] Bump `CURRENT_PLUGIN_VERSION` to "1.10.5", confirm banner appears for a user still on 1.10.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)