### PR TITLE
Plugin: CURRENT_PLUGIN_VERSION 1.11.6

### DIFF
--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -13,4 +13,4 @@
  * time as LADDER_PLUGIN_VERSION in ai-design-assistant's plugin/ui.html
  * (they must match) and add a release note somewhere user-visible.
  */
-export const CURRENT_PLUGIN_VERSION = "1.11.5";
+export const CURRENT_PLUGIN_VERSION = "1.11.6";


### PR DESCRIPTION
Tracks the plugin's skeleton-scorecard + white-score release.