### PR TITLE
Score detail: remove inline annotations, defer to dedicated redline surface

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,17 @@ Core self-serve Pro shipped 2026-05-02. Remaining work is admin tooling, lifecyc
 - **Per-rung refinement dashboard** — let Ward tune individual rung scoring without a deploy.
 - **Model selection as an admin setting** — toggle Sonnet vs Haiku per mode for cost/quality tradeoff.
 
+## Redline / evaluation surface
+
+Pulled out of the score detail page so scoring stays focused on producing the score. The annotation primitives still live in the codebase (`src/components/ScoreAnnotations.tsx`, `src/components/admin/AnnotatedScreen.tsx`, `/api/dashboard/scores/[id]/annotations`, `src/lib/annotation-analysis.ts`) — this is a UX/surface build, not a from-scratch implementation.
+
+- **Dedicated /dashboard/scores/[id]/redline route** — the canvas where a user pulls findings onto the screenshot, draws rectangles, leaves notes. Entered from a clearly-labeled "Redline this screen" CTA on the score detail page, not auto-shown.
+- **Mode picker on entry** — manual rectangles vs auto-generate from the score's findings (the auto path uses `annotation-analysis.ts`, already on Sonnet 4.6).
+- **Multi-annotation review** — diff your annotations vs the model's annotations vs a teammate's annotations. Useful for design reviews and calibration sessions.
+- **Export** — flatten the annotated screen to PNG / PDF for sharing in design crit, Slack, or a Figma frame.
+- **Pricing copy in `src/app/pricing/page.tsx` ("redline annotations on every score")** — leave alone for now; rewrite when the surface ships.
+- **Plugin parity** — eventually the Figma plugin gets a "Redline this frame" action that hands off to the runladder redline surface (or renders inline). Out of scope until web is shipped.
+
 ## Plugin (Ladder for Figma)
 
 - **Compare-mode activity logging** — currently only single-frame modes log to `user:{id}:activity`

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -9,7 +9,10 @@ import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
 import { ScoreBar } from "@/components/ScoreBar";
 import { AnalysisFeedback } from "@/components/AnalysisFeedback";
-import { ScoreAnnotations } from "@/components/ScoreAnnotations";
+// ScoreAnnotations removed from the score detail flow in v0.4.1.
+// The redline / evaluation feature lives as its own surface
+// (separate page, separate entry point) per the ROADMAP. Component
+// + API stay in the codebase as the foundation for that build.
 
 type Finding = {
   title: string;
@@ -352,14 +355,13 @@ export default function ScoreDetailPage() {
           </div>
         )}
 
-        {data.sessionType === "evaluation" && data.thumbnail && (
-          <div className="mt-6">
-            <ScoreAnnotations
-              scoreId={data.id}
-              imageDataUrl={data.thumbnail}
-            />
-          </div>
-        )}
+        {/* ── Redline annotations removed from the score view ──
+            Per ROADMAP "Redline / evaluation surface". The component
+            and the /api/dashboard/scores/[id]/annotations endpoint are
+            still in the codebase so the future feature can pick them
+            up unchanged. Scoring should be one focused job: produce
+            the score. Annotation belongs in its own surface that
+            users explicitly enter when they're ready to mark up. */}
 
         {/* ── Methodology note + Drawbackwards moderated usability promo ──
             Some screens (date pickers, multi-step flows, hover-states) need


### PR DESCRIPTION
## Summary
Pulls the inline annotation block off the score detail page so scoring is one focused job: produce the score. The redline / evaluation feature gets its own surface, ROADMAP'd.

## What changed
- `src/app/dashboard/scores/[id]/page.tsx` — removes the `<ScoreAnnotations>` block (only rendered when sessionType was 'evaluation') and its import.
- `ROADMAP.md` — adds a Redline / evaluation surface section that scopes the future build and points at the primitives still in the codebase.

## Untouched
- `src/components/ScoreAnnotations.tsx`
- `/api/dashboard/scores/[id]/annotations` route
- `src/components/admin/AnnotatedScreen.tsx` (admin evaluations flow)
- `src/lib/annotation-analysis.ts` (Sonnet 4.6 visual reasoning lib)

Existing user annotations stored in Redis are still readable via the API. The feature is paused on the surface, not deleted.

## Test plan
- [x] `npm run build` clean, 94/94 vitest pass
- [ ] Open a score detail page for an evaluation-session score; confirm no annotations block; everything else renders normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)