### PR TITLE
Reviews: move Active Reviews to /dashboard/team (v0.4.16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.4.16 / api 1.0.0 — 2026-05-13
+
+**Move Active Reviews to the team dashboard.**
+
+- Reviews is a manager workflow, so the entry-point card belongs on `/dashboard/team`, not the personal dashboard. Removed from `/dashboard`. Now renders on `/dashboard/team` directly under the team pool meter, gated on `isAdmin`. Non-admin team members will get their own "Reviews you're invited to" panel in a later pass.
+
+---
+
 ## app 0.4.15 / api 1.0.0 — 2026-05-13
 
 **Reviews: the social layer for Ladder.**

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,7 +11,6 @@ import { TeamCard } from "@/components/TeamCard";
 import { TeamSetupBanner } from "@/components/TeamSetupBanner";
 import { ManageSubscriptionButton } from "@/components/ManageSubscriptionButton";
 import { ActivityHeatmap, type DailyActivity } from "@/components/ActivityHeatmap";
-import { ActiveReviewsCard } from "@/components/reviews/ActiveReviewsCard";
 import { FREE_LIFETIME_LIMIT } from "@/lib/plans";
 
 type ScoreEntry = {
@@ -471,8 +470,6 @@ export default function DashboardPage() {
         </div>
 
         <TeamSetupBanner tier={tier} />
-
-        <ActiveReviewsCard />
 
         <DesignRhythmCard scores={scores} />
 

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -15,6 +15,7 @@ import {
   type DailyActivity,
 } from "@/components/ActivityHeatmap";
 import { Avatar } from "@/components/Avatar";
+import { ActiveReviewsCard } from "@/components/reviews/ActiveReviewsCard";
 
 type MemberStats = {
   totalScans: number;
@@ -860,6 +861,8 @@ export default function TeamPage() {
         {isAdmin && teamData?.pool && (
           <TeamPoolMeter pool={teamData.pool} members={memberList} />
         )}
+
+        {isAdmin && <ActiveReviewsCard />}
 
         {isAdmin && (
           <section className="mb-10">

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.15";
+export const CURRENT_APP_VERSION = "0.4.16";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
## Summary

- Active Reviews card belongs on the team dashboard, not the personal one — Reviews is a manager workflow.
- Removed the card from `/dashboard`.
- Added it on `/dashboard/team` directly under the team pool meter, gated on `isAdmin`.

## Test plan

- [ ] `/dashboard` no longer shows Active reviews
- [ ] `/dashboard/team` shows Active reviews directly under the team pool meter (admin only)
- [ ] Cards still link into `/dashboard/reviews/[slug]` correctly
- [ ] Non-admin team members do not see the card

🤖 Generated with [Claude Code](https://claude.com/claude-code)