### PR TITLE
Remove anonymous scoring — sign-up required (v0.4.14)

### DIFF
--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -9,7 +9,6 @@ import {
 import { makeThumbnail } from "@/lib/thumbnail";
 import {
   FREE_LIFETIME_LIMIT,
-  ANON_LIMIT,
   PRO_MONTHLY_LIMIT,
   isPaidTier,
   monthlyHardCapForTier,
@@ -31,61 +30,54 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    /* ── Auth (optional — anonymous users allowed with lower limit) ── */
+    /* ── Auth required ── Web scoring requires a Clerk account. The
+     * anonymous "try one score" path was removed in v0.4.14 to match
+     * every other Ladder surface (Skill, Plugin, MCP, API), which all
+     * gate at the door. Marketing CTAs now point at sign-up first. */
     const { userId } = await auth();
-    const ip =
-      req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-      req.headers.get("x-real-ip") ||
-      "unknown";
+    if (!userId) {
+      return NextResponse.json(
+        {
+          error: `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
+          signup: true,
+        },
+        { status: 401 }
+      );
+    }
 
     /* ── Rate limiting ── */
-    if (userId) {
-      const tier = await getUserTier(userId);
-      if (!isPaidTier(tier)) {
-        const usedKey = lifetimeScansKey(userId);
-        const used = (await redis.get<number>(usedKey)) ?? 0;
-        if (used >= FREE_LIFETIME_LIMIT) {
+    const tier = await getUserTier(userId);
+    if (!isPaidTier(tier)) {
+      const usedKey = lifetimeScansKey(userId);
+      const used = (await redis.get<number>(usedKey)) ?? 0;
+      if (used >= FREE_LIFETIME_LIMIT) {
+        return NextResponse.json(
+          {
+            error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
+            upgrade: true,
+          },
+          { status: 429 }
+        );
+      }
+    } else {
+      // Paid-tier hard ceiling — 2x the soft cap. Above this we stop
+      // scoring entirely and direct the user to start a higher-volume
+      // conversation. The soft-cap zone between the soft cap and this
+      // hard ceiling is intentionally wide so the meter, email alert,
+      // and "talk to us" outreach can all land before the wall.
+      const hardCap = monthlyHardCapForTier(tier);
+      if (hardCap !== null) {
+        const monthly = await getMonthlyScans(userId);
+        if (monthly >= hardCap) {
           return NextResponse.json(
             {
-              error: `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
-              upgrade: true,
+              error: `Monthly scoring paused — you're at ${monthly.toLocaleString()} scores, past 2x your tier's cap. Email hello@drawbackwards.com to lift the ceiling.`,
+              hardCapped: true,
+              contact: "hello@drawbackwards.com",
             },
             { status: 429 }
           );
         }
-      } else {
-        // Paid-tier hard ceiling — 2x the soft cap. Above this we
-        // stop scoring entirely and direct the user to start a
-        // higher-volume conversation. The soft-cap zone between the
-        // soft cap and this hard ceiling is intentionally wide so
-        // there's plenty of room for the meter, email alert, and
-        // "talk to us" outreach to land before the wall.
-        const hardCap = monthlyHardCapForTier(tier);
-        if (hardCap !== null) {
-          const monthly = await getMonthlyScans(userId);
-          if (monthly >= hardCap) {
-            return NextResponse.json(
-              {
-                error: `Monthly scoring paused — you're at ${monthly.toLocaleString()} scores, past 2x your tier's cap. Email hello@drawbackwards.com to lift the ceiling.`,
-                hardCapped: true,
-                contact: "hello@drawbackwards.com",
-              },
-              { status: 429 }
-            );
-          }
-        }
-      }
-    } else {
-      const anonKey = `rate:anon:${ip}`;
-      const count = (await redis.get<number>(anonKey)) ?? 0;
-      if (count >= ANON_LIMIT) {
-        return NextResponse.json(
-          {
-            error: `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
-            signup: true,
-          },
-          { status: 429 }
-        );
       }
     }
 
@@ -113,45 +105,32 @@ export async function POST(req: NextRequest) {
     }
 
     /* ── Persist score + increment usage ── */
-    let persistedScoreId: string | null = null;
-    if (userId) {
-      const thumbnail = await makeThumbnail(
-        Buffer.from(parsed.base64Data, "base64"),
-        parsed.mediaType,
-      );
+    const thumbnail = await makeThumbnail(
+      Buffer.from(parsed.base64Data, "base64"),
+      parsed.mediaType,
+    );
 
-      const scoreId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-      await persistScoreEntry(userId, {
-        id: scoreId,
-        score: result.score,
-        label: result.label,
-        screenName: result.screenName || source || "upload",
-        summary: result.summary,
-        next: result.next,
-        findings: result.findings,
-        rungs: result.rungs,
-        source: source || "upload",
-        thumbnail,
-        isPublic: !!isPublic,
-        timestamp: Date.now(),
-        sessionType,
-      });
-      persistedScoreId = scoreId;
-    } else {
-      const anonKey = `rate:anon:${ip}`;
-      await redis.incr(anonKey);
-      const ttl = await redis.ttl(anonKey);
-      if (ttl < 0) {
-        await redis.expire(anonKey, 60 * 60 * 24);
-      }
-    }
+    const scoreId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    await persistScoreEntry(userId, {
+      id: scoreId,
+      score: result.score,
+      label: result.label,
+      screenName: result.screenName || source || "upload",
+      summary: result.summary,
+      next: result.next,
+      findings: result.findings,
+      rungs: result.rungs,
+      source: source || "upload",
+      thumbnail,
+      isPublic: !!isPublic,
+      timestamp: Date.now(),
+      sessionType,
+    });
 
     return NextResponse.json({
       ...result,
       screenName: result.screenName || source || "Screen",
-      // Echo the persisted score's id so the client can route the user
-      // straight to /dashboard/scores/[id] after analysis. Null for anon.
-      scoreId: persistedScoreId,
+      scoreId,
     });
   } catch (err) {
     console.error("[LADDER:ERROR] Score endpoint:", err);

--- a/src/app/api/score/stream/route.ts
+++ b/src/app/api/score/stream/route.ts
@@ -8,7 +8,6 @@ import {
 import { makeThumbnail } from "@/lib/thumbnail";
 import {
   FREE_LIFETIME_LIMIT,
-  ANON_LIMIT,
   PRO_MONTHLY_LIMIT,
   isPaidTier,
   monthlyHardCapForTier,
@@ -43,52 +42,42 @@ export async function POST(req: NextRequest) {
     return errorResponse("Automated requests are not allowed.", 403);
   }
 
-  /* ── Auth ── */
+  /* ── Auth required ── Mirror /api/score: web scoring requires a
+   * Clerk account. Anonymous IP path removed in v0.4.14. */
   const { userId } = await auth();
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
-    req.headers.get("x-real-ip") ||
-    "unknown";
+  if (!userId) {
+    return errorResponse(
+      `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
+      401,
+      { signup: true },
+    );
+  }
 
   /* ── Rate limiting (matches /api/score) ── */
-  if (userId) {
-    const tier = await getUserTier(userId);
-    if (!isPaidTier(tier)) {
-      const usedKey = lifetimeScansKey(userId);
-      const used = (await redis.get<number>(usedKey)) ?? 0;
-      if (used >= FREE_LIFETIME_LIMIT) {
-        return errorResponse(
-          `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
-          429,
-          { upgrade: true },
-        );
-      }
-    } else {
-      // Paid-tier hard ceiling at 2x the soft cap. See /api/score for
-      // the rationale — keep both endpoints in lockstep so the user
-      // gets identical enforcement whether they're using the SSE
-      // stream or the JSON endpoint.
-      const hardCap = monthlyHardCapForTier(tier);
-      if (hardCap !== null) {
-        const monthly = await getMonthlyScans(userId);
-        if (monthly >= hardCap) {
-          return errorResponse(
-            `Monthly scoring paused — you're at ${monthly.toLocaleString()} scores, past 2x your tier's cap. Email hello@drawbackwards.com to lift the ceiling.`,
-            429,
-            { hardCapped: true, contact: "hello@drawbackwards.com" },
-          );
-        }
-      }
+  const tier = await getUserTier(userId);
+  if (!isPaidTier(tier)) {
+    const usedKey = lifetimeScansKey(userId);
+    const used = (await redis.get<number>(usedKey)) ?? 0;
+    if (used >= FREE_LIFETIME_LIMIT) {
+      return errorResponse(
+        `You've used all ${FREE_LIFETIME_LIMIT} free Ladder scores. Upgrade to Pro for ${PRO_MONTHLY_LIMIT.toLocaleString()} scores per month.`,
+        429,
+        { upgrade: true },
+      );
     }
   } else {
-    const anonKey = `rate:anon:${ip}`;
-    const count = (await redis.get<number>(anonKey)) ?? 0;
-    if (count >= ANON_LIMIT) {
-      return errorResponse(
-        `Sign up for free to get ${FREE_LIFETIME_LIMIT} Ladder scores.`,
-        429,
-        { signup: true },
-      );
+    // Paid-tier hard ceiling at 2x the soft cap. Mirrors /api/score so
+    // SSE and JSON paths give identical enforcement.
+    const hardCap = monthlyHardCapForTier(tier);
+    if (hardCap !== null) {
+      const monthly = await getMonthlyScans(userId);
+      if (monthly >= hardCap) {
+        return errorResponse(
+          `Monthly scoring paused — you're at ${monthly.toLocaleString()} scores, past 2x your tier's cap. Email hello@drawbackwards.com to lift the ceiling.`,
+          429,
+          { hardCapped: true, contact: "hello@drawbackwards.com" },
+        );
+      }
     }
   }
 
@@ -130,38 +119,33 @@ export async function POST(req: NextRequest) {
           if (ev.kind === "complete") {
             const result = ev.value;
             // Persist + count usage now that we have the full result.
+            // userId is guaranteed by the auth gate above — anonymous
+            // scoring was removed in v0.4.14.
             let persistedScoreId: string | null = null;
             try {
-              if (userId) {
-                const thumbnail = await makeThumbnail(
-                  Buffer.from(parsed.base64Data, "base64"),
-                  parsed.mediaType,
-                );
-                const scoreId = `${Date.now()}-${Math.random()
-                  .toString(36)
-                  .slice(2, 8)}`;
-                await persistScoreEntry(userId, {
-                  id: scoreId,
-                  score: result.score,
-                  label: result.label,
-                  screenName: result.screenName || source || "upload",
-                  summary: result.summary,
-                  next: result.next,
-                  findings: result.findings,
-                  rungs: result.rungs,
-                  source: source || "upload",
-                  thumbnail,
-                  isPublic: !!isPublic,
-                  timestamp: Date.now(),
-                  sessionType,
-                });
-                persistedScoreId = scoreId;
-              } else {
-                const anonKey = `rate:anon:${ip}`;
-                await redis.incr(anonKey);
-                const ttl = await redis.ttl(anonKey);
-                if (ttl < 0) await redis.expire(anonKey, 60 * 60 * 24);
-              }
+              const thumbnail = await makeThumbnail(
+                Buffer.from(parsed.base64Data, "base64"),
+                parsed.mediaType,
+              );
+              const scoreId = `${Date.now()}-${Math.random()
+                .toString(36)
+                .slice(2, 8)}`;
+              await persistScoreEntry(userId, {
+                id: scoreId,
+                score: result.score,
+                label: result.label,
+                screenName: result.screenName || source || "upload",
+                summary: result.summary,
+                next: result.next,
+                findings: result.findings,
+                rungs: result.rungs,
+                source: source || "upload",
+                thumbnail,
+                isPublic: !!isPublic,
+                timestamp: Date.now(),
+                sessionType,
+              });
+              persistedScoreId = scoreId;
             } catch (e) {
               console.error(
                 "[LADDER:ERROR] Stream persist failed:",

--- a/src/app/contact/ContactForm.tsx
+++ b/src/app/contact/ContactForm.tsx
@@ -82,14 +82,14 @@ export function ContactForm() {
         </p>
         <p className="text-sm text-body leading-relaxed max-w-md mx-auto">
           Thanks for reaching out. Someone from our team will get back to
-          you within one business day. In the meantime, try scoring a
-          screen. It&apos;s free.
+          you within one business day. In the meantime, grab your first
+          Ladder score. Free accounts include 5.
         </p>
         <a
           href="/score"
           className="inline-block mt-6 text-sm font-semibold bg-ladder-green text-background px-8 py-3 rounded-full hover:bg-ladder-green/90 transition-colors"
         >
-          Score a screen
+          Get your first Ladder score
         </a>
       </div>
     );

--- a/src/app/framework/page.tsx
+++ b/src/app/framework/page.tsx
@@ -92,7 +92,7 @@ export default function FrameworkPage() {
               href="/score"
               className="text-body border border-border px-8 py-4 rounded-full hover:text-foreground hover:border-muted transition-colors text-base"
             >
-              Try a free score
+              Get your first Ladder score
             </Link>
           </div>
         </div>
@@ -510,7 +510,7 @@ export default function FrameworkPage() {
               href="/score"
               className="text-body border border-border px-8 py-4 rounded-full hover:text-foreground hover:border-muted transition-colors text-base"
             >
-              Try a free score
+              Get your first Ladder score
             </Link>
           </div>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -47,7 +47,7 @@ const PRODUCTS = [
     name: "runladder.com",
     desc: "You shipped a screen. Is it actually good? Get a trusted quality score in seconds. No installs, no signup, no second-guessing.",
     href: "/score",
-    cta: "Score a screen free",
+    cta: "Get your first Ladder score",
   },
   {
     name: "Ladder Pulse",
@@ -105,7 +105,7 @@ export default function Home() {
               href="/score"
               className="bg-ladder-green text-background font-semibold px-8 py-4 rounded-full hover:bg-ladder-green/90 transition-colors text-base"
             >
-              Score a screen, free
+              Get your first Ladder score
             </Link>
             <Link
               href="/framework"
@@ -437,7 +437,7 @@ export default function Home() {
             href="/score"
             className="inline-block bg-ladder-green text-background font-semibold px-10 py-4 rounded-full hover:bg-ladder-green/90 transition-colors text-lg"
           >
-            Score a screen, free
+            Get your first Ladder score
           </Link>
         </div>
       </section>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -242,7 +242,7 @@ export default function ProductsPage() {
               href="/score"
               className="bg-ladder-green text-background font-semibold px-8 py-4 rounded-full hover:bg-ladder-green/90 transition-colors text-base"
             >
-              Score a screen, free
+              Get your first Ladder score
             </Link>
           </div>
         </div>

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -562,6 +562,43 @@ export default function ScorePage() {
     );
   }
 
+  // Signed-out gate. As of v0.4.14 web scoring requires a Clerk
+  // account — matches every other Ladder surface (Skill, Plugin,
+  // MCP, API). Anonymous "try one score" was removed because it was
+  // an inconsistent backdoor on a professional product and the
+  // friction it saved didn't pay back in conversion. Free tier
+  // remains 5 scores lifetime, but you have to sign up to start.
+  if (isLoaded && !isSignedIn) {
+    return (
+      <div className="pt-32 font-mono">
+        <div className="max-w-md mx-auto px-6 py-20 text-center">
+          <p className="font-mono text-[10px] text-ladder-green uppercase tracking-widest mb-6">
+            Ladder score
+          </p>
+          <h1 className="text-3xl font-bold text-foreground mb-4 font-sans">
+            Get your first Ladder score
+          </h1>
+          <p className="text-sm text-body font-sans leading-relaxed mb-8">
+            Free accounts get 5 scores. No credit card. Your scores
+            stay private to you across the web, Skill, and Figma.
+          </p>
+          <Link
+            href="/sign-up"
+            className="inline-block bg-ladder-green text-background font-semibold px-8 py-3 rounded-full hover:bg-ladder-green/90 transition-colors text-sm"
+          >
+            Sign up free
+          </Link>
+          <p className="text-[11px] text-muted font-sans mt-6">
+            Already have an account?{" "}
+            <Link href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors">
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="analysis-grid pt-20 font-mono">
       {showSessionTypePrompt && (

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.13";
+export const CURRENT_APP_VERSION = "0.4.14";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/plans.test.ts
+++ b/src/lib/plans.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { ANON_LIMIT, FREE_LIFETIME_LIMIT, isPaidTier } from "./plans";
+import { FREE_LIFETIME_LIMIT, isPaidTier } from "./plans";
 
 /**
  * plans.ts is the single source of truth for tier gating across every
@@ -25,9 +25,5 @@ describe("free quota constants", () => {
   // bump.
   it("FREE_LIFETIME_LIMIT is 5", () => {
     expect(FREE_LIFETIME_LIMIT).toBe(5);
-  });
-
-  it("ANON_LIMIT is 1 per IP per 24h", () => {
-    expect(ANON_LIMIT).toBe(1);
   });
 });

--- a/src/lib/plans.ts
+++ b/src/lib/plans.ts
@@ -8,8 +8,10 @@ export type Tier = "free" | "pro" | "team" | "pulse";
 /** Free-tier lifetime score quota. Shared across all surfaces (web, Skill, Figma, MCP, API). */
 export const FREE_LIFETIME_LIMIT = 5;
 
-/** Anonymous (unauthenticated) rate limit, per IP, per 24 hours. */
-export const ANON_LIMIT = 1;
+// ANON_LIMIT removed in v0.4.14 — anonymous scoring was retired so
+// the web aligns with every other Ladder surface (Skill, Plugin, MCP,
+// API) which all gate at the door. Marketing CTAs now route through
+// /sign-up first.
 
 /**
  * Soft monthly caps shown to paid users on /pricing and the dashboard


### PR DESCRIPTION
Web aligns with every other Ladder surface. Backend /api/score and /api/score/stream return 401 when unauthenticated. /score page gates upload UI on isSignedIn. Marketing CTAs swept to 'Get your first Ladder score'. ANON_LIMIT and its test removed.