### PR TITLE
Homepage: drop 'Ward Andrews and' from hero copy (v0.4.3)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -96,9 +96,9 @@ export default function Home() {
             <span className="text-ladder-green">every experience</span>
           </h1>
           <p className="text-lg text-body max-w-2xl mx-auto mb-12 leading-relaxed">
-            Ladder is the framework Ward Andrews and the team at Drawbackwards
-            built over two decades of designing products for the Fortune 50.
-            Now it&apos;s an AI-powered scoring engine anyone can use.
+            Ladder is the framework the team at Drawbackwards built over two
+            decades of designing products for the Fortune 50. Now it&apos;s an
+            AI-powered scoring engine anyone can use.
           </p>
           <div className="flex items-center justify-center gap-6">
             <Link

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.2";
+export const CURRENT_APP_VERSION = "0.4.3";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
Hero subhead now credits the team rather than the founder by name.