### PR TITLE
Team pool meter: cap reads as prominently as used count (v0.4.18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.4.18 / api 1.0.0 — 2026-05-13
+
+**Team pool meter: show the 25K cap prominently.**
+
+- The pool meter on `/dashboard/team` was compacted in v0.4.17, but the limit number (25,000 default) ended up in muted text where it could be missed at a glance. Restructured the inline numbers so both used and cap render at the same weight, foreground color, semibold mono, tabular-nums. Reads "0 of 25,000 scores · this month" with both numerals equally legible.
+
+---
+
 ## app 0.4.17 / api 1.0.0 — 2026-05-13
 
 **Reviews: request flow, interactive pins, scoring integration.**

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -355,12 +355,22 @@ function TeamPoolMeter({
       <span className="text-[10px] text-muted uppercase tracking-widest whitespace-nowrap">
         Team pool
       </span>
-      <span className="text-[11px] text-foreground font-mono tabular-nums whitespace-nowrap">
-        {pool.used.toLocaleString()}{" "}
-        <span className="text-muted">
-          / {pool.limit.toLocaleString()} this month
+      <div className="flex items-baseline gap-1.5 whitespace-nowrap font-mono">
+        <span
+          className="text-sm text-foreground font-semibold tabular-nums"
+          title="Scores used this month"
+        >
+          {pool.used.toLocaleString()}
         </span>
-      </span>
+        <span className="text-[10px] text-muted">of</span>
+        <span
+          className="text-sm text-foreground font-semibold tabular-nums"
+          title="Monthly pool cap"
+        >
+          {pool.limit.toLocaleString()}
+        </span>
+        <span className="text-[10px] text-muted">scores · this month</span>
+      </div>
       <div className={`relative flex-1 min-w-[120px] h-1.5 ${baseClass}`}>
         {segments.map((seg, i) => {
           const segPct = Math.min(100, (seg.value / pool.limit) * 100);

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.4.17";
+export const CURRENT_APP_VERSION = "0.4.18";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
## Summary

Tiny follow-up to v0.4.17. The pool meter on `/dashboard/team` was compacted but the 25,000 cap ended up in muted text where it could be missed at a glance. Now both numbers render at the same weight: foreground color, semibold mono, tabular-nums.

Before: `0 / 25,000 this month` (cap muted)
After: `0 of 25,000 scores · this month` (both numerals equally legible)

## Test plan

- [ ] `/dashboard/team` pool meter shows both numbers in same prominence
- [ ] Tooltip on each number names what it is (used / monthly cap)
- [ ] Bar still renders compact and inline

🤖 Generated with [Claude Code](https://claude.com/claude-code)