### PR TITLE
Plugin: bump CURRENT_PLUGIN_VERSION to 1.11.4

### DIFF
--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -13,4 +13,4 @@
  * time as LADDER_PLUGIN_VERSION in ai-design-assistant's plugin/ui.html
  * (they must match) and add a release note somewhere user-visible.
  */
-export const CURRENT_PLUGIN_VERSION = "1.11.3";
+export const CURRENT_PLUGIN_VERSION = "1.11.4";


### PR DESCRIPTION
Matches the plugin's new version. Drives the dashboard 'Update available' banner for existing v1.11.3 users.