### PR TITLE
Hotfix: drop adaptive thinking from scoring paths

### DIFF
--- a/src/lib/annotation-analysis.ts
+++ b/src/lib/annotation-analysis.ts
@@ -117,16 +117,16 @@ export async function analyzeScreenForReport(
   }
 
   try {
-    // Sonnet 4.6 with adaptive thinking + effort:high. Annotation
-    // analysis pins findings to specific regions of the screen, which
-    // needs careful visual reasoning — exactly the kind of work
-    // adaptive thinking is designed for. max_tokens bumped to give
-    // the thinking budget room ahead of the JSON output.
+    // Sonnet 4.6 with effort:medium. Adaptive thinking is OFF here
+    // because Vercel function timeouts (60s) can't reliably contain
+    // the latency thinking adds. Sonnet 4.6 by itself is the quality
+    // upgrade. Reserve thinking for /api/improve where users expect
+    // a longer wait. effort:medium is set explicitly because 4.6
+    // defaults to high.
     const response = await client.messages.create({
       model: "claude-sonnet-4-6",
-      max_tokens: 8192,
-      thinking: { type: "adaptive" },
-      output_config: { effort: "high" },
+      max_tokens: 4096,
+      output_config: { effort: "medium" },
       system: buildAnalysisPrompt(mode, learningCtx),
       messages: [
         {

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -235,19 +235,20 @@ export async function scoreImage(
   }
 
   /* ── Ladder scoring ──
-   * Sonnet 4.6 with adaptive thinking + effort:high. This is the
-   * intelligence-sensitive path of the whole product — accurate
-   * visual reasoning, calibrated scores, and well-grounded findings
-   * are worth the extra thinking tokens (per-score cost rises from
-   * roughly $0.046 to $0.075, still comfortably inside the 30%
-   * COGS ceiling). max_tokens bumped to 8192 so the thinking
-   * budget has room before the JSON output starts.
+   * Sonnet 4.6 with effort:medium. Adaptive thinking is OFF here
+   * because Vercel function timeouts (60s) can't safely accommodate
+   * the variable latency thinking introduces — we saw real 504s on
+   * the plugin's analyze path with thinking on. Sonnet 4.6 alone
+   * is already a real quality jump from Sonnet 4 on visual reasoning
+   * and structured output. Thinking is reserved for /api/improve
+   * where users expect a longer wait. effort:medium is set
+   * explicitly because Sonnet 4.6 defaults to effort:high, which
+   * costs more for marginal gain on this task.
    */
   const response = await client.messages.create({
     model: "claude-sonnet-4-6",
-    max_tokens: 8192,
-    thinking: { type: "adaptive" },
-    output_config: { effort: "high" },
+    max_tokens: 4096,
+    output_config: { effort: "medium" },
     messages: [
       {
         role: "user",


### PR DESCRIPTION
## Bug
Plugin `/api/analyze` started returning 504s (Vercel Runtime Timeout) right after the Sonnet 4.6 migration. Adaptive thinking + `effort: "high"` lets the model spend variable time reasoning before output, frequently exceeding the 60s function timeout.

## Fix
- Drop `thinking: {type: "adaptive"}` from `scoring.ts` and `annotation-analysis.ts`.
- Drop `effort` to `"medium"` (Sonnet 4.6 defaults to `"high"` which is also slow).
- Drop `max_tokens` back to pre-migration values (no thinking headroom needed).

## What stays
- Sonnet 4.6 — the model upgrade itself is the quality lift.
- Explicit `effort` per call site.

## What's reserved
Adaptive thinking is held back for the upcoming `/api/improve` endpoint, where slow is expected and we can configure a higher maxDuration.

## Test plan
- [x] `npm run build` clean, 94/94 vitest pass
- [ ] After deploy: score a screen, confirm response in <30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)