### PR TITLE
Usage: email alert on soft-cap crossing (v0.4.10)

### DIFF
--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.9";
+export const CURRENT_APP_VERSION = "0.4.10";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/scores.ts
+++ b/src/lib/scores.ts
@@ -4,6 +4,7 @@ import {
   monthlyScansKey,
   currentYearMonth,
 } from "@/lib/redis";
+import { maybeAlertCapCrossed, ANY_TIER_CAP_THRESHOLD } from "@/lib/usage";
 
 /**
  * Single source of truth for persisting a Ladder score to a user's
@@ -131,15 +132,21 @@ export async function persistScoreEntry(
   // querying "this month's usage" mid-month always hits a live key, and
   // a buffer past month-end so a late-arriving query during the next
   // month's first day still finds the prior month for trend graphs.
+  //
+  // The monthly increment is awaited standalone so we can capture the
+  // post-increment count and drive the soft-cap-crossed alert from it.
+  // One extra Redis round-trip is fine; the cap-alert path needs the
+  // value and the rest of the writes don't.
   const yyyymm = currentYearMonth(new Date(entry.timestamp));
   const monthlyKey = monthlyScansKey(userId, yyyymm);
+  const newMonthlyCount = await redis.incr(monthlyKey);
+
   const ops: Promise<unknown>[] = [
     redis.zadd(SCORE_HISTORY_KEY(userId), {
       score: entry.timestamp,
       member: JSON.stringify(entry),
     }),
     redis.incr(lifetimeScansKey(userId)),
-    redis.incr(monthlyKey),
     // Forty-day TTL: month length (max 31) + 9-day buffer for late reads.
     redis.expire(monthlyKey, 60 * 60 * 24 * 40),
     redis.set(LASTSCORE_KEY(userId, screenKey), {
@@ -153,6 +160,16 @@ export async function persistScoreEntry(
     redis.hset(STATS_KEY(userId), { lastScoreAt: entry.timestamp }),
   ];
   await Promise.all(ops);
+
+  // Soft-cap crossing alert. Cheap integer compare against the lowest
+  // paid cap (Pro) gatekeeps this — only run the alert pipeline when
+  // there's a chance the user has actually crossed. Fire-and-forget so
+  // a slow email send never blocks the score response.
+  if (newMonthlyCount > ANY_TIER_CAP_THRESHOLD) {
+    maybeAlertCapCrossed(userId, newMonthlyCount).catch((err) => {
+      console.error("[LADDER:CAP-ALERT] background failure:", err);
+    });
+  }
 
   // Update bestScore only if the new score beats the current best.
   const currentBestRaw = await redis.hget<number | string>(

--- a/src/lib/usage.ts
+++ b/src/lib/usage.ts
@@ -9,6 +9,9 @@
  * same number — no per-call-site arithmetic drift.
  */
 import { redis, lifetimeScansKey, monthlyScansKey, currentYearMonth } from "@/lib/redis";
+import { monthlyScoreCapForTier, PRO_MONTHLY_LIMIT } from "@/lib/plans";
+import { getUserSubscription } from "@/lib/tier";
+import { clerkClient } from "@clerk/nextjs/server";
 
 /**
  * Days remaining in the current UTC month, inclusive of today.
@@ -69,4 +72,116 @@ export async function getTeamMonthlyByUser(
     out[id] = counts[i];
   });
   return out;
+}
+
+/**
+ * Pre-threshold for the alert pipeline. The lowest paid cap is Pro's
+ * monthly limit, so any monthly count at or below that can't be an
+ * over-cap event for any tier. Hoisting this here keeps the check
+ * inside persistScoreEntry trivially cheap — one integer compare,
+ * no Clerk / Redis lookups, no work for the 99% of users who never
+ * approach it.
+ */
+export const ANY_TIER_CAP_THRESHOLD = PRO_MONTHLY_LIMIT;
+
+/**
+ * Sends a one-time email alert to hello@drawbackwards.com when a paid
+ * user crosses their tier's monthly soft cap for the first time in
+ * the current month.
+ *
+ * Resolves tier + user email internally so the call site doesn't have
+ * to wire them through. Designed for fire-and-forget: callers should
+ * `.catch(() => {})` and not await. The function self-contains all
+ * errors — failure to send never propagates back to the scoring path.
+ *
+ * Idempotent via a Redis flag (`user:{id}:cap_alert:{yyyy-mm}`) set
+ * with SET NX, so concurrent score writes from the same user can't
+ * fan out duplicate emails. Flag TTL matches the monthly counter's
+ * (~40 days) so flags age out with the data they track.
+ *
+ * No-ops when:
+ *   - tier has no monthly cap (free, pulse)
+ *   - newCount hasn't actually crossed the user's tier cap
+ *   - alert flag for this month is already set
+ *   - RESEND_API_KEY is not configured (falls back to console.log so
+ *     the event still appears in Vercel runtime logs for ops review)
+ */
+export async function maybeAlertCapCrossed(
+  userId: string,
+  newMonthlyCount: number,
+): Promise<void> {
+  // Cheap early-out before any external lookups. Pro is the lowest
+  // paid cap; anything at or under it definitionally isn't a crossing.
+  if (newMonthlyCount <= ANY_TIER_CAP_THRESHOLD) return;
+
+  const sub = await getUserSubscription(userId);
+  const tier = sub.tier;
+  const cap = monthlyScoreCapForTier(tier);
+  if (cap === null) return;
+  if (newMonthlyCount <= cap) return;
+
+  const yyyymm = currentYearMonth();
+  const flagKey = `user:${userId}:cap_alert:${yyyymm}`;
+  // SET NX returns null when the key already exists.
+  const claimed = await redis.set(flagKey, "1", { nx: true, ex: 60 * 60 * 24 * 40 });
+  if (claimed === null) return; // already alerted for this user this month
+
+  // Look up email via Clerk for the alert body. Best-effort — if Clerk
+  // is unreachable we still send with userId.
+  let userEmail: string | null = null;
+  try {
+    const clerk = await clerkClient();
+    const user = await clerk.users.getUser(userId);
+    userEmail = user.primaryEmailAddress?.emailAddress ?? null;
+  } catch {
+    // Non-fatal — proceed without email.
+  }
+
+  const subject = `[Ladder] ${tier} user crossed monthly cap (${newMonthlyCount} / ${cap})`;
+  const dashboardLink = `https://runladder.com/admin/users/${userId}`;
+  const replyLink = userEmail
+    ? `mailto:${userEmail}?subject=Higher-volume%20Ladder%20conversation`
+    : null;
+  const body = [
+    `User: ${userEmail ?? "(no email on file, id " + userId + ")"}`,
+    `Tier: ${tier}`,
+    `Scores this month: ${newMonthlyCount}`,
+    `Soft cap: ${cap}`,
+    `Overage: ${newMonthlyCount - cap}`,
+    "",
+    `Admin: ${dashboardLink}`,
+    replyLink ? `Reach out: ${replyLink}` : null,
+    "",
+    "This is a one-time alert per user per month. The user is still",
+    "scoring (no hard block). If you want to start a conversation",
+    "about higher-volume pricing, reply directly.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    console.log("[LADDER:CAP-ALERT]", subject, "—", body.replace(/\n/g, " | "));
+    return;
+  }
+
+  try {
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${key}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: "Ladder <alerts@runladder.com>",
+        to: ["hello@drawbackwards.com"],
+        subject,
+        text: body,
+      }),
+    });
+  } catch (err) {
+    console.error("[LADDER:CAP-ALERT] send failed:", err);
+    // Note: we don't unset the flag — better to under-alert than spam
+    // on transient send failures. Next month we'll alert fresh.
+  }
 }


### PR DESCRIPTION
One-time email to hello@drawbackwards.com when a Pro/Team user crosses their monthly cap. Idempotent via Redis SET NX flag (user:{id}:cap_alert:{yyyy-mm}). Fire-and-forget from the score persist path so a slow Resend send never blocks scoring. Falls back to console.log when RESEND_API_KEY is unset.