### PR TITLE
Reviews: request flow + interactive pins + scoring integration (v0.4.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.4.17 / api 1.0.0 — 2026-05-13
+
+**Reviews: request flow, interactive pins, scoring integration.**
+
+- **Designer-initiated review requests.** New `/dashboard/reviews/request` form lets a designer ask their manager for human eyes on a screen. Picks an optional Review to attach to. A "Request a review" CTA card sits on `/dashboard` for team-tier members.
+- **Manager-side requests panel.** `/dashboard/team` now shows incoming review requests above Active reviews. Each card carries the requester avatar, screen thumbnail, current Ladder score, and a context note. Accept expands an in-row "Add to" picker (suggested Review highlighted) or "Start a new Review". Decline dismisses. Seeded with three sample requests for the mock.
+- **Drop-a-pin interactivity.** On the frame workspace, click "+ Drop a pin", then click anywhere on the screen image. A dashed-outline pending pin appears with an inline comment input. Submit drops it as a real pin in local state, selected by default in the right rail.
+- **Submit-a-Team-Take.** The "+ Submit your Team Take" button on the frame workspace now opens an inline form. Score (1.0–5.0) plus a one-line rationale. Submit adds your take to the list and updates the aggregate subscore.
+- **Scoring assign-to-Review.** "+ Score a frame" on a review detail page and "+ Score next iteration" on the frame workspace now route to `/score?review=<slug>`. /score reads that param and surfaces a "Adding to [Review name]" banner above the upload zone so the user knows the next score lands inside that Review. Mock-grade — real persistence ships with the next pass.
+- **Compact team pool meter.** The pool meter on `/dashboard/team` is now a one-line slim bar instead of a section card. Same data, tooltip-on-hover for the over/near-ceiling messaging. Frees up the vertical real estate for the manager workflow.
+
+---
+
 ## app 0.4.16 / api 1.0.0 — 2026-05-13
 
 **Move Active Reviews to the team dashboard.**

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { TeamCard } from "@/components/TeamCard";
 import { TeamSetupBanner } from "@/components/TeamSetupBanner";
 import { ManageSubscriptionButton } from "@/components/ManageSubscriptionButton";
 import { ActivityHeatmap, type DailyActivity } from "@/components/ActivityHeatmap";
+import { RequestReviewCTA } from "@/components/reviews/RequestReviewCTA";
 import { FREE_LIFETIME_LIMIT } from "@/lib/plans";
 
 type ScoreEntry = {
@@ -470,6 +471,8 @@ export default function DashboardPage() {
         </div>
 
         <TeamSetupBanner tier={tier} />
+
+        {(tier === "team" || tier === "pulse") && <RequestReviewCTA />}
 
         <DesignRhythmCard scores={scores} />
 

--- a/src/app/dashboard/reviews/[id]/frames/[frameId]/FrameWorkspace.tsx
+++ b/src/app/dashboard/reviews/[id]/frames/[frameId]/FrameWorkspace.tsx
@@ -1,18 +1,24 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type {
   MockFrame,
   MockPin,
   MockReview,
+  MockTeamTake,
 } from "@/lib/reviews/mockData";
-import {
-  iterationsSorted,
-  teamTakeAverage,
-} from "@/lib/reviews/mockData";
+import { iterationsSorted } from "@/lib/reviews/mockData";
 import { getScoreColor } from "@/lib/ladder";
 import { MockScreen } from "@/components/reviews/MockScreen";
+
+/** "You" — placeholder reviewer used for client-side mock submissions. */
+const SELF_REVIEWER = {
+  id: "self",
+  name: "You",
+  initials: "YO",
+  role: "key" as const,
+};
 
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString(undefined, {
@@ -46,19 +52,82 @@ export function FrameWorkspace({
   const lift = currentIter && startIter
     ? Math.round((currentIter.score - startIter.score) * 10) / 10
     : 0;
-  const take = teamTakeAverage(frame);
 
   const [selectedIterId, setSelectedIterId] = useState(currentIter?.id);
-  const [selectedPinId, setSelectedPinId] = useState<string | null>(
-    frame.pins.find((p) => !p.resolved)?.id ?? null,
-  );
   const [rightTab, setRightTab] = useState<"pin" | "takes" | "findings">(
     "pin",
   );
 
+  // Pins are local state so the user can drop new pins and reply in the mock.
+  const [pins, setPins] = useState<MockPin[]>(frame.pins);
+  const [selectedPinId, setSelectedPinId] = useState<string | null>(
+    pins.find((p) => !p.resolved)?.id ?? null,
+  );
+  /** When true, clicking on the screen drops a pin at that location. */
+  const [dropMode, setDropMode] = useState(false);
+  /** Coords of an in-progress pin awaiting a comment. */
+  const [pendingPin, setPendingPin] = useState<{ x: number; y: number } | null>(
+    null,
+  );
+  const [pendingComment, setPendingComment] = useState("");
+  const canvasRef = useRef<HTMLDivElement>(null);
+
+  // Team Takes are local state so the user can submit their own in the mock.
+  const [takes, setTakes] = useState<MockTeamTake[]>(frame.teamTakes);
+  const take =
+    takes.length === 0
+      ? null
+      : Math.round((takes.reduce((a, t) => a + t.score, 0) / takes.length) * 10) /
+        10;
+
   const selectedPin: MockPin | null = selectedPinId
-    ? frame.pins.find((p) => p.id === selectedPinId) ?? null
+    ? pins.find((p) => p.id === selectedPinId) ?? null
     : null;
+
+  function handleCanvasClick(e: React.MouseEvent<HTMLDivElement>) {
+    if (!dropMode) return;
+    const rect = canvasRef.current?.getBoundingClientRect();
+    if (!rect) return;
+    const x = ((e.clientX - rect.left) / rect.width) * 100;
+    const y = ((e.clientY - rect.top) / rect.height) * 100;
+    setPendingPin({ x: Math.max(2, Math.min(98, x)), y: Math.max(2, Math.min(98, y)) });
+    setDropMode(false);
+    setRightTab("pin");
+  }
+
+  function commitPendingPin() {
+    if (!pendingPin || !pendingComment.trim()) return;
+    const newPin: MockPin = {
+      id: `pin_local_${Date.now()}`,
+      x: pendingPin.x,
+      y: pendingPin.y,
+      author: SELF_REVIEWER,
+      comment: pendingComment.trim(),
+      createdAt: new Date().toISOString(),
+      resolved: false,
+      replies: [],
+    };
+    setPins((ps) => [...ps, newPin]);
+    setSelectedPinId(newPin.id);
+    setPendingPin(null);
+    setPendingComment("");
+  }
+
+  function cancelPendingPin() {
+    setPendingPin(null);
+    setPendingComment("");
+  }
+
+  function addTeamTake(score: number, rationale: string) {
+    const newTake: MockTeamTake = {
+      id: `tt_local_${Date.now()}`,
+      author: SELF_REVIEWER,
+      score,
+      rationale,
+      createdAt: new Date().toISOString(),
+    };
+    setTakes((ts) => [...ts, newTake]);
+  }
 
   return (
     <div className="pt-20 font-mono">
@@ -111,12 +180,12 @@ export function FrameWorkspace({
               }
             />
             <DeltaBadge lift={lift} />
-            <button
-              type="button"
+            <Link
+              href={`/score?review=${review.slug}`}
               className="text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-4 py-2 hover:bg-ladder-green/90 transition-colors"
             >
               + Score next iteration
-            </button>
+            </Link>
           </div>
         </div>
 
@@ -124,7 +193,33 @@ export function FrameWorkspace({
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_360px] gap-6 mb-8">
           {/* Screen with pins */}
           <div>
-            <div className="relative">
+            <div className="mb-2 flex items-center justify-between gap-3 flex-wrap">
+              <p className="text-[10px] text-muted uppercase tracking-widest">
+                {pins.length} pin{pins.length !== 1 ? "s" : ""} ·{" "}
+                {pins.filter((p) => !p.resolved).length} open
+              </p>
+              <button
+                type="button"
+                onClick={() => {
+                  setDropMode((d) => !d);
+                  cancelPendingPin();
+                }}
+                className={`text-[10px] font-semibold uppercase tracking-widest px-3 py-1.5 border transition-colors ${
+                  dropMode
+                    ? "border-ladder-green bg-ladder-green text-background"
+                    : "border-ladder-green/40 text-ladder-green hover:bg-ladder-green/10"
+                }`}
+              >
+                {dropMode ? "Click on the screen ↓" : "+ Drop a pin"}
+              </button>
+            </div>
+            <div
+              ref={canvasRef}
+              onClick={handleCanvasClick}
+              className={`relative ${
+                dropMode ? "cursor-crosshair" : "cursor-default"
+              }`}
+            >
               <MockScreen
                 hue={frame.hue}
                 name={frame.name}
@@ -134,19 +229,60 @@ export function FrameWorkspace({
                     : frame.name
                 }
               />
-              {frame.pins.map((pin, index) => (
+              {pins.map((pin, index) => (
                 <PinMarker
                   key={pin.id}
                   pin={pin}
                   index={index + 1}
                   selected={selectedPinId === pin.id}
                   onSelect={() => {
+                    if (dropMode) return;
                     setSelectedPinId(pin.id);
                     setRightTab("pin");
                   }}
                 />
               ))}
+              {pendingPin && (
+                <PendingPinMarker
+                  x={pendingPin.x}
+                  y={pendingPin.y}
+                  index={pins.length + 1}
+                />
+              )}
             </div>
+
+            {pendingPin && (
+              <div className="mt-3 border border-ladder-green/40 bg-ladder-green/[0.04] p-3">
+                <p className="text-[10px] text-ladder-green uppercase tracking-widest font-mono mb-2">
+                  New pin at {pendingPin.x.toFixed(0)}, {pendingPin.y.toFixed(0)}
+                </p>
+                <textarea
+                  autoFocus
+                  rows={2}
+                  value={pendingComment}
+                  onChange={(e) => setPendingComment(e.target.value)}
+                  placeholder="What's the crit?"
+                  className="w-full bg-[#1a1a1a] border border-[#2a2a2a] focus:border-ladder-green/50 outline-none px-3 py-2 text-xs text-foreground font-sans placeholder:text-muted transition-colors resize-none mb-2"
+                />
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={commitPendingPin}
+                    disabled={!pendingComment.trim()}
+                    className="text-[10px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-3 py-1.5 hover:bg-ladder-green/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Drop pin
+                  </button>
+                  <button
+                    type="button"
+                    onClick={cancelPendingPin}
+                    className="text-[10px] font-semibold uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
 
             {/* Iterations strip */}
             <div className="mt-6 border-t border-[#2a2a2a] pt-5">
@@ -234,7 +370,7 @@ export function FrameWorkspace({
 
             {rightTab === "pin" && (
               <PinPanel
-                pins={frame.pins}
+                pins={pins}
                 selectedPinId={selectedPinId}
                 onSelect={(id) => setSelectedPinId(id)}
                 selectedPin={selectedPin}
@@ -242,7 +378,7 @@ export function FrameWorkspace({
             )}
 
             {rightTab === "takes" && (
-              <TeamTakesPanel frame={frame} take={take} />
+              <TeamTakesPanel takes={takes} take={take} onSubmit={addTeamTake} />
             )}
 
             {rightTab === "findings" && <FindingsPanel frame={frame} />}
@@ -357,7 +493,10 @@ function PinMarker({
   return (
     <button
       type="button"
-      onClick={onSelect}
+      onClick={(e) => {
+        e.stopPropagation();
+        onSelect();
+      }}
       style={{ left: `${pin.x}%`, top: `${pin.y}%` }}
       className={`absolute -translate-x-1/2 -translate-y-1/2 w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-mono font-semibold transition-all border-2 ${
         pin.resolved
@@ -371,6 +510,26 @@ function PinMarker({
     >
       {index}
     </button>
+  );
+}
+
+function PendingPinMarker({
+  x,
+  y,
+  index,
+}: {
+  x: number;
+  y: number;
+  index: number;
+}) {
+  return (
+    <div
+      style={{ left: `${x}%`, top: `${y}%` }}
+      className="absolute -translate-x-1/2 -translate-y-1/2 w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-mono font-semibold bg-ladder-green/30 border-2 border-dashed border-ladder-green text-ladder-green animate-pulse pointer-events-none"
+      aria-label="New pin awaiting comment"
+    >
+      {index}
+    </div>
   );
 }
 
@@ -497,12 +656,28 @@ function PinPanel({
 }
 
 function TeamTakesPanel({
-  frame,
+  takes,
   take,
+  onSubmit,
 }: {
-  frame: MockFrame;
+  takes: MockTeamTake[];
   take: number | null;
+  onSubmit: (score: number, rationale: string) => void;
 }) {
+  const [submitting, setSubmitting] = useState(false);
+  const [score, setScore] = useState("3.0");
+  const [rationale, setRationale] = useState("");
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const n = parseFloat(score);
+    if (!Number.isFinite(n) || n < 1 || n > 5 || !rationale.trim()) return;
+    onSubmit(Math.round(n * 10) / 10, rationale.trim());
+    setSubmitting(false);
+    setScore("3.0");
+    setRationale("");
+  }
+
   return (
     <div className="space-y-4">
       <div className="border border-[#333] bg-[#1e1e1e] p-4">
@@ -517,8 +692,7 @@ function TeamTakesPanel({
             {take !== null ? take.toFixed(1) : "—"}
           </span>
           <span className="text-xs text-muted font-sans">
-            {frame.teamTakes.length} peer
-            {frame.teamTakes.length !== 1 ? "s" : ""}
+            {takes.length} peer{takes.length !== 1 ? "s" : ""}
           </span>
         </div>
         <p className="text-[10px] text-muted font-sans mt-2 leading-relaxed">
@@ -527,7 +701,7 @@ function TeamTakesPanel({
       </div>
 
       <div className="space-y-2">
-        {frame.teamTakes.map((t) => (
+        {takes.map((t) => (
           <div
             key={t.id}
             className="border border-[#2a2a2a] bg-[#1a1a1a] p-3"
@@ -558,12 +732,64 @@ function TeamTakesPanel({
         ))}
       </div>
 
-      <button
-        type="button"
-        className="w-full text-[11px] font-semibold uppercase tracking-widest border border-ladder-green/40 bg-ladder-green/[0.04] text-ladder-green hover:bg-ladder-green/10 py-2.5 transition-colors"
-      >
-        + Submit your Team Take
-      </button>
+      {submitting ? (
+        <form
+          onSubmit={handleSubmit}
+          className="border border-ladder-green/40 bg-ladder-green/[0.04] p-3 space-y-3"
+        >
+          <div>
+            <label className="block text-[10px] text-muted uppercase tracking-widest mb-1.5">
+              Your score (1.0 – 5.0)
+            </label>
+            <input
+              type="number"
+              min="1"
+              max="5"
+              step="0.1"
+              value={score}
+              onChange={(e) => setScore(e.target.value)}
+              className="w-24 bg-[#1a1a1a] border border-[#2a2a2a] focus:border-ladder-green/50 outline-none px-3 py-2 text-sm text-foreground font-mono tabular-nums transition-colors"
+            />
+          </div>
+          <div>
+            <label className="block text-[10px] text-muted uppercase tracking-widest mb-1.5">
+              Rationale
+            </label>
+            <textarea
+              autoFocus
+              rows={3}
+              value={rationale}
+              onChange={(e) => setRationale(e.target.value)}
+              placeholder="One line on why you scored it that way."
+              className="w-full bg-[#1a1a1a] border border-[#2a2a2a] focus:border-ladder-green/50 outline-none px-3 py-2 text-xs text-foreground font-sans placeholder:text-muted transition-colors resize-none"
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="submit"
+              disabled={!rationale.trim()}
+              className="text-[10px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-3 py-1.5 hover:bg-ladder-green/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Submit Take
+            </button>
+            <button
+              type="button"
+              onClick={() => setSubmitting(false)}
+              className="text-[10px] font-semibold uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <button
+          type="button"
+          onClick={() => setSubmitting(true)}
+          className="w-full text-[11px] font-semibold uppercase tracking-widest border border-ladder-green/40 bg-ladder-green/[0.04] text-ladder-green hover:bg-ladder-green/10 py-2.5 transition-colors"
+        >
+          + Submit your Team Take
+        </button>
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/reviews/[id]/page.tsx
+++ b/src/app/dashboard/reviews/[id]/page.tsx
@@ -62,12 +62,12 @@ export default async function ReviewDetailPage({ params }: { params: Params }) {
             >
               Share
             </button>
-            <button
-              type="button"
+            <Link
+              href={`/score?review=${review.slug}`}
               className="text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-5 py-2 hover:bg-ladder-green/90 transition-colors"
             >
               + Score a frame
-            </button>
+            </Link>
           </div>
         </div>
 

--- a/src/app/dashboard/reviews/request/page.tsx
+++ b/src/app/dashboard/reviews/request/page.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { MOCK_REVIEWS } from "@/lib/reviews/mockData";
+
+export default function RequestReviewPage() {
+  const [subject, setSubject] = useState("");
+  const [reviewId, setReviewId] = useState<string>("");
+  const [note, setNote] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!subject.trim() || !note.trim()) return;
+    // Mock submit. Real build will POST /api/reviews/requests
+    setSubmitted(true);
+  }
+
+  if (submitted) {
+    return (
+      <div className="pt-20 font-mono">
+        <div className="max-w-2xl mx-auto px-6 py-16">
+          <div className="border border-ladder-green/30 bg-ladder-green/[0.04] p-8 text-center">
+            <div className="mx-auto mb-5 w-14 h-14 border border-ladder-green/40 bg-ladder-green/10 flex items-center justify-center">
+              <svg
+                width="22"
+                height="22"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="#6AC89B"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            </div>
+            <p className="text-lg font-bold text-foreground font-sans mb-2">
+              Request sent.
+            </p>
+            <p className="text-sm text-muted font-sans leading-relaxed max-w-md mx-auto mb-6">
+              Your manager will see it on their team dashboard. You&apos;ll
+              get a notification when they pick it up.
+            </p>
+            <Link
+              href="/dashboard"
+              className="inline-block text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-5 py-2.5 hover:bg-ladder-green/90 transition-colors"
+            >
+              Back to dashboard
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-2 text-[10px] text-muted uppercase tracking-widest hover:text-foreground transition-colors mb-6"
+        >
+          ← Dashboard
+        </Link>
+
+        <div className="mb-8">
+          <h1 className="text-2xl text-foreground font-sans mb-2">
+            Request a review
+          </h1>
+          <p className="text-sm text-muted font-sans leading-relaxed">
+            Ask your team manager for human eyes on a screen. Ladder will
+            score it. Your manager and the assigned reviewers will drop
+            notes and weigh in with a Team Take.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="block text-[10px] font-mono uppercase tracking-widest text-muted mb-2">
+              Screen name *
+            </label>
+            <input
+              type="text"
+              required
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              className="w-full bg-[#1a1a1a] border border-[#2a2a2a] focus:border-ladder-green/50 outline-none px-4 py-3 text-sm text-foreground font-sans placeholder:text-muted transition-colors"
+              placeholder="Cart page, Onboarding step 2, etc."
+            />
+          </div>
+
+          <div>
+            <label className="block text-[10px] font-mono uppercase tracking-widest text-muted mb-2">
+              Add to a Review
+            </label>
+            <p className="text-[11px] text-muted font-sans mb-2">
+              Optional. Pick an existing Review to attach this screen to, or
+              leave blank and let the manager decide.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => setReviewId("")}
+                className={`text-[11px] px-3 py-1.5 border transition-colors ${
+                  reviewId === ""
+                    ? "border-ladder-green text-ladder-green bg-ladder-green/10"
+                    : "border-[#3a3a3a] text-body hover:border-[#555] hover:text-foreground"
+                }`}
+              >
+                Manager decides
+              </button>
+              {MOCK_REVIEWS.filter((r) => r.status === "active").map((r) => (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => setReviewId(r.id)}
+                  className={`text-[11px] px-3 py-1.5 border transition-colors ${
+                    reviewId === r.id
+                      ? "border-ladder-green text-ladder-green bg-ladder-green/10"
+                      : "border-[#3a3a3a] text-body hover:border-[#555] hover:text-foreground"
+                  }`}
+                >
+                  {r.name}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-[10px] font-mono uppercase tracking-widest text-muted mb-2">
+              Context *
+            </label>
+            <textarea
+              required
+              rows={5}
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="w-full bg-[#1a1a1a] border border-[#2a2a2a] focus:border-ladder-green/50 outline-none px-4 py-3 text-sm text-foreground font-sans placeholder:text-muted transition-colors resize-none"
+              placeholder="What's the screen about? What are you wrestling with? Anything specific you want eyes on?"
+            />
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={!subject.trim() || !note.trim()}
+              className="text-[11px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-6 py-3 hover:bg-ladder-green/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              Send request
+            </button>
+            <Link
+              href="/dashboard"
+              className="text-[11px] font-semibold uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Cancel
+            </Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ActivityHeatmap";
 import { Avatar } from "@/components/Avatar";
 import { ActiveReviewsCard } from "@/components/reviews/ActiveReviewsCard";
+import { ReviewRequestsPanel } from "@/components/reviews/ReviewRequestsPanel";
 
 type MemberStats = {
   totalScans: number;
@@ -330,18 +331,37 @@ function TeamPoolMeter({
       : []),
   ];
 
+  const overOrWarn = over || warn;
+  const ceilingLink = (
+    <a
+      href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20higher%20volume%20inquiry"
+      className="text-ladder-green hover:underline"
+    >
+      Talk to us
+    </a>
+  );
+
   return (
-    <section className="mb-10">
-      <div className="flex items-baseline justify-between mb-3">
-        <h2 className="text-[10px] text-muted uppercase tracking-widest">
-          Team pool
-        </h2>
-        <span className="text-[10px] text-muted font-mono">
-          {pool.used.toLocaleString()} / {pool.limit.toLocaleString()} this month
+    <section
+      className="mb-6 border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-2.5 flex items-center gap-4 flex-wrap"
+      title={
+        over
+          ? "Team is over the pool ceiling — talk to us about a custom volume"
+          : warn
+            ? "Approaching the team pool ceiling"
+            : undefined
+      }
+    >
+      <span className="text-[10px] text-muted uppercase tracking-widest whitespace-nowrap">
+        Team pool
+      </span>
+      <span className="text-[11px] text-foreground font-mono tabular-nums whitespace-nowrap">
+        {pool.used.toLocaleString()}{" "}
+        <span className="text-muted">
+          / {pool.limit.toLocaleString()} this month
         </span>
-      </div>
-      <div className={`relative h-2 ${baseClass}`}>
-        {/* Stacked breakdown by contributor. Tooltips on hover via title. */}
+      </span>
+      <div className={`relative flex-1 min-w-[120px] h-1.5 ${baseClass}`}>
         {segments.map((seg, i) => {
           const segPct = Math.min(100, (seg.value / pool.limit) * 100);
           return (
@@ -360,29 +380,12 @@ function TeamPoolMeter({
           );
         })}
       </div>
-      {over ? (
-        <p className="text-[11px] text-muted mt-3">
-          You&apos;ve passed the standard team pool.{" "}
-          <a
-            href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20higher%20volume%20inquiry"
-            className="text-ladder-green hover:underline"
-          >
-            Talk to us about a custom volume
-          </a>
-          .
-        </p>
-      ) : warn ? (
-        <p className="text-[11px] text-muted mt-3">
-          Approaching the team pool ceiling.{" "}
-          <a
-            href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20higher%20volume%20inquiry"
-            className="text-ladder-green hover:underline"
-          >
-            We&apos;ll size you up
-          </a>{" "}
-          before it bites.
-        </p>
-      ) : null}
+      {overOrWarn && (
+        <span className="text-[10px] text-muted">
+          {over ? "Over ceiling. " : "Near ceiling. "}
+          {ceilingLink}.
+        </span>
+      )}
     </section>
   );
 }
@@ -861,6 +864,8 @@ export default function TeamPage() {
         {isAdmin && teamData?.pool && (
           <TeamPoolMeter pool={teamData.pool} members={memberList} />
         )}
+
+        {isAdmin && <ReviewRequestsPanel />}
 
         {isAdmin && <ActiveReviewsCard />}
 

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth, useOrganization } from "@clerk/nextjs";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
@@ -644,8 +644,12 @@ export default function ScorePage() {
 
             {/* Review context banner — present when /score is opened with
                 ?review=<slug>. Tells the user the score will land inside
-                that Review. */}
-            <ScoreReviewContextBanner />
+                that Review. Suspense boundary required because the banner
+                reads useSearchParams; without it, static prerender of
+                /score bails out (Next.js CSR bailout). */}
+            <Suspense fallback={null}>
+              <ScoreReviewContextBanner />
+            </Suspense>
 
             {/* Informational callouts — above the drop zone (Ward feedback).
                 Public/private toggle for signed-in users, terms note for anon. */}

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -8,6 +8,7 @@ import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
 import { ScoreLoadingSkeleton } from "@/components/score/ScoreLoadingSkeleton";
+import { ScoreReviewContextBanner } from "@/components/reviews/ScoreReviewContextBanner";
 import {
   SessionTypeModal,
   SessionTypePill,
@@ -640,6 +641,11 @@ export default function ScorePage() {
                 Drop a screen. Get the number. See exactly what to fix, and what level your experience is really at.
               </p>
             </div>
+
+            {/* Review context banner — present when /score is opened with
+                ?review=<slug>. Tells the user the score will land inside
+                that Review. */}
+            <ScoreReviewContextBanner />
 
             {/* Informational callouts — above the drop zone (Ward feedback).
                 Public/private toggle for signed-in users, terms note for anon. */}

--- a/src/components/reviews/RequestReviewCTA.tsx
+++ b/src/components/reviews/RequestReviewCTA.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+
+/**
+ * Designer-side entry point for asking a manager for human eyes on a
+ * design. Renders on /dashboard so designers see it next to their own
+ * recent scores. Manager-side, the request appears on /dashboard/team
+ * inside the Review Requests panel.
+ */
+export function RequestReviewCTA() {
+  return (
+    <Link
+      href="/dashboard/reviews/request"
+      className="block border border-ladder-green/30 bg-ladder-green/[0.04] hover:bg-ladder-green/[0.08] hover:border-ladder-green/60 transition-colors p-4 mb-6 group"
+    >
+      <div className="flex items-center gap-4">
+        <div className="flex-shrink-0 w-10 h-10 border border-ladder-green/40 bg-ladder-green/10 flex items-center justify-center">
+          <svg
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#6AC89B"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+          >
+            <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z" />
+          </svg>
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-foreground font-sans">
+            Ask your team for a review
+          </p>
+          <p className="text-[11px] text-muted font-sans mt-0.5">
+            Send a screen to your manager for human crit. They&apos;ll see it
+            on their team dashboard.
+          </p>
+        </div>
+        <span className="text-ladder-green text-base flex-shrink-0 pr-2 group-hover:translate-x-0.5 transition-transform">
+          →
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/reviews/ReviewRequestsPanel.tsx
+++ b/src/components/reviews/ReviewRequestsPanel.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import {
+  MOCK_REVIEW_REQUESTS,
+  MOCK_REVIEWS,
+  findReviewById,
+  type MockReviewRequest,
+} from "@/lib/reviews/mockData";
+import { getScoreColor } from "@/lib/ladder";
+import { MockScreen } from "@/components/reviews/MockScreen";
+
+function timeAgo(iso: string): string {
+  const diff = Date.now() - +new Date(iso);
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return "just now";
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+/**
+ * Manager-side panel showing pending review requests from designers.
+ * Accept routes the manager to "add to Review" flow (mock: marks
+ * accepted in local state). Decline removes from view.
+ *
+ * Sits on /dashboard/team above Active reviews so incoming asks
+ * land first thing the manager sees on the team page.
+ */
+export function ReviewRequestsPanel() {
+  // Local state lets the manager dismiss requests interactively in the
+  // mock. Real build will hit /api/reviews/requests with optimistic UI.
+  const [requests, setRequests] = useState<MockReviewRequest[]>(
+    MOCK_REVIEW_REQUESTS.filter((r) => r.status === "pending"),
+  );
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  if (requests.length === 0) return null;
+
+  function handleAccept(id: string) {
+    setRequests((rs) => rs.filter((r) => r.id !== id));
+  }
+  function handleDecline(id: string) {
+    setRequests((rs) => rs.filter((r) => r.id !== id));
+  }
+
+  return (
+    <section className="mb-6 border border-ladder-green/30 bg-ladder-green/[0.04] p-5">
+      <div className="flex items-baseline justify-between gap-3 mb-4">
+        <div>
+          <div className="flex items-baseline gap-2.5">
+            <h2 className="text-[10px] text-ladder-green uppercase tracking-widest font-mono font-semibold">
+              Review requests
+            </h2>
+            <span className="text-[10px] text-muted font-mono tabular-nums">
+              {requests.length} pending
+            </span>
+          </div>
+          <p className="text-xs text-muted font-sans mt-1">
+            Designers asking for your eyes. Accept to start (or extend) a
+            Review.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {requests.map((req) => {
+          const suggested = req.suggestedReviewId
+            ? findReviewById(req.suggestedReviewId)
+            : null;
+          const isExpanded = expandedId === req.id;
+          return (
+            <div
+              key={req.id}
+              className="border border-[#2a2a2a] bg-[#1a1a1a] p-3"
+            >
+              <div className="flex items-stretch gap-3">
+                <div className="w-20 flex-shrink-0">
+                  <MockScreen hue={req.hue} name={req.subject} />
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-2 mb-0.5 flex-wrap">
+                    <h3 className="text-sm text-foreground font-sans font-semibold">
+                      {req.subject}
+                    </h3>
+                    {req.currentScore !== null && (
+                      <span
+                        className="text-[11px] font-mono font-semibold tabular-nums"
+                        style={{ color: getScoreColor(req.currentScore) }}
+                        title="Current Ladder score"
+                      >
+                        {req.currentScore.toFixed(1)}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-[10px] text-muted font-sans mb-1.5">
+                    {req.requestedBy.name} · {timeAgo(req.requestedAt)}
+                    {suggested && (
+                      <>
+                        {" · "}
+                        <span className="text-ladder-green">
+                          suggests {suggested.name}
+                        </span>
+                      </>
+                    )}
+                  </p>
+                  <p className="text-[11px] text-body font-sans leading-relaxed line-clamp-2">
+                    {req.note}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-1.5 flex-shrink-0">
+                  <button
+                    type="button"
+                    onClick={() => setExpandedId(isExpanded ? null : req.id)}
+                    className="text-[10px] font-semibold uppercase tracking-widest bg-ladder-green text-background px-3 py-1.5 hover:bg-ladder-green/90 transition-colors"
+                  >
+                    {isExpanded ? "Close" : "Accept"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDecline(req.id)}
+                    className="text-[10px] font-semibold uppercase tracking-widest border border-[#3a3a3a] text-muted px-3 py-1.5 hover:text-foreground hover:border-[#555] transition-colors"
+                  >
+                    Decline
+                  </button>
+                </div>
+              </div>
+
+              {isExpanded && (
+                <div className="mt-3 pt-3 border-t border-[#2a2a2a]">
+                  <p className="text-[10px] text-muted uppercase tracking-widest mb-2">
+                    Add to
+                  </p>
+                  <div className="flex flex-wrap gap-1.5 mb-3">
+                    {MOCK_REVIEWS.filter((r) => r.status === "active").map(
+                      (r) => (
+                        <Link
+                          key={r.id}
+                          href={`/dashboard/reviews/${r.slug}`}
+                          onClick={() => handleAccept(req.id)}
+                          className={`text-[10px] px-3 py-1.5 border transition-colors ${
+                            suggested?.id === r.id
+                              ? "border-ladder-green text-ladder-green bg-ladder-green/10"
+                              : "border-[#3a3a3a] text-body hover:border-[#555] hover:text-foreground"
+                          }`}
+                        >
+                          {r.name}
+                          {suggested?.id === r.id && (
+                            <span className="ml-1.5 text-[9px] opacity-70">
+                              suggested
+                            </span>
+                          )}
+                        </Link>
+                      ),
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => handleAccept(req.id)}
+                      className="text-[10px] font-semibold px-3 py-1.5 border border-ladder-green/40 text-ladder-green bg-ladder-green/5 hover:bg-ladder-green/15 transition-colors"
+                    >
+                      + Start a new Review
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/reviews/ScoreReviewContextBanner.tsx
+++ b/src/components/reviews/ScoreReviewContextBanner.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { findReviewBySlug } from "@/lib/reviews/mockData";
+
+/**
+ * When /score is opened via ?review=<slug>, surface a banner so the
+ * user knows the next score will land inside that Review. Mock — real
+ * build will persist the association in the score record.
+ */
+export function ScoreReviewContextBanner() {
+  const params = useSearchParams();
+  const slug = params?.get("review") ?? null;
+  const review = slug ? findReviewBySlug(slug) : null;
+  if (!review) return null;
+  return (
+    <div className="mb-6 border border-ladder-green/40 bg-ladder-green/[0.06] px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+      <div className="flex items-center gap-3 min-w-0">
+        <span className="text-[9px] font-mono font-semibold uppercase tracking-widest text-ladder-green bg-ladder-green/15 border border-ladder-green/40 px-1.5 py-0.5 flex-shrink-0">
+          Review
+        </span>
+        <p className="text-xs text-foreground font-sans truncate">
+          Adding to <span className="font-semibold">{review.name}</span>.
+          This score will land inside the Review.
+        </p>
+      </div>
+      <Link
+        href="/score"
+        className="text-[10px] uppercase tracking-widest font-semibold text-muted hover:text-foreground transition-colors flex-shrink-0"
+      >
+        Clear
+      </Link>
+    </div>
+  );
+}

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.16";
+export const CURRENT_APP_VERSION = "0.4.17";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/reviews/mockData.ts
+++ b/src/lib/reviews/mockData.ts
@@ -86,6 +86,28 @@ export type MockReview = {
   unread: number;
 };
 
+/**
+ * A designer-initiated request for the manager to start (or extend) a
+ * Review on a specific screen. Lives on the manager's team dashboard
+ * until accepted or declined.
+ */
+export type MockReviewRequest = {
+  id: string;
+  requestedBy: MockReviewer;
+  requestedAt: string;
+  /** Short name of the screen the requester wants feedback on. */
+  subject: string;
+  /** Placeholder gradient hue for the thumbnail. */
+  hue: number;
+  /** Current Ladder score on the screen, if it has been scored. */
+  currentScore: number | null;
+  /** Free-text context from the requester. */
+  note: string;
+  /** Optional: review the requester suggests adding this to. */
+  suggestedReviewId?: string;
+  status: "pending" | "accepted" | "declined";
+};
+
 // --- Reviewers ---------------------------------------------------------
 
 const SARAH: MockReviewer = { id: "sarah", name: "Sarah Chen", initials: "SC", role: "owner" };
@@ -267,6 +289,42 @@ export const MOCK_REVIEWS: MockReview[] = [
         ],
       },
     ],
+  },
+];
+
+// --- Review requests ---------------------------------------------------
+
+export const MOCK_REVIEW_REQUESTS: MockReviewRequest[] = [
+  {
+    id: "req_settings_v2",
+    requestedBy: ALEX,
+    requestedAt: "2026-05-12T16:30:00Z",
+    subject: "Account settings v2",
+    hue: 78,
+    currentScore: 2.6,
+    note: "Pushed the new settings screen yesterday. Hierarchy feels off at the top and I can't tell if the dividers are doing anything. Would love eyes before the sprint review Friday.",
+    status: "pending",
+  },
+  {
+    id: "req_pricing_mobile",
+    requestedBy: JORDAN,
+    requestedAt: "2026-05-13T09:14:00Z",
+    subject: "Pricing page, mobile",
+    hue: 12,
+    currentScore: 3.1,
+    note: "Mobile pricing is comfortable on Ladder but the tier comparison feels cramped. Could use a designer eye on the breakpoint behavior.",
+    suggestedReviewId: "rev_pricing_refresh",
+    status: "pending",
+  },
+  {
+    id: "req_empty_state",
+    requestedBy: DANA,
+    requestedAt: "2026-05-13T11:42:00Z",
+    subject: "Dashboard empty state",
+    hue: 220,
+    currentScore: null,
+    note: "Brand new empty state, not scored yet. Want to crit before I commit to the direction.",
+    status: "pending",
   },
 ];
 


### PR DESCRIPTION
## Summary

Closes the loop on the Reviews mock.

- **Designers can request a review.** `/dashboard/reviews/request` form, CTA card on `/dashboard` for team-tier.
- **Managers see incoming requests.** New "Review requests" panel on `/dashboard/team` above Active reviews. Accept routes to an "Add to" picker (existing Review or start new); Decline dismisses.
- **Drop-a-pin works.** Click "+ Drop a pin", click on the screen, write the comment, submit. Real pin lands in the rail.
- **Submit-a-Team-Take works.** Inline score + rationale form. Aggregate updates.
- **Scoring is aware of the Review context.** `+ Score a frame` and `+ Score next iteration` route through `/score?review=<slug>`, which surfaces a "Adding to [Review name]" banner above the upload zone.
- **Pool meter compacted** to a one-line slim bar with tooltip warnings so the manager workflow gets the vertical space.

Mock-grade. Real persistence (API + Redis schema) ships in the next pass.

## Test plan

- [ ] `/dashboard` (team tier) shows "Ask your team for a review" CTA
- [ ] Submit a request → success state, link back to dashboard
- [ ] `/dashboard/team` shows three pending requests above Active reviews
- [ ] Accept on a request expands the "Add to" picker; clicking a Review dismisses
- [ ] Decline removes the request
- [ ] Pool meter is now a thin one-line bar
- [ ] Frame workspace: "+ Drop a pin" then click the screen, type a comment, submit → pin appears
- [ ] "+ Submit your Team Take" form: enter 3.5 + rationale, submit → aggregate updates
- [ ] "+ Score a frame" on a Review opens `/score?review=<slug>` with the banner
- [ ] Clear link on the banner returns to `/score` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)