### PR TITLE
Legal: add Ladder for Figma to AI Agent policy (v0.4.7)

### DIFF
--- a/src/app/legal/page.tsx
+++ b/src/app/legal/page.tsx
@@ -219,8 +219,8 @@ export default function LegalPage() {
               not limited to Claude, ChatGPT, Gemini, and custom agents &mdash; may
               generate, compute, or return Ladder scores{" "}
               <strong className="text-foreground">
-                only when routed through the official Ladder API, Claude skill, or
-                MCP server
+                only when routed through the official Ladder API, Claude skill,
+                MCP server, or Ladder for Figma plugin
               </strong>
               .
             </p>

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.6";
+export const CURRENT_APP_VERSION = "0.4.7";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
Section 4 was missing Figma plugin from the list of official AI-mediated scoring surfaces. Now in line with sections 2 and 3.