### PR TITLE
Scrub 'unlimited' from upgrade copy (v0.4.12)

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -7,7 +7,12 @@ import {
   isScoringError,
 } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
-import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
+import {
+  FREE_LIFETIME_LIMIT,
+  ANON_LIMIT,
+  PRO_MONTHLY_LIMIT,
+  isPaidTier,
+} from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
 import { persistScoreEntry } from "@/lib/scores";
 
@@ -40,7 +45,7 @@ export async function POST(req: NextRequest) {
         if (used >= FREE_LIFETIME_LIMIT) {
           return NextResponse.json(
             {
-              error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for unlimited scoring.`,
+              error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
               upgrade: true,
             },
             { status: 429 }

--- a/src/app/api/score/stream/route.ts
+++ b/src/app/api/score/stream/route.ts
@@ -6,7 +6,12 @@ import {
   scoreImageStream,
 } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
-import { FREE_LIFETIME_LIMIT, ANON_LIMIT, isPaidTier } from "@/lib/plans";
+import {
+  FREE_LIFETIME_LIMIT,
+  ANON_LIMIT,
+  PRO_MONTHLY_LIMIT,
+  isPaidTier,
+} from "@/lib/plans";
 import { getUserTier } from "@/lib/tier";
 import { persistScoreEntry } from "@/lib/scores";
 
@@ -51,7 +56,7 @@ export async function POST(req: NextRequest) {
       const used = (await redis.get<number>(usedKey)) ?? 0;
       if (used >= FREE_LIFETIME_LIMIT) {
         return errorResponse(
-          `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for unlimited scoring.`,
+          `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
           429,
           { upgrade: true },
         );

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -9,6 +9,7 @@ import { makeThumbnail } from "@/lib/thumbnail";
 import { userIdFromBearer, touchSkillToken } from "@/lib/skill-auth";
 import {
   FREE_LIFETIME_LIMIT,
+  PRO_MONTHLY_LIMIT,
   isPaidTier,
   monthlyScoreCapForTier,
 } from "@/lib/plans";
@@ -56,7 +57,7 @@ export async function POST(req: NextRequest) {
       if (used >= FREE_LIFETIME_LIMIT) {
         return NextResponse.json(
           {
-            error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade at https://runladder.com/pricing for unlimited scoring.`,
+            error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade at https://runladder.com/pricing for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
             upgrade: true,
           },
           { status: 429 }

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -169,7 +169,7 @@ function UpgradeStrip({
             <span className="text-ladder-green font-semibold uppercase tracking-widest text-[10px]">
               {tierLabel}
             </span>{" "}
-            — unlimited scoring across every Ladder surface.
+            — high-volume scoring across every Ladder surface. See your monthly meter in the side panel.
           </span>
           <ManageSubscriptionButton className="text-[10px] uppercase tracking-widest font-semibold text-ladder-green hover:text-ladder-green/80 transition-colors">
             Manage subscription →

--- a/src/components/SkillTokenCard.tsx
+++ b/src/components/SkillTokenCard.tsx
@@ -47,7 +47,7 @@ const TROUBLESHOOTING: { title: string; body: React.ReactNode }[] = [
         <a href="/pricing" className="text-ladder-green hover:underline">
           Upgrade to Pro
         </a>{" "}
-        for unlimited.
+        for 2,000 scores per month.
       </>
     ),
   },

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.11";
+export const CURRENT_APP_VERSION = "0.4.12";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
Five spots that contradicted the new soft-cap framing. Backend routes also switched to interpolating PRO_MONTHLY_LIMIT directly so future cap changes are one constant.