### PR TITLE
Score: SSE streaming + early field reveal (v0.4.0)

### DIFF
--- a/src/app/api/score/stream/route.ts
+++ b/src/app/api/score/stream/route.ts
@@ -1,0 +1,197 @@
+import { NextRequest } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { redis, lifetimeScansKey } from "@/lib/redis";
+import {
+  parseImageDataUrl,
+  scoreImageStream,
+} from "@/lib/scoring";
+import { makeThumbnail } from "@/lib/thumbnail";
+import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
+import { getUserTier } from "@/lib/tier";
+import { persistScoreEntry } from "@/lib/scores";
+
+export const maxDuration = 60;
+
+/**
+ * Streaming variant of POST /api/score.
+ *
+ * Emits Server-Sent Events as the model generates the response so the
+ * client can show the score number a couple seconds after submit
+ * instead of waiting 12-18s for the full payload. Event shapes mirror
+ * the ScoringStreamEvent union in src/lib/scoring.ts:
+ *
+ *   event: score        — {"value": 3.2}
+ *   event: label        — {"value": "Comfortable"}
+ *   event: screenName   — {"value": "Newsletter Signup"}
+ *   event: complete     — {"value": <full ScoreResult>, "scoreId": "..."}
+ *   event: error        — {"message": "..."}
+ *
+ * The non-streaming POST /api/score handler stays as the canonical
+ * endpoint and the source of the contract; this is purely a UX layer.
+ */
+export async function POST(req: NextRequest) {
+  /* ── Bot detection ── */
+  const ua = req.headers.get("user-agent") || "";
+  if (/curl|wget|python-requests|httpie|postman|scrapy|phantomjs/i.test(ua)) {
+    return errorResponse("Automated requests are not allowed.", 403);
+  }
+
+  /* ── Auth ── */
+  const { userId } = await auth();
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    req.headers.get("x-real-ip") ||
+    "unknown";
+
+  /* ── Rate limiting (matches /api/score) ── */
+  if (userId) {
+    const tier = await getUserTier(userId);
+    if (!isPaidTier(tier)) {
+      const usedKey = lifetimeScansKey(userId);
+      const used = (await redis.get<number>(usedKey)) ?? 0;
+      if (used >= FREE_LIFETIME_LIMIT) {
+        return errorResponse(
+          `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for unlimited scoring.`,
+          429,
+          { upgrade: true },
+        );
+      }
+    }
+  } else {
+    const anonKey = `rate:anon:${ip}`;
+    const count = (await redis.get<number>(anonKey)) ?? 0;
+    if (count >= ANON_LIMIT) {
+      return errorResponse(
+        `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
+        429,
+        { signup: true },
+      );
+    }
+  }
+
+  const body = await req.json();
+  const {
+    image,
+    source,
+    isPublic,
+    sessionType: rawSessionType,
+  } = body;
+  const sessionType: "design" | "evaluation" =
+    rawSessionType === "evaluation" ? "evaluation" : "design";
+
+  const parsed = parseImageDataUrl(image);
+  if (!parsed) {
+    return errorResponse("Invalid image format. Use a data URL (base64).", 400);
+  }
+
+  /* ── Stream! ── */
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (event: string, data: object) => {
+        controller.enqueue(
+          encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+        );
+      };
+
+      try {
+        for await (const ev of scoreImageStream(parsed)) {
+          if (ev.kind === "error") {
+            send("error", { message: ev.value, status: ev.status });
+            controller.close();
+            return;
+          }
+          if (ev.kind === "score") send("score", { value: ev.value });
+          if (ev.kind === "label") send("label", { value: ev.value });
+          if (ev.kind === "screenName") send("screenName", { value: ev.value });
+          if (ev.kind === "complete") {
+            const result = ev.value;
+            // Persist + count usage now that we have the full result.
+            let persistedScoreId: string | null = null;
+            try {
+              if (userId) {
+                const thumbnail = await makeThumbnail(
+                  Buffer.from(parsed.base64Data, "base64"),
+                  parsed.mediaType,
+                );
+                const scoreId = `${Date.now()}-${Math.random()
+                  .toString(36)
+                  .slice(2, 8)}`;
+                await persistScoreEntry(userId, {
+                  id: scoreId,
+                  score: result.score,
+                  label: result.label,
+                  screenName: result.screenName || source || "upload",
+                  summary: result.summary,
+                  next: result.next,
+                  findings: result.findings,
+                  rungs: result.rungs,
+                  source: source || "upload",
+                  thumbnail,
+                  isPublic: !!isPublic,
+                  timestamp: Date.now(),
+                  sessionType,
+                });
+                persistedScoreId = scoreId;
+              } else {
+                const anonKey = `rate:anon:${ip}`;
+                await redis.incr(anonKey);
+                const ttl = await redis.ttl(anonKey);
+                if (ttl < 0) await redis.expire(anonKey, 60 * 60 * 24);
+              }
+            } catch (e) {
+              console.error(
+                "[LADDER:ERROR] Stream persist failed:",
+                (e as Error).message,
+              );
+              // Don't abort the stream — surface the result anyway.
+            }
+
+            send("complete", {
+              value: {
+                ...result,
+                screenName: result.screenName || source || "Screen",
+                scoreId: persistedScoreId,
+              },
+            });
+            controller.close();
+            return;
+          }
+        }
+        // Generator exhausted without complete (shouldn't happen)
+        send("error", { message: "Scoring ended without result", status: 500 });
+        controller.close();
+      } catch (e) {
+        console.error(
+          "[LADDER:ERROR] Stream handler crashed:",
+          (e as Error).message,
+        );
+        send("error", {
+          message: "Scoring failed. Please try again.",
+          status: 500,
+        });
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+function errorResponse(
+  message: string,
+  status: number,
+  extra: Record<string, unknown> = {},
+) {
+  return new Response(JSON.stringify({ error: message, ...extra }), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -70,6 +70,30 @@ function ScannerCorners() {
   );
 }
 
+/**
+ * Parse one Server-Sent Events frame into a {name, data} record.
+ * Returns null when the frame is malformed or carries no `data:` line.
+ * The streaming /api/score/stream endpoint always sends both `event:`
+ * and `data:` lines, so a null here means a stray heartbeat or a
+ * partial frame caller should skip.
+ */
+function parseSSE(
+  raw: string,
+): { name: string; data: { value?: number | string | ScoreResult; message?: string } } | null {
+  let name = "message";
+  let dataLine = "";
+  for (const line of raw.split("\n")) {
+    if (line.startsWith("event:")) name = line.slice(6).trim();
+    else if (line.startsWith("data:")) dataLine = line.slice(5).trim();
+  }
+  if (!dataLine) return null;
+  try {
+    return { name, data: JSON.parse(dataLine) };
+  } catch {
+    return null;
+  }
+}
+
 function AnimatedScore({ target }: { target: number }) {
   const [value, setValue] = useState(0);
   const color = getScoreColor(target);
@@ -245,6 +269,15 @@ export default function ScorePage() {
   const [result, setResult] = useState<ScoreResult | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [scanPhase, setScanPhase] = useState(0);
+  // Partial scoring state that fills in via SSE before the full result
+  // lands. Drives the skeleton overlay to swap in real values early
+  // (score number, level, screen name) while findings and rungs are
+  // still being generated.
+  const [partial, setPartial] = useState<{
+    score?: number;
+    label?: string;
+    screenName?: string;
+  } | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [pastScores, setPastScores] = useState<PastScore[]>([]);
   const [isPublic, setIsPublic] = useState(true);
@@ -354,6 +387,7 @@ export default function ScorePage() {
     setLoading(true);
     setError(null);
     setResult(null);
+    setPartial(null);
     setScanPhase(0);
     if (img) setImage(img);
 
@@ -368,7 +402,7 @@ export default function ScorePage() {
         generateThumbnail(imageToScore),
       ]);
 
-      const res = await fetch("/api/score", {
+      const res = await fetch("/api/score/stream", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -379,25 +413,78 @@ export default function ScorePage() {
           sessionType: sessionType ?? "design",
         }),
       });
-      const text = await res.text();
-      let data;
-      try { data = JSON.parse(text); } catch { throw new Error("Scoring service returned an unexpected response. Please try again."); }
-      if (!res.ok) {
-        if (data.signup) {
-          throw new Error("Sign up for free to get 5 Ladder scores. Log in at runladder.com/login");
+
+      if (!res.ok || !res.body) {
+        // Non-streamed error response (auth, rate limit, validation).
+        const text = await res.text();
+        let data: { error?: string; signup?: boolean } = {};
+        try {
+          data = JSON.parse(text);
+        } catch {
+          throw new Error(
+            "Scoring service returned an unexpected response. Please try again.",
+          );
         }
-        // The server's error string is already tier-aware (free cap vs
-        // team pool exceeded) — prefer it over any local hardcoded copy.
+        if (data.signup) {
+          throw new Error(
+            "Sign up for free to get 5 Ladder scores. Log in at runladder.com/login",
+          );
+        }
         throw new Error(data.error || "Scoring failed");
+      }
+
+      // Consume the SSE stream. Each event populates state incrementally:
+      // score / label / screenName land seconds before complete, so the
+      // skeleton swaps in real values early.
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let pending = "";
+      let final: (ScoreResult & { scoreId?: string | null }) | null = null;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        pending += decoder.decode(value, { stream: true });
+
+        // SSE messages are separated by blank lines.
+        let split: number;
+        while ((split = pending.indexOf("\n\n")) !== -1) {
+          const raw = pending.slice(0, split);
+          pending = pending.slice(split + 2);
+          const event = parseSSE(raw);
+          if (!event) continue;
+
+          if (event.name === "score" && typeof event.data.value === "number") {
+            const v = event.data.value;
+            setPartial((p) => ({ ...(p ?? {}), score: v }));
+          } else if (event.name === "label" && typeof event.data.value === "string") {
+            const v = event.data.value;
+            setPartial((p) => ({ ...(p ?? {}), label: v }));
+          } else if (event.name === "screenName" && typeof event.data.value === "string") {
+            const v = event.data.value;
+            setPartial((p) => ({ ...(p ?? {}), screenName: v }));
+          } else if (event.name === "complete") {
+            // The server attaches scoreId onto the complete value.
+            final = event.data.value as ScoreResult & { scoreId?: string | null };
+          } else if (event.name === "error") {
+            throw new Error(
+              event.data.message || "Scoring failed. Please try again.",
+            );
+          }
+        }
+      }
+
+      if (!final) {
+        throw new Error("Scoring ended without a result. Please try again.");
       }
 
       // Save to local past scores (used by anon users for in-session history).
       const entry: PastScore = {
-        id: data.scoreId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-        score: data.score,
-        label: data.label,
-        summary: data.summary,
-        thumbnail: imageToScore.slice(0, 200), // Store tiny prefix for identification
+        id: final.scoreId || `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        score: final.score,
+        label: final.label,
+        summary: final.summary,
+        thumbnail: imageToScore.slice(0, 200),
         source: fileName || "Upload",
         timestamp: Date.now(),
       };
@@ -405,20 +492,20 @@ export default function ScorePage() {
       setPastScores(loadPastScores());
 
       // Signed-in users go to the full score detail in their dashboard.
-      // Anon users have nowhere to go — keep the inline result for them.
-      if (data.scoreId) {
-        setRedirectingScoreId(data.scoreId);
+      if (final.scoreId) {
+        setRedirectingScoreId(final.scoreId);
         setTimeout(() => {
-          router.push(`/dashboard/scores/${data.scoreId}`);
+          router.push(`/dashboard/scores/${final.scoreId}`);
         }, 1200);
       } else {
-        setResult(data);
+        setResult(final);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Something went wrong");
     } finally {
       clearInterval(interval);
       setLoading(false);
+      setPartial(null);
     }
   }
 
@@ -780,6 +867,7 @@ export default function ScorePage() {
             image={image}
             scanPhase={scanPhase}
             scanMessages={scanMessages}
+            partial={partial}
           />
         )}
 

--- a/src/components/score/ScoreLoadingSkeleton.tsx
+++ b/src/components/score/ScoreLoadingSkeleton.tsx
@@ -17,6 +17,8 @@
  * All visual rhythm comes from `.shimmer` and `.typing-dot` defined
  * in globals.css. No new keyframes needed.
  */
+import { getScoreColor } from "@/lib/ladder";
+
 // Local copy of the inline ScannerCorners helper from /score/page.tsx
 // (same scanner-corner classes defined in globals.css). Inlined here
 // so the skeleton component stays self-contained.
@@ -35,10 +37,28 @@ type Props = {
   image: string;
   scanPhase: number;
   scanMessages: string[];
+  /**
+   * Partial fields streamed from /api/score/stream. As each arrives the
+   * matching placeholder is replaced with the real value, while the
+   * rest of the panel keeps shimmering. `null` = streaming hasn't
+   * started yielding fields yet (still on moderation or first tokens).
+   */
+  partial?: {
+    score?: number;
+    label?: string;
+    screenName?: string;
+  } | null;
 };
 
-export function ScoreLoadingSkeleton({ image, scanPhase, scanMessages }: Props) {
+export function ScoreLoadingSkeleton({
+  image,
+  scanPhase,
+  scanMessages,
+  partial,
+}: Props) {
   const activeMessage = scanMessages[scanPhase] ?? scanMessages[0];
+  const haveScore = typeof partial?.score === "number";
+  const haveLabel = typeof partial?.label === "string" && partial.label.length > 0;
 
   return (
     <div className="space-y-10">
@@ -60,10 +80,26 @@ export function ScoreLoadingSkeleton({ image, scanPhase, scanMessages }: Props) 
             Screen Score
           </span>
           <div className="flex-1 flex flex-col items-start justify-center">
-            {/* Big score number placeholder */}
-            <div className="shimmer h-14 w-32" />
-            {/* Level label placeholder */}
-            <div className="shimmer h-3 w-24 mt-3" />
+            {/* Big score number — fades from skeleton to the real number
+                as soon as the SSE 'score' event arrives. */}
+            {haveScore ? (
+              <span
+                className="text-6xl font-bold tabular-nums animate-fade-up"
+                style={{ color: getScoreColor(partial!.score!) }}
+              >
+                {partial!.score!.toFixed(1)}
+              </span>
+            ) : (
+              <div className="shimmer h-14 w-32" />
+            )}
+            {/* Level label — fades in on the 'label' SSE event. */}
+            {haveLabel ? (
+              <span className="text-sm font-bold uppercase tracking-widest mt-1 text-foreground animate-fade-up">
+                {partial!.label}
+              </span>
+            ) : (
+              <div className="shimmer h-3 w-24 mt-3" />
+            )}
 
             {/* Gap to next */}
             <div className="mt-6 pt-4 border-t border-[#333] w-full">

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.3.0";
+export const CURRENT_APP_VERSION = "0.4.0";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -305,3 +305,208 @@ export function isScoringError(
 
 // Re-export designTypeClassifierPrompt for callers that want to classify before scoring
 export { designTypeClassifierPrompt };
+
+/**
+ * Streaming variant of scoreImage.
+ *
+ * Yields events as the scoring response is generated, so callers can
+ * surface partial state to the user (the score number lands seconds
+ * before the full payload). Order of events:
+ *
+ *   1. `score` — emitted as soon as the model writes the "score":N.N field
+ *   2. `label` — as soon as "label":"..." appears
+ *   3. `screenName` — as soon as "screenName":"..." appears
+ *   4. `complete` — once the full response is parsed (includes everything)
+ *   5. `error` — on any failure (terminates the generator)
+ *
+ * Moderation still runs first (non-streaming) — it's a fast Haiku call
+ * and rejecting non-UI / explicit images before we spend Sonnet tokens
+ * is the right cost/safety order.
+ */
+export type ScoringStreamEvent =
+  | { kind: "score"; value: number }
+  | { kind: "label"; value: string }
+  | { kind: "screenName"; value: string }
+  | { kind: "complete"; value: ScoreResult }
+  | { kind: "error"; value: string; status: number };
+
+export async function* scoreImageStream(
+  {
+    mediaType,
+    base64Data,
+  }: { mediaType: MediaType; base64Data: string },
+  opts: { applyAiLens?: boolean } = {},
+): AsyncGenerator<ScoringStreamEvent> {
+  if (base64Data.length > 7_000_000) {
+    yield {
+      kind: "error",
+      value: "Image too large. Please use an image under 5MB.",
+      status: 400,
+    };
+    return;
+  }
+
+  const client = new Anthropic();
+
+  /* ── Moderation (Haiku, non-streaming, fast) ── */
+  try {
+    const modCheck = await client.messages.create({
+      model: "claude-haiku-4-5",
+      max_tokens: 200,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: { type: "base64", media_type: mediaType, data: base64Data },
+            },
+            { type: "text", text: "Classify this image." },
+          ],
+        },
+      ],
+      system: MODERATION_PROMPT,
+    });
+    const modText = modCheck.content.find((b) => b.type === "text");
+    if (modText && modText.type === "text") {
+      try {
+        const modResult = JSON.parse(
+          modText.text.replace(/```json|```/g, "").trim(),
+        );
+        if (modResult.isExplicit) {
+          yield {
+            kind: "error",
+            value:
+              "This image contains content that violates our usage policy. Ladder scores UI/UX screens only.",
+            status: 400,
+          };
+          return;
+        }
+        if (!modResult.isUI) {
+          yield {
+            kind: "error",
+            value:
+              "This doesn't appear to be a UI screen. Please upload a screenshot of a website, app, or design mockup.",
+            status: 400,
+          };
+          return;
+        }
+      } catch {
+        // Fail open for usability — proceed with scoring
+        console.warn("[LADDER:WARN] Moderation parse failed, proceeding with score");
+      }
+    }
+  } catch (e) {
+    console.error("[LADDER:ERROR] Moderation failed:", e);
+    // Fail open — proceed to scoring
+  }
+
+  /* ── Streaming scoring call ── */
+  const stream = client.messages.stream({
+    model: "claude-sonnet-4-6",
+    max_tokens: 4096,
+    thinking: { type: "disabled" },
+    output_config: { effort: "low" },
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: mediaType,
+              data: base64Data,
+            },
+          },
+          {
+            type: "text",
+            text: "Score this screen against the Ladder framework. Be honest.",
+          },
+        ],
+      },
+    ],
+    system: buildLadderPrompt(opts),
+  });
+
+  // Accumulate text deltas. Re-scan the buffer after each chunk for
+  // the small set of "early" fields the UI cares about — score,
+  // label, screenName. Regexes are tolerant of the ```json fence
+  // because they don't pin to start-of-string.
+  let buffer = "";
+  let sentScore = false;
+  let sentLabel = false;
+  let sentScreenName = false;
+
+  try {
+    for await (const event of stream) {
+      if (
+        event.type === "content_block_delta" &&
+        event.delta.type === "text_delta"
+      ) {
+        buffer += event.delta.text;
+
+        if (!sentScore) {
+          const m = buffer.match(/"score"\s*:\s*([\d.]+)/);
+          if (m) {
+            const v = parseFloat(m[1]);
+            if (!isNaN(v) && v >= 1 && v <= 5) {
+              sentScore = true;
+              yield { kind: "score", value: v };
+            }
+          }
+        }
+        if (!sentLabel) {
+          // Match the level label (Functional|Usable|Comfortable|Delightful|Meaningful).
+          // Anchored to the top-level "label" key, not the per-rung
+          // "rungs.<x>.score" siblings.
+          const m = buffer.match(/"label"\s*:\s*"([^"]+)"/);
+          if (m) {
+            sentLabel = true;
+            yield { kind: "label", value: m[1] };
+          }
+        }
+        if (!sentScreenName) {
+          const m = buffer.match(/"screenName"\s*:\s*"([^"]+)"/);
+          if (m) {
+            sentScreenName = true;
+            yield { kind: "screenName", value: m[1] };
+          }
+        }
+      }
+    }
+
+    /* ── Parse final ── */
+    const final = await stream.finalMessage();
+    const textBlock = final.content.find((b) => b.type === "text");
+    if (!textBlock || textBlock.type !== "text") {
+      yield { kind: "error", value: "No response from scoring engine", status: 500 };
+      return;
+    }
+    const clean = textBlock.text.replace(/```json|```/g, "").trim();
+    let result: ScoreResult;
+    try {
+      result = JSON.parse(clean);
+    } catch {
+      console.error("[LADDER:ERROR] JSON parse failed:", clean.slice(0, 200));
+      yield { kind: "error", value: "Failed to parse scoring response", status: 500 };
+      return;
+    }
+    if (
+      typeof result.score !== "number" ||
+      !result.label ||
+      !result.summary
+    ) {
+      yield { kind: "error", value: "Invalid scoring response shape", status: 500 };
+      return;
+    }
+    yield { kind: "complete", value: result };
+  } catch (e) {
+    console.error("[LADDER:ERROR] Streaming scoring failed:", e);
+    yield {
+      kind: "error",
+      value: "Scoring failed. Please try again.",
+      status: 500,
+    };
+  }
+}


### PR DESCRIPTION
## Summary
Real streaming for `/score`. The score number and level show within ~2 seconds of submit while the rest fills in. Same Sonnet 4.6 calibration; just dramatically better perceived speed.

## What changed
- `src/lib/scoring.ts` — new `scoreImageStream()` AsyncGenerator that wraps Anthropic streaming and emits structured events as fields become parseable.
- `src/app/api/score/stream/route.ts` — new SSE endpoint with the same auth / rate-limit / persistence as `/api/score`. Persistence happens on the `complete` event.
- `src/app/score/page.tsx` — replaces the JSON fetch with an SSE reader. A `partial` state populates from `score` / `label` / `screenName` events; the skeleton swaps placeholders for real values as they arrive.
- `src/components/score/ScoreLoadingSkeleton.tsx` — accepts `partial` and fades in real values.
- `src/lib/app-version.ts` — bumped 0.3.0 → 0.4.0. Visible in the footer.

## Test plan
- [x] Build clean, 94/94 tests pass
- [ ] After deploy: visible v0.4.0 in footer, score number appears 1-3s after submit, level follows shortly, full scorecard lands in 12-18s as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)