### PR TITLE
Plugin: bump CURRENT_PLUGIN_VERSION to 1.11.5

### DIFF
--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -13,4 +13,4 @@
  * time as LADDER_PLUGIN_VERSION in ai-design-assistant's plugin/ui.html
  * (they must match) and add a release note somewhere user-visible.
  */
-export const CURRENT_PLUGIN_VERSION = "1.11.4";
+export const CURRENT_PLUGIN_VERSION = "1.11.5";


### PR DESCRIPTION
Tracks the plugin's new streaming-scoring release. Dashboard 'Update available' banner fires for users still on v1.11.4.