### PR TITLE
Sonnet 4.6 + adaptive thinking on scoring paths

### DIFF
--- a/src/lib/annotation-analysis.ts
+++ b/src/lib/annotation-analysis.ts
@@ -117,9 +117,16 @@ export async function analyzeScreenForReport(
   }
 
   try {
+    // Sonnet 4.6 with adaptive thinking + effort:high. Annotation
+    // analysis pins findings to specific regions of the screen, which
+    // needs careful visual reasoning — exactly the kind of work
+    // adaptive thinking is designed for. max_tokens bumped to give
+    // the thinking budget room ahead of the JSON output.
     const response = await client.messages.create({
-      model: "claude-sonnet-4-20250514",
-      max_tokens: 3000,
+      model: "claude-sonnet-4-6",
+      max_tokens: 8192,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "high" },
       system: buildAnalysisPrompt(mode, learningCtx),
       messages: [
         {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -185,9 +185,13 @@ export async function scoreImage(
 
   const client = new Anthropic();
 
-  /* ── Content moderation check ── */
+  /* ── Content moderation check ──
+   * Cheap classification call. No adaptive thinking, no effort tuning —
+   * a binary "is this a UI screen + is it explicit" decision doesn't
+   * benefit from extra reasoning depth, and we want the fast path.
+   */
   const modCheck = await client.messages.create({
-    model: "claude-haiku-4-5-20251001",
+    model: "claude-haiku-4-5",
     max_tokens: 200,
     messages: [
       {
@@ -230,10 +234,20 @@ export async function scoreImage(
     }
   }
 
-  /* ── Ladder scoring ── */
+  /* ── Ladder scoring ──
+   * Sonnet 4.6 with adaptive thinking + effort:high. This is the
+   * intelligence-sensitive path of the whole product — accurate
+   * visual reasoning, calibrated scores, and well-grounded findings
+   * are worth the extra thinking tokens (per-score cost rises from
+   * roughly $0.046 to $0.075, still comfortably inside the 30%
+   * COGS ceiling). max_tokens bumped to 8192 so the thinking
+   * budget has room before the JSON output starts.
+   */
   const response = await client.messages.create({
-    model: "claude-sonnet-4-20250514",
-    max_tokens: 2048,
+    model: "claude-sonnet-4-6",
+    max_tokens: 8192,
+    thinking: { type: "adaptive" },
+    output_config: { effort: "high" },
     messages: [
       {
         role: "user",


### PR DESCRIPTION
## Summary
- Migrates the two intelligence-sensitive libs (`src/lib/scoring.ts`, `src/lib/annotation-analysis.ts`) from Sonnet 4 to Sonnet 4.6 with adaptive thinking + `effort: "high"`.
- Same per-token pricing as before. Per-score cost rises modestly (~$0.046 → ~$0.075) from the extra thinking tokens, well inside the 30% COGS ceiling at Pro $250.
- Moderation call stays on Haiku 4.5 (binary classification, no thinking needed).

## Why Sonnet 4.6, not Opus 4.7
Opus 4.7 is 5x the per-token cost. At our pricing ceiling it would drop Pro per-user volume meaningfully without a justifying quality gain on these tasks.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 94/94 tests pass
- [ ] Manual: score a few screens after deploy and confirm score quality holds or improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)