### PR TITLE
Scoring: switch to Haiku 4.5 for speed

### DIFF
--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -235,20 +235,19 @@ export async function scoreImage(
   }
 
   /* ── Ladder scoring ──
-   * Sonnet 4.6 with thinking disabled + effort:low. Tuned for
-   * speed: per the model migration guide, this configuration
-   * performs similar to or better than Sonnet 4.5 no-thinking,
-   * which is the fast non-thinking baseline. Sonnet 4.6 defaults
-   * to effort:high, so setting low explicitly is necessary —
-   * not optional — to actually get the latency win. Thinking
-   * is reserved for the /api/improve endpoint where users
-   * expect a longer wait.
+   * Haiku 4.5. We switched here from Sonnet 4.6 for speed —
+   * the Skill/web scoring user wants a result in seconds, not
+   * tens of seconds. Haiku 4.5 runs ~3x the generation rate of
+   * Sonnet 4.6 (200+ tokens/sec), with TTFT under a second.
+   * Note: Haiku does not support the `effort` or `thinking`
+   * params and will 400 if either is passed — keep this call
+   * lean. Sonnet 4.6 stays as the model of record on the
+   * coming /api/improve endpoint where deeper reasoning is
+   * worth the wait.
    */
   const response = await client.messages.create({
-    model: "claude-sonnet-4-6",
+    model: "claude-haiku-4-5",
     max_tokens: 4096,
-    thinking: { type: "disabled" },
-    output_config: { effort: "low" },
     messages: [
       {
         role: "user",


### PR DESCRIPTION
Sonnet 4.6 + effort:low still landed in the 15+ second range. Haiku 4.5 generates ~3x faster with sub-second TTFT, at 1/3 the cost. Sonnet 4.6 reserved for /api/improve where deeper reasoning is worth the wait. Annotation analysis stays on Sonnet (coordinate precision).