### PR TITLE
HQ: audit corrections + full roadmap + Skill distribution + GTM strategy (v0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.2 / api 1.0.0 (2026-05-19)
+
+**Ladder HQ: audit corrections, full platform roadmap, Go-to-Market strategy, Skill distribution plan.**
+
+- **Audit corrections.** v0.5.0 and v0.5.1 invented things that didn't exist. This release tells the truth: `api.runladder.com` does not exist (DNS NXDOMAIN), MCP server does not exist, `/dashboard/settings` does not exist, the `POST /v1/score` shape was fiction. Every page now distinguishes Live (file/route/PR evidence) vs In flight (code partially exists) vs Roadmap (no code yet).
+- **Codebase map** added to `/hq/architecture`. Three repos called out: `runladder` (this), `ladder-beta` (Pulse on Fly.io), `ladder` (original Rails). Pulse and Ladder stay in separate repos for now; consolidation is roadmap.
+- **API Protocols rewritten** at `/hq/api`. Full table of every endpoint that actually exists in `src/app/api/`. Auth tiers documented honestly. Real `POST /api/score` shape pulled from the actual route file. Roadmap clearly separated from today.
+- **User Journeys re-tagged** with Live / In flight / Roadmap on every flow. Pulse flow notes that Pulse runs in `ladder-beta`. Token issuance flows reference the real `/api/plugin/issue-token` and `/api/skill/token` routes, not the fictional `/dashboard/settings`.
+- **Feature Inventory** every row now has an Evidence column. If a row claims Live, it points to a file path or PR. Otherwise it's In flight or Roadmap. Pulse and Original Ladder get their own sections so the repo split is clear.
+- **Decisions Log** two new entries: (1) Every claim of "live" in /hq must point to a route, file, or PR (UNBREAKABLE rule). (2) Pulse and original Ladder stay in separate repos for now; consolidation is a future decision, not active.
+- **Roadmap expanded** at `/hq/roadmap` with a full platform plan: public-launch gate tracker, This Week / Next 30 Days / This Quarter, **Skill distribution roadmap** (publish `marketplace.json`, submit to `anthropics/skills`, Teams enterprise deployment), **api.runladder.com roadmap** (6 phases: DNS + Phase 1 redirect, architecture decision, API key UI, MCP server, OpenAPI spec, public launch flip), Pulse consolidation triggers, hiring trigger triggers, standing items, weekly review cadence.
+- **Go-to-Market strategy** new page at `/hq/gtm`. CRO-voice draft: north star, positioning recap, ICP, full funnel (awareness, activation, engagement, conversion, expansion, retention) with surface mapping, three-motion sales (PLG for Pro, sales-assisted for Lift, enterprise for Teams and Pulse), channel strategy (owned, earned, partner, paid), public-launch sequence by day, metrics dashboard, risks called out, open questions for Ward.
+
+---
+
 ## app 0.5.1 / api 1.0.0 (2026-05-19)
 
 **Ladder HQ: drop human-owner labels, Sara seeds every section, lockstep protocol baked in.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ## app 0.5.2 / api 1.0.0 (2026-05-19)
 
-**Ladder HQ: audit corrections, full platform roadmap, Go-to-Market strategy, Skill distribution plan.**
+**Ladder HQ: audit corrections, full platform roadmap, Go-to-Market strategy, Skill distribution plan, pricing scrub.**
+
+**Pricing scrub.** Two issues caught by Ward late in PR review: (1) `/hq` was citing Pro at $250 in multiple places, but Pro went to $1,000/mo in v0.4.8 (PR #166) and that's live on Stripe today. All references corrected. (2) `/hq` is read by everyone in `TEAM_EMAILS` / `ADMIN_EMAILS`, including engineering audit and design roles who don't need to see internal sales numbers. Specific Team floor pricing, Pulse engagement ACVs, customer dollar values, and Ladder Lift price bands all removed from `/hq`. They stay in non-`/hq` memory. New Decisions Log entry codifies the rule: "/hq documents PUBLIC pricing only". The GTM page now talks revenue strategy qualitatively, not in specific dollar projections.
+
+
 
 - **Audit corrections.** v0.5.0 and v0.5.1 invented things that didn't exist. This release tells the truth: `api.runladder.com` does not exist (DNS NXDOMAIN), MCP server does not exist, `/dashboard/settings` does not exist, the `POST /v1/score` shape was fiction. Every page now distinguishes Live (file/route/PR evidence) vs In flight (code partially exists) vs Roadmap (no code yet).
 - **Codebase map** added to `/hq/architecture`. Three repos called out: `runladder` (this), `ladder-beta` (Pulse on Fly.io), `ladder` (original Rails). Pulse and Ladder stay in separate repos for now; consolidation is roadmap.

--- a/src/content/hq/_sections.ts
+++ b/src/content/hq/_sections.ts
@@ -70,6 +70,11 @@ export const HQ_SECTIONS: HqSection[] = [
     title: "Roadmap",
     intent: "What's in flight this week, what's queued, what's been shipped.",
   },
+  {
+    slug: "gtm",
+    title: "Go-to-Market",
+    intent: "Funnel, channels, sales motion, pricing strategy, public-launch sequence, metrics, risks.",
+  },
 ];
 
 export function findSection(slug: string): HqSection | undefined {

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -2,137 +2,120 @@
 title: API Protocols
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
-## Surfaces under one contract
+## Two surfaces, one to come
 
-Every Ladder surface calls the same scoring API. The web app, the Figma plugin, the Claude Skill, Pulse, and direct API customers all hit the same endpoints with the same payload shape and get the same response shape. That's the contract.
+Today, the Ladder API exists as **internal endpoints under `runladder.com/api/*`**, gated by Clerk session (web) or short-lived tokens (Plugin, Skill). There is no public `api.runladder.com` yet. The MCP server does not exist yet either.
 
-The API and MCP server live at **api.runladder.com**. (Migration in progress from the `ai-design-assistant` backend.)
+The future-target public API and MCP server are tracked in [Roadmap → api.runladder.com](/hq/roadmap#apirunladdercom-roadmap).
 
-## Auth
+## What exists today (verified in `src/app/api/`)
 
-| Caller | Auth method | Token shape |
-| --- | --- | --- |
-| Web app | Clerk session cookie | Standard browser auth |
-| Figma plugin | Plugin token (server-issued) | Bearer in `Authorization` header |
-| Claude Skill | Skill token (user-issued from dashboard) | Bearer in `Authorization` header |
-| Direct API | API key (issued in dashboard settings) | Bearer in `Authorization` header |
-| MCP | API key in MCP config | Per MCP transport |
+All endpoints below are real routes in this repo. Find them under `src/app/api/`. Auth is Clerk session for the web flow; short-lived server-issued tokens for Plugin and Skill.
 
-**Never put an API key in client-side code.** Plugin tokens and Skill tokens are scoped to a single user; API keys are scoped to an account and have higher rate limits but more blast radius.
+| Endpoint | Method | Auth | Purpose |
+| --- | --- | --- | --- |
+| `/api/score` | POST | Clerk session | Score an image (data URL). Primary web scoring endpoint. |
+| `/api/score/stream` | POST | Clerk session | Streaming variant of the score endpoint. |
+| `/api/framework` | GET | Public | The Ladder framework reference. Does not include rubric. |
+| `/api/top-100` | GET | Public | Top 100 listing. |
+| `/api/dashboard` | GET | Clerk session | Personal dashboard data. |
+| `/api/dashboard/scores` | GET | Clerk session | User's score history. |
+| `/api/dashboard/scores/[id]` | GET | Clerk session | Individual score detail. |
+| `/api/dashboard/scores/[id]/annotations` | GET, POST | Clerk session | Reviews pin annotations. |
+| `/api/dashboard/team` | GET | Clerk Org (team) | Team dashboard data. |
+| `/api/skill/token` | POST | Clerk session | Issue a Skill token for use in Claude.ai. |
+| `/api/skill/score` | POST | Skill token | Scoring callable from the Ladder Skill. |
+| `/api/plugin/issue-token` | POST | Clerk session | Issue a plugin token for use in the Figma plugin. |
+| `/api/plugin/verify-token` | POST | Plugin token | Token introspection for the plugin. |
+| `/api/plugin/analyze` | POST | Plugin token | Scoring callable from the Figma plugin. |
+| `/api/plugin/meta` | GET | Public | Plugin metadata (version, etc.). |
+| `/api/plugin/persist-score` | POST | Plugin token | Save a plugin-originated score. |
+| `/api/stripe/checkout` | POST | Clerk session | Pro upgrade Stripe checkout session. |
+| `/api/stripe/portal` | POST | Clerk session | Stripe customer portal. |
+| `/api/stripe/webhooks` | POST | Stripe webhook signature | Stripe event ingest. |
+| `/api/webhooks/clerk` | POST | Clerk webhook signature | Auto-grant `tier: team` on org join (shipped v0.3.0). |
+| `/api/auth-gate` | GET | Public | Site password-gate check for pre-launch. |
+| `/api/contact` | POST | Public | Contact form submission. |
+| `/api/vote` | POST | Clerk session | Top 100 voting. |
+| `/api/screenshot` | POST | Server-internal | Render a screenshot via puppeteer-core. |
+| `/api/admin/*` | GET, POST, etc. | `ADMIN_EMAILS` | Admin console backends. |
+
+### POST /api/score (the real shape)
+
+Reading [`src/app/api/score/route.ts`](https://github.com/drawbackwards/runladder/blob/main/src/app/api/score/route.ts):
+
+- Auth: requires Clerk session (`auth()`). Anonymous calls return 401 with `{ error, signup: true }`.
+- Bot detection: rejects common HTTP clients (curl, wget, python-requests, httpie, postman, scrapy, phantomjs) with 403.
+- Input: image data URL parsed via `parseImageDataUrl` from `src/lib/scoring.ts`. (Not the `{input: {url}, options: {surface}}` JSON shape this page used to claim.)
+- Limits: read from `src/lib/plans.ts` (`FREE_LIFETIME_LIMIT`, `PRO_MONTHLY_LIMIT`, `monthlyHardCapForTier`). Free tier hard-blocks past the lifetime cap.
+- Persistence: scores are written to Upstash Redis via `persistScoreEntry`.
+
+Detailed request/response shape lives in the route file. When the public API ships at `api.runladder.com`, we document the formal shape on that surface.
+
+## Auth tiers (today)
+
+| Caller | Auth method | Token type | Issued by |
+| --- | --- | --- | --- |
+| Web app | Clerk session cookie | n/a | Clerk |
+| Figma plugin | Plugin token | Short-lived bearer | `POST /api/plugin/issue-token` (Clerk session required) |
+| Claude Skill | Skill token | Short-lived bearer | `POST /api/skill/token` (Clerk session required) |
+| Admin | Email allowlist | n/a | `src/lib/admin.ts` (`ADMIN_EMAILS` env) |
+| Team Hub | Email allowlist | n/a | `src/lib/admin.ts` (`TEAM_EMAILS` env) |
+| Public API key | **Roadmap** | Bearer `ldr_live_...` | UI doesn't exist yet (issuance is roadmap) |
+| MCP | **Roadmap** | Bearer in MCP config | n/a |
+
+There is **no `/dashboard/settings` route today**. Plugin and Skill tokens are issued via API calls from in-product flows. The settings UI that issues these tokens is roadmap.
 
 ## Versioning
 
-Every response includes `X-Ladder-API-Version`. The current contract version lives in `src/lib/app-version.ts` as `CURRENT_API_VERSION`. Bump rules:
+Every response from `src/app/api/*` already carries `X-Ladder-API-Version` (or will once the protocol is fully applied; check `src/lib/app-version.ts` for `CURRENT_API_VERSION`, currently `1.0.0`).
+
+Bump rules when the public API ships:
 
 - **Patch** (`1.0.x`): bug fixes, no contract change.
 - **Minor** (`1.x.0`): additive fields, backwards compatible.
 - **Major** (`x.0.0`): breaking change. Communicate in `CHANGELOG.md` and notify Pro+ customers by email.
 
-Every surface also ships its own version (web app, Skill bundle, plugin). See [Architecture → Versioning](/hq/architecture#versioning).
+Surface versions (independent):
+
+- `CURRENT_APP_VERSION` in `src/lib/app-version.ts` (web app)
+- `CURRENT_API_VERSION` in `src/lib/app-version.ts` (API contract)
+- `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (Skill bundle)
+- Plugin version in `drawbackwards/ai-design-assistant`
+- `ladder-beta` and `ladder` track their own versions in their repos
 
 ## Rate limits
 
-Per-tier monthly query limits. See [Roles](/hq/roles) for the full table.
+Implemented in `src/app/api/score/route.ts` using helpers from `src/lib/plans.ts`. Per-tier monthly limits live in code. The values on [/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only) reflect intent; the canonical numbers are in `plans.ts`.
 
-| Tier | Monthly queries | Burst | Overage |
-| --- | --- | --- | --- |
-| Free | 5 lifetime | 1/sec | Hard cap, no overage |
-| Pro | 1,000 | 10/sec | Tiered overage billing |
-| Teams | 25,000 pool | 20/sec | Tiered overage billing |
-| Pulse | 50,000 pool | 50/sec | Tiered overage billing |
+| Tier | Monthly queries | Notes |
+| --- | --- | --- |
+| Free | 5 lifetime | Hard-blocked past cap, no overage |
+| Pro | `PRO_MONTHLY_LIMIT` | Tiered overage (roadmap to verify exact billing) |
+| Teams | 25,000 pool | Sold via MSA + SOW |
+| Pulse | 50,000 pool | Sold via direct engagement |
 
-Rate-limit responses use HTTP 429 with `Retry-After` and `X-Ladder-Quota-Remaining` headers.
+Rate-limit responses target HTTP 429 with `Retry-After` and `X-Ladder-Quota-Remaining` headers once the public API ships. Today's responses are 401/403 with tier-specific messages.
 
 ## Never expose the prompt
 
-Server-side only. Every surface must be a thin client.
+Server-side only. Every surface is a thin client.
 
 - Prompts, rubric text, scoring logic, model parameters: server-side only.
 - API responses include the final score and breakdown, never the reasoning trace or rubric tokens.
-- The `scripts/check-no-prompt-leak.mjs` pre-build check exists for this. If it trips, fix the leak.
+- `scripts/check-no-prompt-leak.mjs` runs pre-build. If it trips, fix the leak.
 
 See [Decisions Log → Never expose prompts](/hq/decisions#never-expose-prompts-rubric-or-scoring-logic).
 
-## Endpoint shape
+## Public API + MCP (roadmap, not built)
 
-The public API exposes the scoring engine and the framework reference. All endpoints sit under `https://api.runladder.com/v1/`.
+The public Ladder API at `api.runladder.com` and the MCP server are not in code yet. The full plan, with concrete steps, lives at [Roadmap → api.runladder.com](/hq/roadmap#apirunladdercom-roadmap).
 
-| Endpoint | Method | Purpose |
-| --- | --- | --- |
-| `/v1/score` | POST | Score a URL or image. Primary endpoint. |
-| `/v1/score/[id]` | GET | Fetch a stored score by ID (Pro+ history). |
-| `/v1/framework` | GET | The Ladder framework reference (names, ranges, definitions). Cacheable. Does not include rubric. |
-| `/v1/account` | GET | Caller's account info: tier, remaining quota, surfaces enabled. |
-| `/v1/account/keys` | GET, POST, DELETE | API key management for the calling account. |
+Until that ships, anything you read in this page about "v1/score" paths, MCP tools, or Bearer API keys is the future-target contract, not today's reality.
 
-### POST /v1/score request
+## Key rotation (target state)
 
-```json
-{
-  "input": { "url": "https://example.com" },
-  "options": { "surface": "web", "include": ["breakdown", "a11y"] }
-}
-```
-
-`input` accepts either `url` (string) or `image` (base64 or URL). `options.surface` is required so we can attribute usage to the right tier counter. `options.include` is optional; defaults to `["breakdown"]`. A11y and UX copywriting requested by Free callers return a `403 pro_required` error.
-
-### POST /v1/score response
-
-```json
-{
-  "score": 3.42,
-  "rung": "Comfortable",
-  "rungColor": "#eab308",
-  "breakdown": { "...": "per-rung subscores" },
-  "a11y": { "...": "Pro only" },
-  "uxCopy": { "...": "Pro only" },
-  "scoredAt": "2026-05-19T20:14:33Z",
-  "scoreId": "scr_01HX..."
-}
-```
-
-Response headers: `X-Ladder-API-Version`, `X-Ladder-Quota-Remaining`, `X-Ladder-Surface`.
-
-## MCP server
-
-The MCP server exposes scoring as a tool callable by any MCP-aware AI agent (Claude, Cursor, custom agents). Available at `https://api.runladder.com/mcp`.
-
-### MCP tool surface
-
-| Tool | Input | Output |
-| --- | --- | --- |
-| `ladder.score` | `{ url?: string, image?: string, surface: string }` | `{ score, rung, rungColor, breakdown, scoreId }` |
-| `ladder.framework` | `{}` | The framework reference (rungs, ranges, definitions). |
-| `ladder.account` | `{}` | Caller's tier and remaining quota. |
-
-The MCP server is a thin transport over the same `/v1/score` endpoint. Agents that read `ladder.framework` first get the Ladder vocabulary so they can interpret the score they get back. They never see the rubric or the prompts.
-
-### MCP config example
-
-For Claude Desktop, the user adds an entry to their MCP config:
-
-```json
-{
-  "mcpServers": {
-    "ladder": {
-      "url": "https://api.runladder.com/mcp",
-      "headers": { "Authorization": "Bearer ldr_live_..." }
-    }
-  }
-}
-```
-
-API keys for MCP are issued in `/dashboard/settings`, same surface as direct API keys.
-
-### Why MCP matters
-
-This surface is what makes Ladder agent-native. Every AI workflow that touches design (a coding agent reviewing a UI, a research agent comparing competitors, a PM agent triaging customer feedback) can call `ladder.score` and get a number to act on. The MCP shape is part of the public-launch gate. See [Decisions Log → Public launch](/hq/decisions#public-launch-is-gated-on-mcp-skill-and-api-being-live).
-
-## Key rotation
-
-API keys are rotatable from `/dashboard/settings`. Skill tokens rotate from the same page. Old tokens are valid for 24 hours after rotation to give callers time to update config.
-
-Admin-issued tokens (super admin or admin) rotate by editing `SUPER_ADMIN_EMAILS` or `ADMIN_EMAILS`. The hardcoded super admin list requires PR + deploy + passphrase.
+Once API key issuance UI ships, keys rotate from `/dashboard/settings`. Old tokens valid for 24 hours after rotation. Today, Plugin and Skill tokens rotate by re-issuing via the API. Admin allowlists rotate via `ADMIN_EMAILS` env vars; `SUPER_ADMIN_EMAILS` rotates only via PR + deploy + Ward's passphrase.

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -96,7 +96,7 @@ Implemented in `src/app/api/score/route.ts` using helpers from `src/lib/plans.ts
 | Free | 5 lifetime | Hard-blocked past cap, no overage |
 | Pro | `PRO_MONTHLY_LIMIT` | Tiered overage (roadmap to verify exact billing) |
 | Teams | 25,000 pool | Sold via MSA + SOW |
-| Pulse | 50,000 pool | Sold via direct engagement |
+| Pulse | Custom (set per engagement) | Sold via direct Drawbackwards engagement |
 
 Rate-limit responses target HTTP 429 with `Retry-After` and `X-Ladder-Quota-Remaining` headers once the public API ships. Today's responses are 401/403 with tier-specific messages.
 

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,44 +2,61 @@
 title: Architecture
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
-## One scoring engine, five thin clients
+## One scoring framework, three codebases (today)
 
-Every Ladder surface is a thin client over the same scoring engine. The framework, the rubric, the prompts, and the model invocation live server-side. Surfaces do nothing but capture input (URL, screenshot, feedback, Figma frame, MCP call), send it to the API, and render the result.
+Ladder is one framework and one customer-facing brand, but the code today lives across three separate repositories. Pulse and the original Ladder will eventually fold into runladder, but that's a future decision, not active work. See [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now).
 
-This is non-negotiable. See [Decisions Log](/hq/decisions#never-expose-prompts) for why.
+## Codebase map
+
+| Repo | Stack | Hosting | Surfaces | Notes |
+| --- | --- | --- | --- | --- |
+| `drawbackwards/runladder` | Next.js 16, React 19, TypeScript, Tailwind 4 | Vercel | Marketing, public scoring tool, dashboard, Reviews, Pulse marketing page, Plugin backend, Skill backend, admin, HQ | This repo. Where most active development happens. |
+| `drawbackwards/ai-design-assistant` | Plugin codebase + first-gen API | Vercel | Figma plugin bundle (v1.0.6), legacy plugin/API endpoints | Plugin source lives here. Some endpoints have migrated to runladder. |
+| `drawbackwards/ladder-beta` | Next.js + Prisma | Fly.io | Pulse product surface, Pulse data pipeline | Where the live Pulse engagement (Lumin Digital) runs. Default branch `dev`. |
+| `drawbackwards/ladder` | Ruby on Rails | (legacy) | Original Ladder backend | Predecessor to ladder-beta. Still touched occasionally. `ladder-beta` connects via `RAILS_BASE_API_URL`. |
+
+## What lives where (current truth, not the future state)
+
+| Concern | Today | Future |
+| --- | --- | --- |
+| Marketing pages, public scoring, dashboard | `runladder` | Same |
+| Figma plugin source | `ai-design-assistant` | Likely stays separate (Figma deploy target) |
+| Plugin backend endpoints (`/api/plugin/*`) | `runladder` | Same |
+| Claude Skill bundle source | `runladder` (`src/lib/skill-version.ts`, `scripts/sync-skill-version.mjs`) | Same |
+| Claude Skill backend (`/api/skill/*`) | `runladder` | Same |
+| Public Ladder API (api.runladder.com) | Does not exist yet | Roadmap, see [Roadmap](/hq/roadmap#apirunladdercom-roadmap) |
+| MCP server | Does not exist yet | Roadmap |
+| Pulse marketing page (`/pulse`) | `runladder` | Same |
+| **Pulse product + data pipeline** | **`ladder-beta` on Fly.io** | Eventually fold into `runladder`, no timeline |
+| **Original Ladder (Rails)** | **`ladder` repo** | Eventually fold or deprecate, no timeline |
+| Admin console (`/admin`) | `runladder` | Same |
+| Engineering standards docs | `drawbackwards/engineering-standards` | Same |
 
 ## System diagram
 
+This diagram shows the future-target architecture (one engine, thin clients). Today, Pulse uses its own engine in `ladder-beta`. Consolidation onto a single shared engine is roadmap.
+
 <ArchitectureDiagram />
 
-## Where the code lives
+## Shared services (target state, partial today)
 
-| Concern | Repo / location |
-| --- | --- |
-| Web app (runladder.com) | `drawbackwards/runladder` (this repo) |
-| Figma plugin | `drawbackwards/ai-design-assistant` |
-| Claude Skill | `drawbackwards/runladder` (`scripts/sync-skill-version.mjs` syncs the bundle) |
-| API + MCP | Migrating from `ai-design-assistant` into this repo over time |
-| Pulse | `drawbackwards/runladder` (`/dashboard/pulse`) |
-| Admin console | `drawbackwards/runladder` (`/admin`) |
+**Scoring engine.** Anthropic Claude with the Ladder rubric prompt. Server-side only. Today this runs in `runladder` for web, plugin, and Skill surfaces. Pulse runs its own scoring stack in `ladder-beta`. Consolidation is roadmap.
 
-## Shared services
+**Auth.** Clerk for human users on `runladder` surfaces. Plugin token + Skill token (server-issued via `/api/plugin/issue-token` and `/api/skill/token`). API keys for `api.runladder.com` are roadmap (the issuance UI doesn't exist yet either).
 
-**Scoring engine.** Anthropic Claude with the Ladder rubric prompt. Server-side only. Same engine across every surface so a score from the Figma plugin matches a score from the API.
+**Billing.** Stripe. Subscriptions live in `runladder`. Pulse and the legacy Ladder engagement (Lumin Digital) bill outside of Stripe via Drawbackwards agency contracts.
 
-**Auth.** Clerk for human users on web surfaces. API keys for developer surfaces (API, MCP). Same identity, different transport.
-
-**Billing.** Stripe. Subscriptions for Pro and Pulse, usage-based metering for over-cap scoring. See [API Protocols](/hq/api) for tier limits.
-
-**Data.** Upstash Redis today. Postgres planned for richer analytics and scoring history. Migration not yet scheduled.
+**Data.** Upstash Redis in `runladder` for scoring history and tier counters. Pulse uses Prisma + Postgres on Fly.io in `ladder-beta`. Postgres in `runladder` is planned but not scheduled.
 
 ## Versioning
 
 Every surface ships its own version and shows it to users. See [API Protocols](/hq/api) for the contract.
 
 - `src/lib/app-version.ts`: runladder web app (`CURRENT_APP_VERSION`) and API (`CURRENT_API_VERSION`)
-- `src/lib/skill-version.ts`: Figma skill bundle (`CURRENT_SKILL_VERSION`)
+- `src/lib/skill-version.ts`: Skill bundle (`CURRENT_SKILL_VERSION`)
 - Bump on every user-visible change. Always add a matching `CHANGELOG.md` entry.
+
+`ladder-beta` and `ladder` versions live in their own repos and follow their own bump cadence. Their version stamps are not yet visible from `/hq`. Tracking is roadmap.

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -13,6 +13,23 @@ If you want to challenge a decision, file an issue in GitHub with the proposed c
 
 ---
 
+## /hq documents PUBLIC pricing only (2026-05-19)
+
+**Pro at $1,000/mo is public on runladder.com/pricing.** Team and Pulse are listed as "Custom" publicly, so they show as Custom in /hq too. Specific internal targets (Team floor, Pulse engagement ACVs, Ladder Lift price bands, customer dollar values) live in Ward's memory and the Drawbackwards sales pipeline, not in /hq.
+
+Why: `/hq` is read by everyone in `TEAM_EMAILS` or `ADMIN_EMAILS`. That includes engineering audit and design roles who do not need to see internal sales numbers. The principle: if a price isn't on `/pricing`, it doesn't belong here.
+
+How to apply:
+
+- Pricing references in `/hq` use only what's on runladder.com/pricing: Free 5-score trial, Pro $1,000/mo with 2,000 scores/mo, Team Custom, Pulse Custom.
+- Do NOT write specific Team or Pulse dollar amounts in `/hq`.
+- Do NOT name customer ACVs.
+- Do NOT include Ladder Lift price bands.
+- For strategy and GTM, talk qualitatively about expansion ("Pro to Team is a step change in scale, sold via Drawbackwards engagement") instead of specific numbers.
+- Ward and Michael keep the full pricing context in non-/hq memory. Ask if you need a number for a sales conversation.
+
+---
+
 ## Every claim of "live" in /hq must point to a route, file, or PR (2026-05-19)
 
 **UNBREAKABLE rule.** A feature is tagged Live only if you can name the file path, route, or PR that proves it. Otherwise tag it In flight (code exists, partial) or Roadmap (no code yet).
@@ -33,7 +50,7 @@ How to apply:
 
 **Pulse runs in `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io). The original Ladder backend runs in `drawbackwards/ladder` (Rails). Both stay separate. Eventual consolidation into `runladder` is a future decision, not active work.**
 
-Why: Pulse is a working revenue line (Lumin Digital is paying $90K for the current engagement) and the codebase is mature enough that pulling it into `runladder` mid-engagement would create risk without near-term upside. The Rails original is the dependency `ladder-beta` reads from (`RAILS_BASE_API_URL`), so it goes when `ladder-beta` goes. Trying to consolidate now slows down both the public launch on `runladder` and the customer work in `ladder-beta`.
+Why: Pulse is a working revenue line (Lumin Digital is the live engagement) and the codebase is mature enough that pulling it into `runladder` mid-engagement would create risk without near-term upside. The Rails original is the dependency `ladder-beta` reads from (`RAILS_BASE_API_URL`), so it goes when `ladder-beta` goes. Trying to consolidate now slows down both the public launch on `runladder` and the customer work in `ladder-beta`.
 
 How to apply:
 
@@ -97,24 +114,24 @@ How to apply: ship MCP, Skill, and v1 of the public API before any paid acquisit
 
 ---
 
-## Pricing: Free 5-lifetime, Pro $250 self-serve, Teams contact-only
+## Public pricing: Free 5-lifetime, Pro $1,000/mo self-serve, Team and Pulse Custom
 
-**Free** is a try-before-you-buy at 5 scores per account, ever. **Pro** is $250 for individuals, self-serve on Stripe. **Teams** is contact-only, sold as a Drawbackwards engagement (see Teams sales model below).
+**Free** is a try-before-you-buy at 5 scores per account, ever. **Pro** is $1,000/mo for individuals, self-serve on Stripe. **Team** is publicly Custom (Apply to be a beta tester CTA on `/pricing`). **Pulse** is publicly Custom (Contact CTA).
 
-Query allowances on the platform:
+Public limits (visible on `/pricing` and enforced in `src/lib/plans.ts`):
 
-| Tier | Monthly queries | Surfaces |
+| Tier | Limit | Surfaces |
 | --- | --- | --- |
-| Free | 5 lifetime | Web only |
-| Pro | 1,000 | All surfaces |
-| Teams | 25,000 pool | All surfaces |
-| Pulse | 50,000 pool | All surfaces |
+| Free | 5 lifetime scores | Web + Skill + Figma |
+| Pro | 2,000 scores/mo (soft cap, hard cap 2x) | All surfaces + API keys (when public API ships) |
+| Team | 25,000 pooled scores/mo (Beta) | All Pro features + manager workflow |
+| Pulse | Custom (set per engagement) | All Team features + Pulse data ingest in `ladder-beta` |
 
-Overage is tiered, not blocked.
+Pro went from $250/mo to $1,000/mo in v0.4.8 ([PR #166](https://github.com/drawbackwards/runladder/pull/166)) on 2026-04-28. Subscribe button is live via Stripe.
 
-Why: the Free → Pro gap was a leaky funnel when Free was generous. Lifetime cap forces the upgrade decision. Teams stays contact-only because the buyer is a Director of Design, not a credit-card buyer, and the deal value supports a sales motion.
+Why: the Free to Pro gap was a leaky funnel when Free was generous. Lifetime cap forces the upgrade decision. Team stays contact-only because the buyer is a Director of Design, not a credit-card buyer, and the deal value supports a sales motion.
 
-How to apply: don't offer ad-hoc discounts on Pro. Don't offer self-serve Teams. If a buyer pushes for self-serve at the Teams price, that's a Ladder Lift candidate.
+How to apply: don't offer ad-hoc discounts on Pro. Don't offer self-serve Team. Internal price targets stay in memory per [/hq documents PUBLIC pricing only](#hq-documents-public-pricing-only).
 
 ---
 
@@ -128,13 +145,13 @@ How to apply: any "team plan signup" copy on runladder.com routes to a contact f
 
 ---
 
-## Ladder Lift bridges Free → Teams
+## Ladder Lift is an internal concept (not yet productized)
 
-**Ladder Lift** is a named Drawbackwards engagement: audit + workshop + 3 months of Teams access at $18–25K. It lives on drawbackwards.com, not runladder.com.
+**Ladder Lift** is a concept Ward is shaping internally: a Drawbackwards engagement that bridges sub-3.0 free scores into a Team subscription. It is not yet a published product. Specifics (engagement stages, price band, deliverables) live in memory, not in `/hq`.
 
-Why: sub-3.0 scores on the public scoring tool are a high-intent qualifier. We need a CTA that captures that intent at a price point a Director can approve without procurement. Ladder Lift is that bridge.
+Why: the productization isn't ready. The shape (Drawbackwards audit + workshop + month-three Team handoff) is roughly defined, but the public-facing pitch and the runladder.com surface are not. Naming a price in `/hq` would commit to a number we haven't committed to publicly.
 
-How to apply: any score under 3.0 on a /score result for a non-signed-in user should surface a Lift CTA. Pro and Teams users see the upgrade path instead.
+How to apply: do not document Lift specifics in `/hq`. In the meantime, sub-3.0 scores on `/score` should route to a generic "Talk to Drawbackwards about ongoing design work" CTA (see [Roadmap](/hq/roadmap) for the CTA wiring). When Lift productizes, this entry updates to reflect the public shape.
 
 ---
 

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## How to use this page
@@ -10,6 +10,37 @@ lastPr: 178
 The why behind big choices. Read this before you push back on a feature, a price, or a roadmap call. Most decisions look arbitrary until you know the constraint that drove them. New entries go at the top with a date and one-line rule.
 
 If you want to challenge a decision, file an issue in GitHub with the proposed change and link the entry. We update entries when the world changes, never silently.
+
+---
+
+## Every claim of "live" in /hq must point to a route, file, or PR (2026-05-19)
+
+**UNBREAKABLE rule.** A feature is tagged Live only if you can name the file path, route, or PR that proves it. Otherwise tag it In flight (code exists, partial) or Roadmap (no code yet).
+
+Why: the v0.5.0 / v0.5.1 seed of `/hq` invented a few things that didn't exist (an `api.runladder.com` domain that wasn't registered, a `/dashboard/settings` route that doesn't exist, an MCP server with three named tools). Ward caught it in the v0.5.2 audit. The fix is a discipline: no Live without evidence. The fix is also a workflow: I do not write a feature row claiming Live without first grepping the codebase.
+
+How to apply:
+
+- Every row in [/hq/features](/hq/features) Live column must have an Evidence column pointing to a file or PR.
+- Every flow in [/hq/journeys](/hq/journeys) tagged Live must reference a real route handler.
+- Every endpoint in [/hq/api](/hq/api) Live table must exist under `src/app/api/`.
+- If the answer to "does this exist" is "kind of" or "partially", it's In flight, not Live.
+- If the answer is "we plan to", it's Roadmap.
+
+---
+
+## Pulse and original Ladder stay in separate repos for now (2026-05-19)
+
+**Pulse runs in `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io). The original Ladder backend runs in `drawbackwards/ladder` (Rails). Both stay separate. Eventual consolidation into `runladder` is a future decision, not active work.**
+
+Why: Pulse is a working revenue line (Lumin Digital is paying $90K for the current engagement) and the codebase is mature enough that pulling it into `runladder` mid-engagement would create risk without near-term upside. The Rails original is the dependency `ladder-beta` reads from (`RAILS_BASE_API_URL`), so it goes when `ladder-beta` goes. Trying to consolidate now slows down both the public launch on `runladder` and the customer work in `ladder-beta`.
+
+How to apply:
+
+- Track Pulse features and surfaces in [/hq/features → Ladder Pulse](/hq/features#ladder-pulse--drawbackwardsladder-beta) and [/hq/journeys → Ladder Pulse](/hq/journeys#ladder-pulse--live-runs-in-a-separate-codebase). State the repo and stack honestly.
+- Track Rails original in [/hq/features → Original Ladder](/hq/features#original-ladder--drawbackwardsladder).
+- The `/pulse` page on runladder.com is marketing only. Do not pretend it's the product surface.
+- Consolidation decision is on the [Roadmap](/hq/roadmap) as a future item, no commitment to a quarter.
 
 ---
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,121 +2,152 @@
 title: Feature Inventory
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## How to read this page
 
-Every Ladder feature with surface, role gating, status, and link to the PR that shipped it. One row per feature. Status values: **Shipped**, **In flight**, **Roadmap**, **Paused**.
+Every Ladder feature with surface, role gating, status, and link to the PR (or repo + file) that proves it. One row per feature. Status values:
 
-When you ship a feature, add the row here in the same PR. Use this template:
+- **Live**: shipped, in production, has a route/file/PR that proves it
+- **In flight**: code exists but incomplete, not user-facing, or behind a flag
+- **Roadmap**: no code yet
+
+If a row claims Live, it must point to a file, route, or PR. Otherwise it's Roadmap. This rule lives in [Decisions Log](/hq/decisions#every-claim-of-live-in-hq-must-point-to-a-route-file-or-pr).
+
+When you ship a feature, add the row here in the same PR. Template:
 
 ```
-| Feature | Roles | Status | Linked PR |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| Feature name | free / pro / teams / pulse / admin | Shipped | #176 |
+| Feature name | free / pro / teams / pulse / admin | Live | PR #176 or src/path |
 ```
 
-## Web app (runladder.com)
+## Web app: `drawbackwards/runladder`
 
-| Feature | Roles | Status | Linked PR |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| Public scoring tool (`/score`) | All signed-in | Shipped | - |
-| Personal dashboard (`/dashboard`) | All signed-in | Shipped | - |
-| Framework page (`/framework`) | Public | Shipped | - |
-| Sign-up required for scoring | All | Shipped (v0.4.14) | [#172](https://github.com/drawbackwards/runladder/pull/172) |
-| Reviews on dashboard | Pro+ | Shipped (v0.4.15) | [#173](https://github.com/drawbackwards/runladder/pull/173) |
-| Active Reviews on team dashboard | Team Members + Leaders | Shipped (v0.4.16) | [#174](https://github.com/drawbackwards/runladder/pull/174) |
-| Reviews: request flow, pins, scoring integration | Pro+ | Shipped (v0.4.17) | [#175](https://github.com/drawbackwards/runladder/pull/175) |
-| Team pool meter (25K cap rendered prominently) | Team Leaders | Shipped (v0.4.18) | [#176](https://github.com/drawbackwards/runladder/pull/176) |
-| Ladder HQ internal team hub (`/hq`) | Admin + Team | Shipped (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
-| Pricing page (Free 5-lifetime, Pro $250, Teams contact) | Public | In flight | - |
-| Top 100 ranked products (`/top-100`) | Public | Roadmap | - |
-| Public profile (`/[username]`) | All signed-in | Roadmap | - |
-| Ladder Lift CTA on sub-3.0 scores | Free | Roadmap | - |
-| Blog (`/blog`) | Public | Shipped (content ongoing) | - |
-| Teardowns (`/teardowns`) | Public | Roadmap | - |
+| Public scoring tool (`/score`) | All signed-in | Live | `src/app/score/` |
+| Personal dashboard (`/dashboard`) | All signed-in | Live | `src/app/dashboard/` |
+| Framework page (`/framework`) | Public | Live | `src/app/framework/` |
+| Sign-up required for scoring | All | Live (v0.4.14) | [#172](https://github.com/drawbackwards/runladder/pull/172), `src/app/api/score/route.ts` |
+| Reviews on dashboard | Pro+ | Live (v0.4.15) | [#173](https://github.com/drawbackwards/runladder/pull/173) |
+| Active Reviews on team dashboard | Team Members + Leaders | Live (v0.4.16) | [#174](https://github.com/drawbackwards/runladder/pull/174) |
+| Reviews: request flow, pins, scoring integration | Pro+ | Live (v0.4.17) | [#175](https://github.com/drawbackwards/runladder/pull/175) |
+| Team pool meter (25K cap rendered prominently) | Team Leaders | Live (v0.4.18) | [#176](https://github.com/drawbackwards/runladder/pull/176) |
+| Ladder HQ internal team hub (`/hq`) | Admin + Team | Live (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
+| HQ content + PR-stamp protocol | Admin + Team | Live (v0.5.1) | [#178](https://github.com/drawbackwards/runladder/pull/178) |
+| Blog (`/blog`) | Public | Live | `src/app/blog/`, content ongoing |
+| `/pulse` marketing landing page | Public | Live | `src/app/pulse/page.tsx` (NOT the Pulse product surface, just marketing) |
+| Pricing page overhaul (Free 5-lifetime, Pro $250, Teams contact) | Public | In flight | Pricing page exists; needs verification it matches the Decisions Log floors |
+| Top 100 ranked products (`/top-100`) | Public | In flight | `src/app/top-100/` page + `/api/top-100` route exist; full ranking flow TBD |
+| Public profile (`/[username]`) | All signed-in | Roadmap | No route yet |
+| Ladder Lift CTA on sub-3.0 scores | Free | Roadmap | No code yet |
+| Teardowns (`/teardowns`) | Public | Roadmap | No route yet |
+| `/dashboard/settings` (account, billing, API keys) | All signed-in | Roadmap | No route yet |
 
-## Figma plugin
+## Figma plugin: `drawbackwards/ai-design-assistant` + runladder backend
 
-Repo: `drawbackwards/ai-design-assistant`. Bundle version synced via `scripts/sync-skill-version.mjs`. Current version 1.0.6.
+Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`) live in `runladder`.
 
-| Feature | Roles | Status | Notes |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| In-canvas frame scoring | Pro+ | Shipped | Plugin token auth |
-| Inline score result + rung breakdown | Pro+ | Shipped | - |
-| Free 5-lifetime cap inside plugin | Free | Shipped | Same cap as web |
-| Plugin v1.0.6 bundle sync from runladder | All | Shipped (v0.4.18 era) | - |
-| Batch scoring of a frame stack | Pro+ | Roadmap | See [Journeys](/hq/journeys) for open questions |
-| Marketplace listing demo flow | Public | Roadmap | Gates the relaunch |
+| In-canvas frame scoring | Pro+ | Live | `src/app/api/plugin/analyze/route.ts` |
+| Plugin token issuance | All signed-in | Live | `src/app/api/plugin/issue-token/route.ts` |
+| Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
+| Score persistence from plugin | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
+| Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
+| Plugin bundle (v1.0.6) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
+| Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |
+| Marketplace listing demo flow | Public | Roadmap | Gates the relaunch (re-review restarted 2026-04-18 per memory) |
+| Batch scoring of a frame stack | Pro+ | Roadmap | Open question per Journeys |
 
-## Claude Skill
+## Claude Skill: runladder backend + bundle
 
-Bundle version in `src/lib/skill-version.ts` as `CURRENT_SKILL_VERSION`. Currently `1.0.6` synced.
+Bundle source and `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (currently `1.0.6`). Backend endpoints in `runladder` under `/api/skill/*`.
 
-| Feature | Roles | Status | Notes |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| Score a URL or image from a Claude conversation | Pro+ | In flight | Skill token auth |
-| Skill token issuance in `/dashboard/settings` | All signed-in | Roadmap | Required for Skill auth |
-| Structured score block rendered in conversation | All Skill users | In flight | - |
-| Free 5-lifetime cap inside Skill | Free | Roadmap | Matches web and plugin |
-| Anthropic Skill registry listing | Public | Roadmap | One of three public-launch gates |
+| Skill bundle v1.0.6 | All | Live | `src/lib/skill-version.ts`, `scripts/sync-skill-version.mjs` |
+| Skill token issuance | All signed-in | Live | `src/app/api/skill/token/route.ts` |
+| Score from Claude conversation | Skill token | Live | `src/app/api/skill/score/route.ts` |
+| Manual install (Ward and team use it today) | All | Live | Installed via `~/.claude/skills` or workspace |
+| Public plugin marketplace (`marketplace.json` in `drawbackwards/runladder`) | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
+| Submission to `anthropics/skills` public marketplace | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
+| Teams enterprise deployment (admin workspace deploy) | Teams | Roadmap | Shipped by Anthropic Dec 2025, we have not used it yet |
 
-## Ladder Pulse
+## Ladder Pulse: `drawbackwards/ladder-beta`
 
-Lives at `/dashboard/pulse`. First customer is Lumin Digital (engagement Sept 2025 to Sept 2026, $90K).
+**Pulse runs in a separate codebase: `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io).** The `/pulse` route on runladder.com is a marketing landing page only. Live engagement: Lumin Digital (Sept 2025 to Sept 2026, $90K).
 
-| Feature | Roles | Status | Notes |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| Pulse dashboard at `/dashboard/pulse` | Pulse | In flight | Lumin live |
-| Feedback batch ingest endpoint | Pulse | In flight | Lumin pipeline |
-| Aggregate trends (rung distribution, weakest rung) | Pulse | In flight | - |
+| Pulse dashboard (in `ladder-beta`) | Pulse | Live | `drawbackwards/ladder-beta` app, hosted on Fly.io |
+| Alchemer data ingest | Pulse | Live | `ALCHEMER_API_BASE_URL` integration in `ladder-beta` |
+| Prisma + Postgres data layer | Pulse | Live | `drawbackwards/ladder-beta/prisma/schema.prisma` |
+| OpenAI-based scoring engine | Pulse | Live | `OPEN_AI_API_KEY` in `ladder-beta` (NOT shared with runladder's Anthropic engine) |
+| Pulse marketing page (`/pulse`) | Public | Live | `src/app/pulse/page.tsx` in `runladder` |
+| Aggregate trends (rung distribution, weakest rung) | Pulse | In flight | Per Lumin pipeline; verification lives in `ladder-beta` |
 | Drill-down on individual feedback items | Pulse | Roadmap | - |
 | Theme clustering across feedback | Pulse | Roadmap | - |
 | Teams bundle handoff for Pulse customers | Pulse | Roadmap | Lumin interested per memory |
+| Consolidation into `runladder` | All | Roadmap (no timeline) | See [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now) |
 
-## API and MCP
+## Original Ladder: `drawbackwards/ladder`
 
-API and MCP server live at `api.runladder.com` (migration in progress from `ai-design-assistant`). API version in `src/lib/app-version.ts` as `CURRENT_API_VERSION` (currently 1.0.0).
+**The original Ladder backend is a Ruby on Rails app in `drawbackwards/ladder`.** Predates the Next.js rewrite. Still touched (last updated 2026-04-24). `ladder-beta` connects to it via `RAILS_BASE_API_URL`.
 
-| Feature | Roles | Status | Notes |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| `POST /v1/score` (single score) | Pro+ | In flight | Migration from plugin backend |
-| `X-Ladder-API-Version` response header on every call | All | In flight | Versioning protocol |
-| API key issuance in `/dashboard/settings` | Pro+ | Roadmap | Required for direct API |
-| Rate-limit response (429 + `Retry-After`) | All | Roadmap | Tier-based quotas |
-| MCP server with `ladder.score` tool | Pro+ | In flight | One of three public-launch gates |
-| MCP config and connection docs | Public | Roadmap | api.runladder.com |
-| Public OpenAPI spec | Public | Roadmap | One of three public-launch gates |
+| Original Rails backend | Internal | Live (legacy) | `drawbackwards/ladder`, default branch `master` |
+| Connection from `ladder-beta` | Internal | Live | `RAILS_BASE_API_URL` env in ladder-beta |
+| Deprecation or fold into runladder | All | Roadmap (no timeline) | See [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now) |
 
-See [API Protocols](/hq/api) for the contract.
+## Public API + MCP: Roadmap
+
+The dedicated public surface at `api.runladder.com` does not exist (domain doesn't resolve as of 2026-05-19). Today's scoring endpoints live at `runladder.com/api/*` and are internal-focused (Clerk session or short-lived tokens). See [API Protocols](/hq/api) and [Roadmap → api.runladder.com](/hq/roadmap#apirunladdercom-roadmap).
+
+| Feature | Status | Evidence |
+| --- | --- | --- |
+| `api.runladder.com` domain registered + configured | Roadmap | DNS returns NXDOMAIN today |
+| Public `POST /v1/score` with Bearer auth | Roadmap | No code yet |
+| Public `GET /v1/framework` | Roadmap | Internal `/api/framework` exists; public version pending |
+| API key issuance UI (`/dashboard/settings`) | Roadmap | No route yet |
+| Rate-limit response (429 + `Retry-After`) | Roadmap | Today returns 401/403 with tier-specific messages |
+| MCP server with `ladder.score`, `ladder.framework`, `ladder.account` tools | Roadmap | No code yet |
+| OpenAPI spec | Roadmap | No spec written |
+| Docs site at `api.runladder.com` | Roadmap | No site |
 
 ## Admin console (`/admin`)
 
 Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 
-| Feature | Roles | Status | Notes |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| User records + tier management | Admin | Shipped | `/admin` |
-| Invite codes (generate, view, copy, revoke) | Admin | Shipped | `/admin` |
-| Evaluations (rubric evaluation runs) | Admin | Shipped | `/admin/evaluations` |
-| Feedback inbox | Admin | Shipped | `/admin/feedback` |
-| Comps (comparison scoring runs) | Admin | Shipped | `/admin/comps` |
-| Plugin backend proxy (`pluginFetch`) | Admin | Shipped | `src/lib/admin.ts` |
-| Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Shipped | Hardcoded, passphrase-gated |
+| User records + tier management | Admin | Live | `src/app/admin/page.tsx` |
+| Invite codes (generate, view, copy, revoke) | Admin | Live | `src/app/admin/page.tsx` |
+| Evaluations (rubric evaluation runs) | Admin | Live | `src/app/admin/evaluations/page.tsx` |
+| Feedback inbox | Admin | Live | `src/app/admin/feedback/page.tsx` |
+| Comps (comparison scoring runs) | Admin | Live | `src/app/admin/comps/page.tsx` |
+| Plugin backend proxy (`pluginFetch`) | Admin | Live | `src/lib/admin.ts` |
+| Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Live | `src/lib/admin.ts`, hardcoded, passphrase-gated |
+| Webhook handler for Clerk org join | Auto | Live (v0.3.0) | `src/app/api/webhooks/clerk/route.ts` |
 
 ## Ladder HQ (`/hq`)
 
 The internal team hub. Gated by `TEAM_EMAILS` (admins also pass).
 
-| Feature | Roles | Status | Linked PR |
+| Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| `/hq` route, sidebar, 11 sections | Admin + Team | Shipped (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
-| MDX rendering with Mermaid diagrams | - | Shipped (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
-| `TEAM_EMAILS` auth tier | - | Shipped (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
-| Sara-seeded content for all 11 sections | Admin + Team | In flight | Current PR |
+| `/hq` route, sidebar, 12 sections | Admin + Team | Live (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
+| MDX rendering with named Mermaid diagrams | - | Live (v0.5.0 + v0.5.1) | [#177](https://github.com/drawbackwards/runladder/pull/177), [#178](https://github.com/drawbackwards/runladder/pull/178) |
+| `TEAM_EMAILS` auth tier | - | Live (v0.5.0) | `src/lib/admin.ts` getTeamEmailWithStatus |
+| Sara-seeded content for all sections | Admin + Team | Live (v0.5.1) | [#178](https://github.com/drawbackwards/runladder/pull/178) |
+| PR-stamp lockstep protocol | All | Live (v0.5.1) | [#178](https://github.com/drawbackwards/runladder/pull/178), CLAUDE.md |
+| Audit corrections + GTM strategy + roadmap expansion | Admin + Team | In flight | Current PR (#179) |
 | Embedded GitHub Project board on Roadmap page | Admin + Team | Roadmap | Awaits Project setup |
-| Per-page "last updated" automated from git | Admin + Team | Roadmap | Currently manual in frontmatter |
+| Per-page "last updated" automated from git (vs manual frontmatter) | Admin + Team | Roadmap | Today's stamp is manual |
+| Surface this repo's PR list inline on Features page | Admin + Team | Roadmap | Would auto-update Status from open/closed |
 
 ## Pro-only features
 
@@ -126,11 +157,11 @@ Pulled out so the Pro upgrade case is easy to articulate. See [Decisions Log →
 - UX copywriting suggestions
 - Enhanced personal dashboard
 - 1,000 queries per month (vs 5 lifetime free)
-- All surfaces (web, plugin, Skill)
+- All surfaces (web, plugin, Skill, future API/MCP)
 
 ## Teams-only features
 
-Built on top of Pro. Sold as a Drawbackwards engagement.
+Built on top of Pro. Sold as a Drawbackwards engagement (MSA + SOW), not self-serve.
 
 - Team dashboard at `/dashboard/team` with manager view
 - Letter-grade scoring per member (A-F based on 30-day Comfortable+ rate)

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -39,7 +39,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | HQ content + PR-stamp protocol | Admin + Team | Live (v0.5.1) | [#178](https://github.com/drawbackwards/runladder/pull/178) |
 | Blog (`/blog`) | Public | Live | `src/app/blog/`, content ongoing |
 | `/pulse` marketing landing page | Public | Live | `src/app/pulse/page.tsx` (NOT the Pulse product surface, just marketing) |
-| Pricing page overhaul (Free 5-lifetime, Pro $250, Teams contact) | Public | In flight | Pricing page exists; needs verification it matches the Decisions Log floors |
+| Pricing page (Free 5-lifetime, Pro $1,000/mo, Team Custom Beta) | Public | Live (v0.4.8 + v0.4.9) | `src/app/pricing/page.tsx`, [#166](https://github.com/drawbackwards/runladder/pull/166), [#167](https://github.com/drawbackwards/runladder/pull/167) |
 | Top 100 ranked products (`/top-100`) | Public | In flight | `src/app/top-100/` page + `/api/top-100` route exist; full ranking flow TBD |
 | Public profile (`/[username]`) | All signed-in | Roadmap | No route yet |
 | Ladder Lift CTA on sub-3.0 scores | Free | Roadmap | No code yet |
@@ -78,7 +78,7 @@ Bundle source and `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (current
 
 ## Ladder Pulse: `drawbackwards/ladder-beta`
 
-**Pulse runs in a separate codebase: `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io).** The `/pulse` route on runladder.com is a marketing landing page only. Live engagement: Lumin Digital (Sept 2025 to Sept 2026, $90K).
+**Pulse runs in a separate codebase: `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io).** The `/pulse` route on runladder.com is a marketing landing page only. Live engagement: Lumin Digital (Sept 2025 to Sept 2026).
 
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |

--- a/src/content/hq/glossary.mdx
+++ b/src/content/hq/glossary.mdx
@@ -2,7 +2,7 @@
 title: Glossary
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## Why this exists
@@ -46,8 +46,9 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 | Term | Definition |
 | --- | --- |
 | **Free** | Sign-up tier, 5 lifetime scores, base score only. |
-| **Pro** | $250 self-serve, individual, 1K queries/month, all surfaces. |
-| **Teams** | Agency engagement via MSA + SOW. Plural noun, capital T. Not "Team plan." |
+| **Pro** | $1,000/mo self-serve on Stripe, individual, 2,000 scores/month, all surfaces. |
+| **Team** | Agency engagement via MSA + SOW (Beta on /pricing). Publicly Custom. Capital T. |
+| **Teams** | Plural noun ("Teams customers"), referring to multiple Team engagements collectively. |
 | **Team Member** / **Team Leader** | Roles within a Teams engagement. |
 | **Pulse User** | Customer on a Pulse engagement. |
 | **Admin** | Internal Drawbackwards admin (Ward, Michael, Jordan). |
@@ -57,10 +58,10 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 
 | Term | Definition |
 | --- | --- |
-| **Ladder Lift** | Drawbackwards engagement at $18–25K. Audit + workshop + 3 months of Teams. Bridges Free → Teams. |
-| **MSA** | Master Service Agreement. The standing contract with a Teams customer. |
+| **Ladder Lift** | Internal concept for a Drawbackwards engagement that bridges sub-3.0 free scores into a Team subscription. Not yet productized. Pricing and packaging stay in memory. |
+| **MSA** | Master Service Agreement. The standing contract with a Team customer. |
 | **SOW** | Statement of Work. The specific scope under an MSA. |
-| **The pool** | The shared query allowance on a Teams or Pulse engagement (25K or 50K monthly). |
+| **The pool** | The shared score allowance on a Team or Pulse engagement (25,000 pooled on Team, custom on Pulse). |
 
 ## Don't say
 

--- a/src/content/hq/gtm.mdx
+++ b/src/content/hq/gtm.mdx
@@ -7,27 +7,28 @@ lastPr: 179
 
 ## How to read this page
 
-A working draft of Ladder's go-to-market strategy, written in CRO voice. This is what we want the next twelve months to look like, the bets we're making, and the metrics we'll judge ourselves on. Treat the numbers as targets, not promises, until we have a Q1 of post-launch data.
+Ladder's go-to-market strategy, written in CRO voice. Funnel mechanics, channel mix, sales motion, public-launch sequence, metrics, risks. The shape of how revenue happens, not the specific revenue projections.
+
+**Per [Decisions Log -- /hq documents PUBLIC pricing only](/hq/decisions#hq-documents-public-pricing-only), this page does not list specific Team or Pulse dollar targets, customer ACVs, or Ladder Lift price bands.** Pro at $1,000/mo is on the public pricing page and shows up here. Internal targets and projections live in Ward + Michael's working memory and the Drawbackwards sales pipeline.
 
 This page changes as we learn. Every shift bumps `lastPr` and a Decisions Log entry captures the why.
 
 ## North star
 
-**Revenue from teams who treat design quality as infrastructure.** Not free-tool MAU. Not API call volume. Not signed-up email addresses. Revenue from customers who pay for Pro, Teams, or Pulse because Ladder gives them a number their team can act on.
+**Revenue from teams who treat design quality as infrastructure.** Not free-tool MAU. Not API call volume. Not signed-up email addresses. Revenue from customers who pay for Pro, Team, or Pulse because Ladder gives them a number their team can act on.
 
-Year 1 post-public-launch target ranges (call these stretch, not committed):
+Year 1 post-public-launch target shape (specific dollar bands live in non-/hq memory):
 
-- **Pro:** 250 paying users at $250 = ~$62k ARR equivalent (Pro is one-time today, see Decisions Log on whether it converts to recurring).
-- **Teams:** 5 active engagements at $50k average ACV through Drawbackwards = $250k.
-- **Pulse:** 3 active engagements at $100k average (Lumin baseline) = $300k.
-- **Ladder Lift:** 8 to 12 engagements at $20k = $200k.
-- **Total target:** **$800k to $1M ARR-equivalent in Year 1 post-launch.**
+- **Pro**: a healthy self-serve subscription base, anchored by $1,000/mo public price.
+- **Team**: a small handful of multi-seat engagements sold through Drawbackwards.
+- **Pulse**: continue Lumin Digital. Add at least one more Pulse engagement.
+- **Ladder Lift**: when the concept productizes, becomes the high-volume bridge from sub-3.0 free scores into Team.
 
-Real numbers depend on when the public-launch gate flips. See [Roadmap → Public launch gate](/hq/roadmap#public-launch-gate).
+Real targets depend on when the public-launch gate flips. See [Roadmap -- Public launch gate](/hq/roadmap#public-launch-gate).
 
 ## Positioning (recap)
 
-**Ladder is agent-native measurement infrastructure, not SaaS-with-AI.** Every surface (web, plugin, Skill, MCP, API) returns the same score from the same engine. Humans and AI agents are equal-class callers. See [Decisions Log → Positioning](/hq/decisions#positioning).
+**Ladder is agent-native measurement infrastructure, not SaaS-with-AI.** Every surface (web, plugin, Skill, MCP, API) returns the same score from the same engine. Humans and AI agents are equal-class callers. See [Decisions Log -- Positioning](/hq/decisions#positioning).
 
 The CRO read: positioning is a wedge against three adjacent categories.
 
@@ -35,15 +36,15 @@ The CRO read: positioning is a wedge against three adjacent categories.
 - **Customer feedback platforms** (Sprig, Hotjar, Pendo): we turn feedback into a single rung-mapped score, not a wall of charts. Pulse competes here directly.
 - **AI design copilots** (UX-focused LLM wrappers): we are infrastructure those copilots can call, not a copilot ourselves.
 
-The Drawbackwards moat: agency expertise that no pure-software competitor has. Ladder Lift and Teams are the products. The agency is the channel.
+The Drawbackwards moat: agency expertise that no pure-software competitor has. Team and Pulse engagements are the products. The agency is the channel.
 
 ## ICP (recap)
 
-**Primary archetype:** founder-built product, scored 1.5 to 2.5 on Ladder, growth team hired, no design quality infrastructure. See [Decisions Log → ICP](/hq/decisions#icp-founder-built-app-stuck-at-functional).
+**Primary archetype:** founder-built product, scored 1.5 to 2.5 on Ladder, growth team hired, no design quality infrastructure. See [Decisions Log -- ICP](/hq/decisions#icp-founder-built-app-stuck-at-functional).
 
 Secondary archetypes (for prioritization, not equal weight):
 
-- **Design-led teams at Series B+ companies** buying Pro for individuals or Teams for design orgs.
+- **Design-led teams at Series B+ companies** buying Pro for individuals or Team for design orgs.
 - **Product orgs measuring customer experience operationally**, buying Pulse for ongoing feedback scoring.
 - **Developer / AI-tooling teams** integrating the MCP and API into their own agent workflows.
 
@@ -51,7 +52,7 @@ We do not chase: enterprise design system buyers (out of scope), pure accessibil
 
 ## The funnel
 
-CRO mental model: **awareness → activation → engagement → conversion → expansion → retention.** Surface map below.
+CRO mental model: **awareness to activation to engagement to conversion to expansion to retention.** Surface map below.
 
 ### Awareness
 
@@ -77,16 +78,16 @@ CRO bet: the **public scoring tool is the wedge**. Every other channel ultimatel
 A visitor becomes a user.
 
 - Activation event: **first score completed.** Today this requires sign-up (Clerk magic link or Google OAuth, decided in v0.4.14).
-- The sign-up gate is intentional. See [Decisions Log → Sign-up required](/hq/decisions#sign-up-is-required-to-score). Anonymous scoring was removed because it inflated cost and killed attribution.
-- Activation target: 40 percent of `/score` page visitors complete a first score within session one.
+- The sign-up gate is intentional. See [Decisions Log -- Sign-up required](/hq/decisions#sign-up-is-required-to-score). Anonymous scoring was removed because it inflated cost and killed attribution.
+- Activation target: a healthy share of `/score` page visitors complete a first score within session one. Specific target lives in the metrics dashboard (non-/hq).
 
 ### Engagement
 
 A user scores more than once and explores the framework.
 
-- Free users get 5 lifetime scores. Hard cap, no overage. Constant in `src/lib/plans.ts` as `FREE_LIFETIME_LIMIT`. See [Decisions Log → Pricing](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only).
+- Free users get 5 lifetime scores. Hard cap, no overage. Constant in `src/lib/plans.ts` as `FREE_LIFETIME_LIMIT`. See [Decisions Log -- Pricing](/hq/decisions#public-pricing-free-5-lifetime-pro-1000mo-self-serve-team-and-pulse-custom).
 - Engagement events to track: score count, framework page reads, Top 100 visits, blog reads.
-- Engagement target: 60 percent of activated users score 2 or more before hitting the cap. Below that, our score result page isn't selling the next score well enough.
+- Engagement target: most activated users score more than once before hitting the cap. Below that, our score result page isn't selling the next score well enough.
 
 ### Conversion
 
@@ -94,15 +95,13 @@ A free user becomes a paying customer or routes into a sales engagement.
 
 Two paths, depending on score:
 
-- **Sub-3.0 score (`Functional` or `Usable`):** Ladder Lift CTA. The buyer is in pain. The score is the qualifier. Route to a contact form, Drawbackwards delivery lead handles discovery. Lift is **$18 to 25k**, MSA + SOW, includes audit + workshop + 3 months of Teams. See [Decisions Log → Ladder Lift](/hq/decisions#ladder-lift-bridges-free--teams).
-- **3.0-plus score (`Comfortable` and up):** Pro upgrade prompt. The buyer is curious. A11y and UX copywriting tabs are locked. The lifetime cap is approaching. Stripe checkout self-serve at **$250**. No procurement, no sales call.
+- **Sub-3.0 score (`Functional` or `Usable`)**: the buyer is in pain. The score is the qualifier. Route to a contact form. The Ladder Lift concept will productize this conversation when ready (see [Decisions Log -- Ladder Lift](/hq/decisions#ladder-lift-is-an-internal-concept-not-yet-productized)). In the meantime, sub-3.0 routes to a generic "Talk to Drawbackwards" CTA.
+- **3.0-plus score (`Comfortable` and up)**: the buyer is curious. A11y and UX copywriting tabs are locked. The lifetime cap is approaching. **Pro upgrade self-serve at $1,000/mo** on Stripe. No procurement, no sales call.
 
-Conversion targets:
+Conversion math (specific targets in non-/hq metrics):
 
-- **Sub-3.0 score to Lift discovery call:** 5 percent of sub-3.0 scorers click the CTA. Of those, 25 percent take a discovery call. Of those, 30 percent close. Implied: 0.4 percent of sub-3.0 scorers become Lift customers.
-- **Free to Pro:** 8 percent of free users who hit the 5-lifetime cap upgrade to Pro within 30 days.
-
-Both numbers are CRO bets. Real numbers replace them after one full quarter of post-launch data.
+- Sub-3.0 to discovery call to close: a multi-step funnel that Drawbackwards owns. Track each step.
+- Free to Pro: lifetime cap is the natural conversion lever. Pro's $1,000/mo signals "serious tool" which is intentional positioning.
 
 ### Expansion
 
@@ -110,12 +109,12 @@ A paying customer buys more.
 
 | Land | Expand to | Path |
 | --- | --- | --- |
-| Pro individual | Teams | They mention a team. Drawbackwards delivery lead reaches out with a Lift proposal. |
-| Lift customer | Teams | Lift includes 3 months of Teams. Renewal at end of Lift converts to a Teams MSA. |
-| Teams customer | Pulse | Pulse is the next infrastructure layer: scoring customer feedback instead of designed screens. Drawbackwards sells this in. |
-| Pulse customer | Teams bundle | Lumin Digital pattern (per memory). Customer wants seat-based design scoring on top of Pulse. |
+| Pro individual | Team | They mention a team. Drawbackwards delivery lead reaches out with an engagement proposal. |
+| Discovery call | Team | When Lift productizes, the bridge runs through it. Today, manual handoff from Drawbackwards. |
+| Team customer | Pulse | Pulse is the next infrastructure layer: scoring customer feedback instead of designed screens. Drawbackwards sells this in. |
+| Pulse customer | Team bundle | Lumin Digital pattern (customer signaled interest in adding Team on top of Pulse). |
 
-CRO target: **Net revenue retention > 110 percent** within 12 months of first Teams or Pulse engagement.
+CRO target: **net revenue retention > 110 percent** within 12 months of first Team or Pulse engagement.
 
 ### Retention
 
@@ -123,12 +122,12 @@ A customer keeps paying.
 
 Retention levers in priority order:
 
-1. **Reviews + Team Take social layer.** Teams customers who use Reviews engage more designers, run more scores, generate internal momentum. The product becomes the team's daily process. Shipped v0.4.15 to v0.4.17.
-2. **Letter grades on `/dashboard/team`.** Managers see designer trends. Pulls Teams into weekly leadership conversations.
+1. **Reviews + Team Take social layer.** Team customers who use Reviews engage more designers, run more scores, generate internal momentum. The product becomes the team's daily process. Shipped v0.4.15 to v0.4.17.
+2. **Letter grades on `/dashboard/team`.** Managers see designer trends. Pulls Team into weekly leadership conversations.
 3. **Pulse continuous feedback scoring.** Pulse is by nature recurring (data keeps flowing). Renewal logic is operational, not negotiated.
-4. **Engineering standards integration (future).** When Drawbackwards engineering standards ship, Teams + Lift customers get an upgrade path into ongoing audit work.
+4. **Engineering standards integration (future).** When Drawbackwards engineering standards ship, Team + Lift customers get an upgrade path into ongoing audit work.
 
-Churn risk: customers who only used Ladder for a one-time audit (Lift without renewal). Mitigation: bake Teams renewal into the Lift SOW from day one.
+Churn risk: customers who only used Ladder for a one-time audit (Lift without renewal). Mitigation: bake Team renewal into the Lift SOW from day one when it productizes.
 
 ## Sales motion
 
@@ -137,27 +136,22 @@ Three motions, layered.
 ### 1. Product-led (PLG) for Pro
 
 - Channel: free scoring tool.
-- Auth: Stripe self-serve.
-- ACV: $250 (one-time today, see open question below).
+- Auth: Stripe self-serve at $1,000/mo (live).
 - Touch: zero sales touch. Marketing email follow-up only.
 - Owner: Sara (lifecycle emails when shipped), Jordan (marketing pages).
 
-Open question: is Pro one-time or recurring? Today the price is $250, which reads like one-time. For ARR math, we need to either move Pro to $250/year subscription or accept $250 as a foot-in-the-door for the Lift conversion. Flag for Decisions Log clarification.
-
-### 2. Sales-assisted for Ladder Lift
+### 2. Sales-assisted for sub-3.0 scores (Ladder Lift when ready)
 
 - Channel: sub-3.0 score CTA, direct outreach, content.
-- ACV: $18 to 25k per engagement.
-- Touch: discovery call, audit proposal, MSA + SOW.
-- Cycle: 30 to 60 days from CTA click to signed SOW.
+- Touch: discovery call, audit proposal, MSA + SOW. Specific deal sizing in non-/hq memory.
+- Cycle: a few weeks to a couple of months from CTA click to signed SOW.
 - Owner: Ward + Michael, Drawbackwards delivery lead per engagement.
 
-### 3. Enterprise for Teams and Pulse
+### 3. Enterprise for Team and Pulse
 
-- Channel: Lift conversion, direct sales, customer expansion.
-- ACV: Teams $30 to $100k, Pulse $80 to $200k.
+- Channel: Lift conversion (future), direct sales, customer expansion.
 - Touch: multi-call, executive sponsor, procurement.
-- Cycle: 60 to 120 days.
+- Cycle: two to four months.
 - Owner: Ward (close), Michael (PM), Drawbackwards delivery org.
 
 ## Channel strategy
@@ -166,10 +160,10 @@ Owned, earned, partner, paid. Tracked separately because the unit economics diff
 
 ### Owned
 
-- **runladder.com:** the wedge. Optimize for sign-up to score conversion.
-- **drawbackwards.com:** the agency channel. Optimize for Lift inquiry conversion.
-- **/framework, /top-100, /teardowns, /blog:** content marketing. Optimize for repeat visits and shares.
-- **Email lifecycle:** Pro upgrade nudges, Teams expansion offers, Pulse case studies. Roadmap (not built).
+- **runladder.com**: the wedge. Optimize for sign-up to score conversion.
+- **drawbackwards.com**: the agency channel. Optimize for engagement inquiry conversion.
+- **/framework, /top-100, /teardowns, /blog**: content marketing. Optimize for repeat visits and shares.
+- **Email lifecycle**: Pro upgrade nudges, Team expansion offers, Pulse case studies. Roadmap (not built).
 
 ### Earned
 
@@ -181,12 +175,12 @@ Owned, earned, partner, paid. Tracked separately because the unit economics diff
 
 - **Anthropic Skills marketplace** (Roadmap, see [Skill distribution](/hq/roadmap#skill-distribution-roadmap)).
 - **Figma plugin marketplace** (in re-review).
-- **MCP ecosystem:** developer tools that integrate the MCP server when it ships.
-- **Drawbackwards client relationships:** the highest-warmth channel for Teams and Pulse. Existing clients become beta customers.
+- **MCP ecosystem**: developer tools that integrate the MCP server when it ships.
+- **Drawbackwards client relationships**: the highest-warmth channel for Team and Pulse. Existing clients become beta customers.
 
 ### Paid
 
-**Not active.** Public-launch gate must flip before paid acquisition starts. See [Decisions Log → Public launch](/hq/decisions#public-launch-is-gated-on-mcp-skill-and-api-being-live).
+**Not active.** Public-launch gate must flip before paid acquisition starts. See [Decisions Log -- Public launch](/hq/decisions#public-launch-is-gated-on-mcp-skill-and-api-being-live).
 
 When paid kicks in, sequence:
 
@@ -195,7 +189,7 @@ When paid kicks in, sequence:
 3. Search ads on "design quality framework", "UX audit tool", "design system score".
 4. Sponsored newsletters in design community (Sidebar, UX Tools, etc.).
 
-Test budget: $5k per channel, kill what doesn't show CAC payback under 12 months.
+Test budget per channel: small, killable. Kill what doesn't show CAC payback within a reasonable window.
 
 ## Public launch sequence
 
@@ -207,7 +201,7 @@ When the three public-launch gates flip ([MCP, Skill marketplace, public API](/h
 | Day 1 | Drawbackwards-published blog post announcing the launch. Cross-post to LinkedIn, Twitter. |
 | Day 2 to 5 | Top 100 entries seeded (10 to 20 well-known apps). Each gets a public scorecard. Social shares from accounts. |
 | Day 7 | Email to existing free users: "Pro is live, here's what you unlock." |
-| Day 7 | Email to Drawbackwards client list: "Ladder Lift is available. Sub-3.0 score discount for first 5 sign-ups." |
+| Day 7 | Email to Drawbackwards client list: "Ongoing Team engagement is available. Sub-3.0 score discount for first 5 sign-ups." |
 | Day 10 | Designer leader outreach: founder interviews on 2 to 3 podcasts or newsletters. |
 | Day 14 | Paid acquisition test budgets activate (LinkedIn, Twitter, Search, Newsletters). |
 | Day 21 | First retrospective: top-of-funnel volume, sign-up rate, free to Pro conversion. Adjust. |
@@ -215,7 +209,7 @@ When the three public-launch gates flip ([MCP, Skill marketplace, public API](/h
 
 ## Metrics dashboard
 
-The numbers we watch weekly. Most are roadmap to track in `/admin` (today the data exists, the dashboards don't).
+The numbers we watch weekly. Most are roadmap to track in `/admin` (today the data exists, the dashboards don't). Specific revenue and ACV numbers live in non-/hq memory; only the categories show up here.
 
 ### Top of funnel
 
@@ -227,26 +221,24 @@ The numbers we watch weekly. Most are roadmap to track in `/admin` (today the da
 ### Conversion
 
 - Free to Pro conversion rate (lifetime cap to checkout)
-- Sub-3.0 score to Lift CTA click rate
-- Lift CTA click to discovery call rate
-- Lift discovery call to signed SOW rate
-- Teams expansion rate (Lift to Teams renewal)
+- Sub-3.0 score to discovery call click rate
+- Discovery call to signed SOW rate
+- Team expansion rate (engagement to renewal)
 
-### Revenue
+### Revenue (categories, not specifics)
 
-- ARR-equivalent by tier (Pro, Teams, Pulse, Lift)
-- ACV by tier
-- New revenue per quarter
-- Expansion revenue per quarter
-- Churn revenue per quarter
-- Net revenue retention (NRR)
+- Pro MRR
+- Team engagements active
+- Pulse engagements active
+- Net revenue retention
+- Expansion vs new revenue split
 
 ### Engagement and retention
 
 - Scores per active user per month
-- Reviews created per Teams customer per month
-- Pro renewal rate (if Pro converts to recurring)
-- Teams renewal rate at SOW end
+- Reviews created per Team customer per month
+- Pro renewal rate
+- Team renewal rate at SOW end
 - Pulse data ingest volume
 
 ### Channel performance
@@ -260,17 +252,17 @@ The numbers we watch weekly. Most are roadmap to track in `/admin` (today the da
 CRO must name them out loud.
 
 1. **Public-launch gate slips past Q3 2026.** Year 1 target compresses. Mitigation: prioritize MCP + Skill marketplace over polish work. Phase the gate aggressively in [Roadmap](/hq/roadmap).
-2. **Free to Pro conversion under 5 percent.** Targets miss by 2x. Mitigation: tighten the lifetime cap pitch, test pricing experiments.
-3. **Lift sales cycle is longer than 60 days.** Drawbackwards delivery capacity becomes the bottleneck. Mitigation: pre-built Lift package, fewer custom proposals.
-4. **Pulse engine drift.** ladder-beta runs on OpenAI, runladder on Anthropic. Consolidation roadmap is open-ended. Mitigation: track in [Roadmap → Pulse consolidation](/hq/roadmap#pulse-consolidation-future).
+2. **Free to Pro conversion underperforms.** Targets miss. Mitigation: tighten the lifetime cap pitch, test pricing experiments (Pro $1,000/mo is the current public price; alternatives stay in non-/hq memory).
+3. **Sales cycle longer than expected.** Drawbackwards delivery capacity becomes the bottleneck. Mitigation: pre-built engagement packages, fewer custom proposals.
+4. **Pulse engine drift.** ladder-beta runs on OpenAI, runladder on Anthropic. Consolidation roadmap is open-ended. Mitigation: track in [Roadmap -- Pulse consolidation](/hq/roadmap#pulse-consolidation-future).
 5. **Anthropic marketplace policy change.** If Anthropic gates third-party Skill listings, Skill distribution path (b) breaks. Mitigation: marketplace.json in our own repo (path a) still works regardless.
 6. **Trademark dispute.** Ladder is a common word. If a competitor challenges the mark, marketing has to rebrand mid-launch. Mitigation: trademark filing in flight (see [Decisions Log](/hq/decisions#trademark-and-proprietary-framework)).
 
 ## Open questions
 
-These need Ward's call before the strategy locks.
+These need Ward's call before the strategy locks. (Ward + Michael own the answers; this page captures the questions for team visibility, not the answers.)
 
-1. **Is Pro $250 one-time or annual?** ARR math hinges on this. Recommendation: convert to $250/year subscription with first-year discount option for friction-sensitive buyers.
-2. **What's the Teams ACV floor?** Currently a Drawbackwards engagement (MSA + SOW), bespoke. Recommendation: publish a starting price ("$30k for up to 10 seats and 25,000 queries") so the buyer can self-qualify before reaching out.
-3. **Should the Ladder Lift land on runladder.com (as a CTA) or drawbackwards.com (as a service page)?** Per [Decisions Log → Ladder Lift](/hq/decisions#ladder-lift-bridges-free--teams), Lift lives on drawbackwards.com. Recommendation: confirmed, with a CTA bridge from runladder.com sub-3.0 results.
-4. **Who owns marketing operations?** Today this page is Sara's plan. The actual execution (email, paid, content cadence) needs a human owner. Recommendation: Michael as MarketingOps owner, Jordan supports on assets.
+1. **Team published floor.** Should we publish a Team starting price so buyers can self-qualify, or stay Custom?
+2. **Pulse pricing model.** Is Pulse pay-per-engagement, annual subscription, or something hybrid? Lumin's structure may not generalize.
+3. **Ladder Lift productization.** When does Lift become public? What does the sub-3.0 CTA say in the meantime?
+4. **Marketing operations owner.** Suggested: Michael as MarketingOps lead, Jordan supports on assets. Confirm with Michael.

--- a/src/content/hq/gtm.mdx
+++ b/src/content/hq/gtm.mdx
@@ -1,0 +1,276 @@
+---
+title: Go-to-Market Strategy
+updatedAt: 2026-05-19
+updatedBy: Sara
+lastPr: 179
+---
+
+## How to read this page
+
+A working draft of Ladder's go-to-market strategy, written in CRO voice. This is what we want the next twelve months to look like, the bets we're making, and the metrics we'll judge ourselves on. Treat the numbers as targets, not promises, until we have a Q1 of post-launch data.
+
+This page changes as we learn. Every shift bumps `lastPr` and a Decisions Log entry captures the why.
+
+## North star
+
+**Revenue from teams who treat design quality as infrastructure.** Not free-tool MAU. Not API call volume. Not signed-up email addresses. Revenue from customers who pay for Pro, Teams, or Pulse because Ladder gives them a number their team can act on.
+
+Year 1 post-public-launch target ranges (call these stretch, not committed):
+
+- **Pro:** 250 paying users at $250 = ~$62k ARR equivalent (Pro is one-time today, see Decisions Log on whether it converts to recurring).
+- **Teams:** 5 active engagements at $50k average ACV through Drawbackwards = $250k.
+- **Pulse:** 3 active engagements at $100k average (Lumin baseline) = $300k.
+- **Ladder Lift:** 8 to 12 engagements at $20k = $200k.
+- **Total target:** **$800k to $1M ARR-equivalent in Year 1 post-launch.**
+
+Real numbers depend on when the public-launch gate flips. See [Roadmap → Public launch gate](/hq/roadmap#public-launch-gate).
+
+## Positioning (recap)
+
+**Ladder is agent-native measurement infrastructure, not SaaS-with-AI.** Every surface (web, plugin, Skill, MCP, API) returns the same score from the same engine. Humans and AI agents are equal-class callers. See [Decisions Log → Positioning](/hq/decisions#positioning).
+
+The CRO read: positioning is a wedge against three adjacent categories.
+
+- **Design QA tools** (Stark, axe DevTools): we score the whole experience, not just accessibility audits. A11y is one of five rungs, not the entire product.
+- **Customer feedback platforms** (Sprig, Hotjar, Pendo): we turn feedback into a single rung-mapped score, not a wall of charts. Pulse competes here directly.
+- **AI design copilots** (UX-focused LLM wrappers): we are infrastructure those copilots can call, not a copilot ourselves.
+
+The Drawbackwards moat: agency expertise that no pure-software competitor has. Ladder Lift and Teams are the products. The agency is the channel.
+
+## ICP (recap)
+
+**Primary archetype:** founder-built product, scored 1.5 to 2.5 on Ladder, growth team hired, no design quality infrastructure. See [Decisions Log → ICP](/hq/decisions#icp-founder-built-app-stuck-at-functional).
+
+Secondary archetypes (for prioritization, not equal weight):
+
+- **Design-led teams at Series B+ companies** buying Pro for individuals or Teams for design orgs.
+- **Product orgs measuring customer experience operationally**, buying Pulse for ongoing feedback scoring.
+- **Developer / AI-tooling teams** integrating the MCP and API into their own agent workflows.
+
+We do not chase: enterprise design system buyers (out of scope), pure accessibility-only buyers (wrong wedge), pre-launch startups without traction (no signal to score against).
+
+## The funnel
+
+CRO mental model: **awareness → activation → engagement → conversion → expansion → retention.** Surface map below.
+
+### Awareness
+
+How an ICP buyer first hears about Ladder.
+
+| Channel | Surface | Status |
+| --- | --- | --- |
+| Free public scoring tool | `runladder.com/score` | Live |
+| Top 100 teardowns | `runladder.com/top-100`, `runladder.com/teardowns` | Roadmap |
+| Framework page | `runladder.com/framework` | Live |
+| Blog and content | `runladder.com/blog` | Live, ongoing |
+| Anthropic Skill marketplace | Discoverable via Claude.ai | Roadmap (see [Skill distribution](/hq/roadmap#skill-distribution-roadmap)) |
+| Figma plugin marketplace | Discoverable in Figma | In flight (re-review) |
+| MCP ecosystem | Discoverable by AI agents | Roadmap |
+| Drawbackwards agency network | Existing client referrals | Live (informal) |
+| Design leader social (LinkedIn, Twitter) | Earned shares of low-scoring well-known apps | Roadmap |
+| Conferences and podcasts | Founder interviews, Top 100 reveals | Roadmap |
+
+CRO bet: the **public scoring tool is the wedge**. Every other channel ultimately routes to it. The score is the hook. The framework is the story. The agency is the close.
+
+### Activation
+
+A visitor becomes a user.
+
+- Activation event: **first score completed.** Today this requires sign-up (Clerk magic link or Google OAuth, decided in v0.4.14).
+- The sign-up gate is intentional. See [Decisions Log → Sign-up required](/hq/decisions#sign-up-is-required-to-score). Anonymous scoring was removed because it inflated cost and killed attribution.
+- Activation target: 40 percent of `/score` page visitors complete a first score within session one.
+
+### Engagement
+
+A user scores more than once and explores the framework.
+
+- Free users get 5 lifetime scores. Hard cap, no overage. Constant in `src/lib/plans.ts` as `FREE_LIFETIME_LIMIT`. See [Decisions Log → Pricing](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only).
+- Engagement events to track: score count, framework page reads, Top 100 visits, blog reads.
+- Engagement target: 60 percent of activated users score 2 or more before hitting the cap. Below that, our score result page isn't selling the next score well enough.
+
+### Conversion
+
+A free user becomes a paying customer or routes into a sales engagement.
+
+Two paths, depending on score:
+
+- **Sub-3.0 score (`Functional` or `Usable`):** Ladder Lift CTA. The buyer is in pain. The score is the qualifier. Route to a contact form, Drawbackwards delivery lead handles discovery. Lift is **$18 to 25k**, MSA + SOW, includes audit + workshop + 3 months of Teams. See [Decisions Log → Ladder Lift](/hq/decisions#ladder-lift-bridges-free--teams).
+- **3.0-plus score (`Comfortable` and up):** Pro upgrade prompt. The buyer is curious. A11y and UX copywriting tabs are locked. The lifetime cap is approaching. Stripe checkout self-serve at **$250**. No procurement, no sales call.
+
+Conversion targets:
+
+- **Sub-3.0 score to Lift discovery call:** 5 percent of sub-3.0 scorers click the CTA. Of those, 25 percent take a discovery call. Of those, 30 percent close. Implied: 0.4 percent of sub-3.0 scorers become Lift customers.
+- **Free to Pro:** 8 percent of free users who hit the 5-lifetime cap upgrade to Pro within 30 days.
+
+Both numbers are CRO bets. Real numbers replace them after one full quarter of post-launch data.
+
+### Expansion
+
+A paying customer buys more.
+
+| Land | Expand to | Path |
+| --- | --- | --- |
+| Pro individual | Teams | They mention a team. Drawbackwards delivery lead reaches out with a Lift proposal. |
+| Lift customer | Teams | Lift includes 3 months of Teams. Renewal at end of Lift converts to a Teams MSA. |
+| Teams customer | Pulse | Pulse is the next infrastructure layer: scoring customer feedback instead of designed screens. Drawbackwards sells this in. |
+| Pulse customer | Teams bundle | Lumin Digital pattern (per memory). Customer wants seat-based design scoring on top of Pulse. |
+
+CRO target: **Net revenue retention > 110 percent** within 12 months of first Teams or Pulse engagement.
+
+### Retention
+
+A customer keeps paying.
+
+Retention levers in priority order:
+
+1. **Reviews + Team Take social layer.** Teams customers who use Reviews engage more designers, run more scores, generate internal momentum. The product becomes the team's daily process. Shipped v0.4.15 to v0.4.17.
+2. **Letter grades on `/dashboard/team`.** Managers see designer trends. Pulls Teams into weekly leadership conversations.
+3. **Pulse continuous feedback scoring.** Pulse is by nature recurring (data keeps flowing). Renewal logic is operational, not negotiated.
+4. **Engineering standards integration (future).** When Drawbackwards engineering standards ship, Teams + Lift customers get an upgrade path into ongoing audit work.
+
+Churn risk: customers who only used Ladder for a one-time audit (Lift without renewal). Mitigation: bake Teams renewal into the Lift SOW from day one.
+
+## Sales motion
+
+Three motions, layered.
+
+### 1. Product-led (PLG) for Pro
+
+- Channel: free scoring tool.
+- Auth: Stripe self-serve.
+- ACV: $250 (one-time today, see open question below).
+- Touch: zero sales touch. Marketing email follow-up only.
+- Owner: Sara (lifecycle emails when shipped), Jordan (marketing pages).
+
+Open question: is Pro one-time or recurring? Today the price is $250, which reads like one-time. For ARR math, we need to either move Pro to $250/year subscription or accept $250 as a foot-in-the-door for the Lift conversion. Flag for Decisions Log clarification.
+
+### 2. Sales-assisted for Ladder Lift
+
+- Channel: sub-3.0 score CTA, direct outreach, content.
+- ACV: $18 to 25k per engagement.
+- Touch: discovery call, audit proposal, MSA + SOW.
+- Cycle: 30 to 60 days from CTA click to signed SOW.
+- Owner: Ward + Michael, Drawbackwards delivery lead per engagement.
+
+### 3. Enterprise for Teams and Pulse
+
+- Channel: Lift conversion, direct sales, customer expansion.
+- ACV: Teams $30 to $100k, Pulse $80 to $200k.
+- Touch: multi-call, executive sponsor, procurement.
+- Cycle: 60 to 120 days.
+- Owner: Ward (close), Michael (PM), Drawbackwards delivery org.
+
+## Channel strategy
+
+Owned, earned, partner, paid. Tracked separately because the unit economics differ.
+
+### Owned
+
+- **runladder.com:** the wedge. Optimize for sign-up to score conversion.
+- **drawbackwards.com:** the agency channel. Optimize for Lift inquiry conversion.
+- **/framework, /top-100, /teardowns, /blog:** content marketing. Optimize for repeat visits and shares.
+- **Email lifecycle:** Pro upgrade nudges, Teams expansion offers, Pulse case studies. Roadmap (not built).
+
+### Earned
+
+- **Top 100 teardowns** generate social shares because the entries are well-known apps.
+- **Sub-3.0 score posts** from individual users on Twitter or LinkedIn ("just scored my app at 2.1 on Ladder, ouch") drive curiosity inbound.
+- **Designer leader op-eds** referencing the framework. Cultivate three to five thought-leader relationships in the design community.
+
+### Partner
+
+- **Anthropic Skills marketplace** (Roadmap, see [Skill distribution](/hq/roadmap#skill-distribution-roadmap)).
+- **Figma plugin marketplace** (in re-review).
+- **MCP ecosystem:** developer tools that integrate the MCP server when it ships.
+- **Drawbackwards client relationships:** the highest-warmth channel for Teams and Pulse. Existing clients become beta customers.
+
+### Paid
+
+**Not active.** Public-launch gate must flip before paid acquisition starts. See [Decisions Log → Public launch](/hq/decisions#public-launch-is-gated-on-mcp-skill-and-api-being-live).
+
+When paid kicks in, sequence:
+
+1. LinkedIn ads targeting Director of Design, VP Product at Series B to D companies.
+2. Twitter/X promoted Top 100 reveals.
+3. Search ads on "design quality framework", "UX audit tool", "design system score".
+4. Sponsored newsletters in design community (Sidebar, UX Tools, etc.).
+
+Test budget: $5k per channel, kill what doesn't show CAC payback under 12 months.
+
+## Public launch sequence
+
+When the three public-launch gates flip ([MCP, Skill marketplace, public API](/hq/roadmap#public-launch-gate)), here's the firing order. Day 0 is the day gate three flips.
+
+| Day | Action |
+| --- | --- |
+| Day 0 | All three gates verified live. Sara updates the gate tracker and adds a Decisions Log entry. |
+| Day 1 | Drawbackwards-published blog post announcing the launch. Cross-post to LinkedIn, Twitter. |
+| Day 2 to 5 | Top 100 entries seeded (10 to 20 well-known apps). Each gets a public scorecard. Social shares from accounts. |
+| Day 7 | Email to existing free users: "Pro is live, here's what you unlock." |
+| Day 7 | Email to Drawbackwards client list: "Ladder Lift is available. Sub-3.0 score discount for first 5 sign-ups." |
+| Day 10 | Designer leader outreach: founder interviews on 2 to 3 podcasts or newsletters. |
+| Day 14 | Paid acquisition test budgets activate (LinkedIn, Twitter, Search, Newsletters). |
+| Day 21 | First retrospective: top-of-funnel volume, sign-up rate, free to Pro conversion. Adjust. |
+| Day 30 | Top 100 launch event (live-scoring stream, podcast push). |
+
+## Metrics dashboard
+
+The numbers we watch weekly. Most are roadmap to track in `/admin` (today the data exists, the dashboards don't).
+
+### Top of funnel
+
+- Weekly score volume (free + paid combined)
+- Unique signed-up users per week
+- Activation rate (visitors who score on first session)
+- Channel attribution per signup (UTM, referrer)
+
+### Conversion
+
+- Free to Pro conversion rate (lifetime cap to checkout)
+- Sub-3.0 score to Lift CTA click rate
+- Lift CTA click to discovery call rate
+- Lift discovery call to signed SOW rate
+- Teams expansion rate (Lift to Teams renewal)
+
+### Revenue
+
+- ARR-equivalent by tier (Pro, Teams, Pulse, Lift)
+- ACV by tier
+- New revenue per quarter
+- Expansion revenue per quarter
+- Churn revenue per quarter
+- Net revenue retention (NRR)
+
+### Engagement and retention
+
+- Scores per active user per month
+- Reviews created per Teams customer per month
+- Pro renewal rate (if Pro converts to recurring)
+- Teams renewal rate at SOW end
+- Pulse data ingest volume
+
+### Channel performance
+
+- Cost per signup by channel (when paid kicks in)
+- LTV by acquisition channel
+- CAC payback by channel
+
+## Risks
+
+CRO must name them out loud.
+
+1. **Public-launch gate slips past Q3 2026.** Year 1 target compresses. Mitigation: prioritize MCP + Skill marketplace over polish work. Phase the gate aggressively in [Roadmap](/hq/roadmap).
+2. **Free to Pro conversion under 5 percent.** Targets miss by 2x. Mitigation: tighten the lifetime cap pitch, test pricing experiments.
+3. **Lift sales cycle is longer than 60 days.** Drawbackwards delivery capacity becomes the bottleneck. Mitigation: pre-built Lift package, fewer custom proposals.
+4. **Pulse engine drift.** ladder-beta runs on OpenAI, runladder on Anthropic. Consolidation roadmap is open-ended. Mitigation: track in [Roadmap → Pulse consolidation](/hq/roadmap#pulse-consolidation-future).
+5. **Anthropic marketplace policy change.** If Anthropic gates third-party Skill listings, Skill distribution path (b) breaks. Mitigation: marketplace.json in our own repo (path a) still works regardless.
+6. **Trademark dispute.** Ladder is a common word. If a competitor challenges the mark, marketing has to rebrand mid-launch. Mitigation: trademark filing in flight (see [Decisions Log](/hq/decisions#trademark-and-proprietary-framework)).
+
+## Open questions
+
+These need Ward's call before the strategy locks.
+
+1. **Is Pro $250 one-time or annual?** ARR math hinges on this. Recommendation: convert to $250/year subscription with first-year discount option for friction-sensitive buyers.
+2. **What's the Teams ACV floor?** Currently a Drawbackwards engagement (MSA + SOW), bespoke. Recommendation: publish a starting price ("$30k for up to 10 seats and 25,000 queries") so the buyer can self-qualify before reaching out.
+3. **Should the Ladder Lift land on runladder.com (as a CTA) or drawbackwards.com (as a service page)?** Per [Decisions Log → Ladder Lift](/hq/decisions#ladder-lift-bridges-free--teams), Lift lives on drawbackwards.com. Recommendation: confirmed, with a CTA bridge from runladder.com sub-3.0 results.
+4. **Who owns marketing operations?** Today this page is Sara's plan. The actual execution (email, paid, content cadence) needs a human owner. Recommendation: Michael as MarketingOps owner, Jordan supports on assets.

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,31 +2,31 @@
 title: User Journeys
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## How to read this page
 
 One section per surface. Each section walks the primary flow, calls out the key decision points, names the screens or steps, and flags what we want to improve next. Diagrams are Mermaid, defined in `src/content/hq/diagrams.ts` and referenced by name.
 
-The flows below are what's live today plus what's about to ship. Anything in stub-or-roadmap is called out inline.
+Flows are tagged **Live** (works today), **In flight** (code partially exists), or **Roadmap** (not built). Don't trust a flow labeled Roadmap as something we can demo.
 
-## Web app (runladder.com)
+## Web app (runladder.com): Live
 
 The web app is the canonical surface. Everything else routes to it eventually for billing, account management, and the public marketing story.
 
-### First-time score
+### First-time score (Live)
 
 <Diagram name="WEB_FIRST_SCORE" />
 
 Key beats:
 
-- Anonymous visitors can read marketing pages but cannot score. Sign-up gate sits on the scoring CTA (decided in v0.4.14, see [Decisions Log](/hq/decisions#sign-up-is-required-to-score)).
+- Anonymous visitors can read marketing pages but cannot score. Sign-up gate sits on the scoring CTA (shipped in v0.4.14, enforced by `auth()` check in `src/app/api/score/route.ts` line 38-46).
 - Sign-up is Clerk email-code or Google OAuth. No password.
-- First score lands on `/score?just-signed-up=1` so we can show first-time UX (currently a quiet welcome line).
-- Score result branches on score value: sub-3.0 surfaces a Ladder Lift CTA, 3.0-plus surfaces the Pro upgrade prompt with a11y and UX copywriting locked.
+- Free tier is 5 lifetime scores. Hard-blocked past the cap (no overage). Constant lives in `src/lib/plans.ts` as `FREE_LIFETIME_LIMIT`.
+- Score result branches on score value: sub-3.0 shows the Ladder Lift CTA (currently roadmap, see [Features](/hq/features)), 3.0-plus shows the Pro upgrade prompt with a11y and UX copywriting locked.
 
-### Free to Pro upgrade
+### Free to Pro upgrade (Live)
 
 <Diagram name="WEB_FREE_TO_PRO" />
 
@@ -36,87 +36,99 @@ Triggers for the upgrade conversation:
 - User clicks a Pro-only tab (a11y audit, UX copywriting) on a score result.
 - User hits the Pricing page directly.
 
-The Stripe checkout is self-serve at $250. On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
+The Stripe checkout is self-serve at $250 (via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
 
-### Team manager flow (post-engagement)
+### Team manager flow (Live, post-engagement)
 
 After a Drawbackwards Teams engagement closes, the manager gets an admin invite. From there:
 
 1. Land on `/dashboard/team` with an empty roster.
 2. Invite designers by email. Clerk Organization handles the invite.
-3. Accepted invitees auto-get a `tier: "team"` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
-4. Manager sees the team pool meter (25,000 monthly default), member roster with letter grades A-F, and the Reviews workflow.
+3. Accepted invitees auto-get a `tier: team` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
+4. Manager sees the team pool meter (25,000 monthly default, shipped v0.4.18), member roster with letter grades A-F, and the Reviews workflow.
 5. Reviews flow: designer requests review, manager accepts or declines, designer scores iterations in `/dashboard/reviews/[slug]`, manager and peers add Team Takes and pin annotations.
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
 
-## Figma plugin
+## Figma plugin: Live (in marketplace re-review per memory)
 
-The plugin (`drawbackwards/ai-design-assistant` repo) lives in Figma's canvas. The current bundle is v1.0.6, synced from this repo via `scripts/sync-skill-version.mjs`.
+The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.0.6 (synced via `scripts/sync-skill-version.mjs`).
 
-### Plugin first-run
+### Plugin first-run (Live, with caveats)
 
 <Diagram name="PLUGIN_FIRST_RUN" />
 
 Key beats:
 
-- Plugin token is issued from `/dashboard/settings` on runladder.com and pasted into the plugin once.
-- Token is server-issued, single-user, scoped to plugin requests. Never expose it client-side outside Figma's plugin sandbox.
-- Score request hits the same Ladder API as the web app. Same engine, same response shape.
+- Plugin token is issued via `POST /api/plugin/issue-token` (Clerk session required), then pasted into the Figma plugin. There is **no `/dashboard/settings` UI for this yet**; issuance happens via in-plugin auth flow.
+- Token is server-issued, single-user, scoped to plugin requests. Verified via `POST /api/plugin/verify-token`.
+- Score requests hit `/api/plugin/analyze`. Same scoring engine as the web app. Persisted via `POST /api/plugin/persist-score`.
 - Free users hit the 5-lifetime cap inside the plugin same as on web.
 
-Open questions to resolve before relaunch (see [Decisions Log](/hq/decisions)):
+Open questions before relaunch (see [Decisions Log](/hq/decisions)):
 
 - Plugin demo flow for the Figma marketplace listing.
-- Whether the plugin should support batch scoring of a frame stack.
+- Whether the plugin should support batch scoring of a frame stack (roadmap).
 
-## Claude Skill
+## Claude Skill: Live (distribution roadmap pending)
 
-The Skill (`Ladder for Claude`) is a bundle invoked inside Claude.ai conversations. Version tracked in `src/lib/skill-version.ts`.
+The Skill (`Ladder for Claude`) is a bundle invoked inside Claude.ai conversations. Bundle version tracked in `src/lib/skill-version.ts` (currently 1.0.6). Backend endpoints live in `runladder` under `/api/skill/*`.
 
-### Skill flow
+### Skill flow (Live, manual install today)
 
 <Diagram name="SKILL_FLOW" />
 
 Key beats:
 
-- Skill token issued from `/dashboard/settings`. User pastes it into Claude.ai once.
-- Skill is a thin client. It pulls the URL or image from the conversation context, sends to the Ladder API, and renders the result back into the conversation as a structured block.
+- Skill bundle is installed manually today: Ward has it running in his Claude.ai. Broader distribution is roadmap (see [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap)).
+- Skill token issued via `POST /api/skill/token` (Clerk session required). Pasted into Claude.ai once.
+- Skill is a thin client. Pulls URL or image from conversation context, sends to `/api/skill/score`, renders the result inline.
 - Free users hit the 5-lifetime cap same as everywhere.
 - This is the surface that proves the agent-native positioning. An AI can ask for a Ladder score the same way a human can.
 
-## Ladder Pulse
+## Ladder Pulse: Live (runs in a separate codebase)
 
-Pulse is the customer-feedback scoring surface. First customer is Lumin Digital (Sept 2025 to Sept 2026 engagement). The Pulse dashboard lives at `/dashboard/pulse` and is gated to Pulse-tier accounts.
+**Pulse runs in `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io), not in `runladder`.** The `/pulse` route on runladder.com is a marketing landing page that points at `/contact`, not the Pulse product surface.
 
-### Pulse data flow
+First customer is Lumin Digital (Sept 2025 to Sept 2026 engagement, $90K). Pulse customer data, scoring, and dashboards all live in `ladder-beta`. Consolidation into `runladder` is a future decision, not active (see [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now)).
+
+### Pulse data flow (Live, in ladder-beta)
 
 <Diagram name="PULSE_DATA_FLOW" />
 
-Key beats:
+Key beats (per `ladder-beta` README):
 
-- Pulse customers send feedback in scheduled batches or via the Pulse ingest endpoint.
-- The scoring engine runs against each feedback item and tags it with a Ladder rung plus a sentiment vector.
-- Dashboard renders aggregate trends (rung distribution over time, top-themes-at-risk, weakest rung this month).
-- Pulse pool is 50,000 queries per month; overage is tiered, not blocked.
+- Pulse customers send feedback via Alchemer (survey tool) and other sources. `ladder-beta` reads via `ALCHEMER_API_BASE_URL`.
+- Data persists in Prisma + Postgres on Fly.io.
+- Scoring uses OpenAI (`OPEN_AI_API_KEY` env), separate from `runladder`'s Anthropic scoring engine. Engine consolidation is roadmap.
+- Dashboard renders aggregate trends inside `ladder-beta` (not on runladder.com).
+- Pulse pool target is 50,000 queries per month per [Decisions Log → Pricing](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only).
 
-## Ladder API and MCP
+## Ladder API and MCP: Roadmap (not built)
 
-Direct callers (developer or AI agent). Lives at api.runladder.com once the migration from `ai-design-assistant` completes.
+This is the future-target surface. Today, the same scoring is callable via `/api/score`, `/api/plugin/analyze`, and `/api/skill/score` on `runladder.com`. The dedicated public surface at `api.runladder.com` and the MCP server are roadmap. See [Roadmap → api.runladder.com](/hq/roadmap#apirunladdercom-roadmap) for the concrete plan.
 
-### API key flow
+### API key flow (Roadmap)
 
 <Diagram name="API_KEY_FLOW" />
 
-### MCP agent flow
+When the public API ships:
+
+- Sign up on runladder.com, upgrade to Pro or Teams.
+- Generate an API key from the Pro settings page (`/dashboard/settings`, also roadmap).
+- Call `POST /api/score` (or the future `api.runladder.com/v1/score`) with Bearer auth.
+- Response includes `X-Ladder-API-Version` header.
+
+### MCP agent flow (Roadmap)
 
 <Diagram name="MCP_AGENT_FLOW" />
 
-Key beats:
+When the MCP server ships:
 
-- The MCP server exposes scoring as a tool that any MCP-aware agent (Claude, Cursor, custom) can call.
-- Same auth model as direct API: Bearer token in the MCP config.
-- The agent doesn't see the rubric, the prompt, or the reasoning. It gets the final score, the rung, and a structured breakdown.
-- This surface is what makes Ladder agent-native. Every AI workflow that touches design can call this.
+- AI agent (Claude Desktop, Cursor, custom) loads MCP config with API key.
+- Connects to the MCP server at `api.runladder.com/mcp` (or wherever we host it).
+- Calls `ladder.score(url or image)` tool.
+- Receives the score, rung, and breakdown as structured tool output.
+- Never sees the rubric, the prompt, or the reasoning.
 
-See [API Protocols](/hq/api) for endpoint shape, rate limits, and the never-expose-prompts rule.
+This is what makes Ladder agent-native. Until it ships, the agent-native story is real only via the Claude Skill, which is the closest live equivalent.

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -36,7 +36,7 @@ Triggers for the upgrade conversation:
 - User clicks a Pro-only tab (a11y audit, UX copywriting) on a score result.
 - User hits the Pricing page directly.
 
-The Stripe checkout is self-serve at $250 (via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
+The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
 
 ### Team manager flow (Live, post-engagement)
 
@@ -90,7 +90,7 @@ Key beats:
 
 **Pulse runs in `drawbackwards/ladder-beta` (Next.js + Prisma on Fly.io), not in `runladder`.** The `/pulse` route on runladder.com is a marketing landing page that points at `/contact`, not the Pulse product surface.
 
-First customer is Lumin Digital (Sept 2025 to Sept 2026 engagement, $90K). Pulse customer data, scoring, and dashboards all live in `ladder-beta`. Consolidation into `runladder` is a future decision, not active (see [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now)).
+First customer is Lumin Digital (Sept 2025 to Sept 2026 engagement). Pulse customer data, scoring, and dashboards all live in `ladder-beta`. Consolidation into `runladder` is a future decision, not active (see [Decisions Log](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now)).
 
 ### Pulse data flow (Live, in ladder-beta)
 
@@ -102,7 +102,7 @@ Key beats (per `ladder-beta` README):
 - Data persists in Prisma + Postgres on Fly.io.
 - Scoring uses OpenAI (`OPEN_AI_API_KEY` env), separate from `runladder`'s Anthropic scoring engine. Engine consolidation is roadmap.
 - Dashboard renders aggregate trends inside `ladder-beta` (not on runladder.com).
-- Pulse pool target is 50,000 queries per month per [Decisions Log → Pricing](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only).
+- Pulse pool size is set per engagement (publicly Custom on `/pricing`). See [Decisions Log -- Public pricing](/hq/decisions#public-pricing-free-5-lifetime-pro-1000mo-self-serve-team-and-pulse-custom) for what's public.
 
 ## Ladder API and MCP: Roadmap (not built)
 

--- a/src/content/hq/roadmap.mdx
+++ b/src/content/hq/roadmap.mdx
@@ -2,64 +2,210 @@
 title: Roadmap
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## How this page works
 
-This is the human-readable roadmap. When the GitHub Project board for `drawbackwards/runladder` is set up, it becomes the live source of truth and this page links to it. Until then, this is the snapshot.
+The platform roadmap. What's gated on what, what we're working this week, and the longer threads.
 
-Priorities refresh every Wednesday during the weekly review. Sara updates this page when a priority lands or shifts.
+Priorities refresh every Wednesday during the weekly review. Sara updates this page when a priority lands or shifts. Every PR that changes roadmap status bumps `lastPr` per the [lockstep protocol](/hq/decisions#hq-stays-in-lockstep-with-the-code).
+
+The GitHub Project board for `drawbackwards/runladder` is the live source of truth when it ships. Until then, this page is the snapshot.
 
 ## Public launch gate
 
 Public marketing launch is gated on three developer surfaces being live. See [Decisions Log → Public launch](/hq/decisions#public-launch-is-gated-on-mcp-skill-and-api-being-live).
 
-- [ ] MCP server live at `api.runladder.com/mcp` with `ladder.score` tool
-- [ ] Claude Skill v1 in the Anthropic skill registry
-- [ ] Public Ladder API v1 documented at api.runladder.com
+- [ ] MCP server live (likely at `api.runladder.com/mcp`)
+- [ ] Claude Skill distributed beyond manual install (marketplace.json published)
+- [ ] Public Ladder API v1 documented and callable (at `api.runladder.com/v1/*`)
 
-All three are this-month work per the accelerated [API headless strategy](/hq/decisions). Until all three flip, no paid acquisition push. Soft launches with the design community on `/framework` are fine.
+Until all three flip, no paid acquisition push. Soft launches with the design community on `/framework` are fine.
 
 ## This week (active)
 
 | Priority | Surface | Status |
 | --- | --- | --- |
-| Ladder HQ content fill (Sara seeds all sections) | `/hq` | In flight (this PR) |
+| HQ audit corrections + GTM strategy + roadmap expansion | `/hq` | In flight (this PR) |
 | Pricing page overhaul (Free 5-lifetime, Pro $250, Teams contact) | Web | In flight |
-| MCP server v1 (`ladder.score` tool) | API + MCP | In flight |
-| Claude Skill polish for registry submission | Skill | In flight |
-| Pulse pipeline for Lumin Digital | Pulse | Ongoing (Sept 2025 to Sept 2026 engagement) |
+| Pulse pipeline for Lumin Digital | Pulse (ladder-beta) | Ongoing (Sept 2025 to Sept 2026 engagement) |
 
 ## Next 30 days
 
 | Priority | Surface | Notes |
 | --- | --- | --- |
-| Public API v1 documentation at api.runladder.com | API | Public-launch gate |
-| Anthropic Skill registry submission | Skill | Public-launch gate |
+| Skill distribution: publish `marketplace.json` in this repo | Skill | See [Skill distribution roadmap](#skill-distribution-roadmap) |
+| `api.runladder.com` Phase 1 (DNS + subdomain serving runladder.com/api) | API | See [api.runladder.com roadmap](#apirunladdercom-roadmap) |
+| MCP server design + spec | API + MCP | Decide tool surface, auth, transport |
+| Claude Skill polish for broader install | Skill | Onboarding, error handling, docs |
 | Ladder Lift CTA on sub-3.0 scores | Web | Free to Teams bridge per [Decisions Log](/hq/decisions#ladder-lift-bridges-free--teams) |
-| Top 100 launch (`/top-100`) | Web | Marketing surface, content engine |
-| Figma plugin relaunch + marketplace demo | Plugin | Re-review restarted 2026-04-18 |
 | Trademark filing + legal protection | Business | Required before public references add the trademark symbol |
 
 ## This quarter
 
 | Priority | Surface | Notes |
 | --- | --- | --- |
-| Public marketing launch | All | Gated on the three above |
+| `api.runladder.com` Phase 2 (public API endpoints with Bearer auth) | API | Splits internal vs public scoring |
+| MCP server v1 build | API + MCP | Public-launch gate |
+| Top 100 launch (`/top-100`) | Web | Marketing surface, content engine |
+| Public profile (`/[username]`) | Web | After Top 100 ships |
+| Figma plugin relaunch + marketplace demo | Plugin | Re-review restarted 2026-04-18 |
 | Pro upsell flow polish (a11y + UX copywriting unlock) | Web | Conversion lever |
-| Pulse expansion (theme clustering, drill-down) | Pulse | Beyond Lumin pilot |
+| `/dashboard/settings` (account, billing, API keys) | Web | Required before public API ships (key issuance UI) |
 | Engineering hire trigger evaluation | Team | See [Decisions Log → Engineering model](/hq/decisions#engineering-model-current-state) |
-| `/[username]` public profile pages | Web | After Top 100 ships |
+
+## Skill distribution roadmap
+
+The Ladder Skill (`Ladder for Claude`) works today: bundle v1.0.6, backend at `/api/skill/*`. Distribution is currently manual (Ward installed it in his Claude.ai by hand). Broader distribution path:
+
+### Phase 1: publish `marketplace.json` (Now to 30 days)
+
+Anthropic's Skills distribution model uses **plugin marketplaces** defined by a `marketplace.json` file in a public git repo. Anyone with the repo URL can `/plugin marketplace add drawbackwards/runladder` and then `/plugin install ladder`.
+
+Concrete steps:
+
+1. Create `.claude-plugin/marketplace.json` at the root of `drawbackwards/runladder`.
+2. Add the Ladder Skill bundle as a plugin in the manifest (point at the existing `src/lib/skill-version.ts` bundle definition).
+3. Test installation flow with a fresh Claude.ai account.
+4. Document install steps on `/framework` (or a dedicated `/skill` page) so designers know how to add it.
+5. Cross-link from runladder marketing pages.
+
+Owner: Ward + Sara (build) or Chester + Michael with Ward approval. Sean reviews.
+
+### Phase 2: submit to `anthropics/skills` (30 to 60 days)
+
+Anthropic maintains a public marketplace at [anthropics/skills](https://github.com/anthropics/skills). External skills can be listed there for broader discovery.
+
+Concrete steps:
+
+1. Verify Anthropic's submission policy (open PR vs application form).
+2. Prepare a Ladder skill description that matches their listing format.
+3. Submit via the appropriate channel.
+4. Maintain the listing as the bundle updates.
+
+Owner: Michael (PM coordinates), Ward signs off on listing copy.
+
+### Phase 3: Teams enterprise deployment (after Teams scales)
+
+Anthropic supports admin workspace-wide skill deployment (shipped December 2025). When a Teams customer onboards, their workspace admin can install Ladder for the whole team in one move.
+
+Concrete steps:
+
+1. Document the workspace deploy flow in the Teams onboarding handoff.
+2. Add a "deploy Ladder to your Claude.ai workspace" step to the Drawbackwards Teams engagement SOW.
+3. Build a smooth handoff so Teams customers don't have to figure this out themselves.
+
+Owner: Michael (PM), with Drawbackwards delivery lead on each engagement.
+
+## api.runladder.com roadmap
+
+The dedicated public API surface and MCP server do not exist yet. `api.runladder.com` DNS returns NXDOMAIN today. Below is the phased plan.
+
+### Phase 1: domain + DNS (1 day)
+
+1. Register `api.runladder.com` subdomain at the DNS provider.
+2. Point at Vercel (same project or new project, see Phase 2).
+3. Add an `auth-gate` redirect so anything hitting the bare domain returns a friendly "Ladder API coming soon" page until Phase 2 ships.
+
+Owner: Ward.
+
+### Phase 2: architecture decision and scaffold (1 to 2 weeks)
+
+Pick one of three options for what lives at the subdomain:
+
+- **Option A: Rewrite to `runladder.com/api/*`.** Simplest. Single Vercel project. Routes rewritten at the edge. Less isolation; harder to apply different rate limits or auth.
+- **Option B: Separate Vercel project for the public API.** Cleanest separation. Lets us version the public contract independently of the web app. More infra to maintain.
+- **Option C: Same project, subdomain-aware routing.** Middle ground. Single deploy, route handlers check `Host` header to gate public vs internal endpoints.
+
+Recommended: **Option A for Phase 2** (fastest to ship), revisit Option B when public API traffic warrants it.
+
+Whichever option, add a `/v1/score` endpoint (separate from `/api/score`) that:
+
+- Authenticates via Bearer token (`Authorization: Bearer ldr_live_...`)
+- Accepts a richer input shape (URL or image, surface tag, options)
+- Returns the same scoring result the web app uses
+- Emits `X-Ladder-API-Version`, `X-Ladder-Quota-Remaining`, `X-Ladder-Surface` headers
+- Counts against tier limits in the same `plans.ts` system
+
+Owner: Ward + Sara.
+
+### Phase 3: API key issuance UI (1 week)
+
+Build `/dashboard/settings`:
+
+1. List existing API keys (masked).
+2. Generate new keys with a label.
+3. Rotate or revoke individual keys.
+4. Show usage stats per key (this month, lifetime).
+
+Owner: Ward + Sara (eng), Chester (design).
+
+### Phase 4: MCP server (2 to 3 weeks)
+
+Build the MCP server as a separate route on `api.runladder.com/mcp` (or a separate transport per MCP spec).
+
+Tool surface (target):
+
+- `ladder.score(url? | image?, surface)` returns `{ score, rung, rungColor, breakdown, scoreId }`
+- `ladder.framework()` returns the framework reference (rungs, ranges, definitions)
+- `ladder.account()` returns the caller's tier and remaining quota
+
+Auth: Bearer API key in MCP config. Never exposes the rubric or the prompt.
+
+Owner: Ward + Sara. Sean engineering review.
+
+### Phase 5: OpenAPI spec + docs site (1 to 2 weeks)
+
+1. Write the OpenAPI 3.1 spec for the public API.
+2. Choose a docs tool (Mintlify, Scalar, Docusaurus, or MDX in this repo).
+3. Publish at `api.runladder.com/docs` (or just the root of `api.runladder.com`).
+4. Include MCP server config example, auth flow, rate limit table, error codes, example requests.
+
+Owner: Michael (writes copy), Ward + Sara (implements).
+
+### Phase 6: Public-launch gate flip
+
+When Phases 1 to 5 are live, all three public-launch gates flip (MCP, Skill marketplace, public API docs). At that point:
+
+- Decisions Log entry: public launch gate flipped, paid acquisition unblocked.
+- Marketing push: blog announcement, social, designer newsletter outreach, Top 100 launch coordinated.
+- GTM funnel activates as documented in [/hq/gtm](/hq/gtm).
+
+## Pulse consolidation (future)
+
+`drawbackwards/ladder-beta` (Pulse) and `drawbackwards/ladder` (original Rails) stay in their own repos for now. See [Decisions Log → Pulse and original Ladder stay in separate repos](/hq/decisions#pulse-and-original-ladder-stay-in-separate-repos-for-now).
+
+Triggers that would move this from future to active:
+
+- Lumin Digital engagement renewal or expansion that requires shared infra.
+- Pulse signs a second customer and the duplicate-engine cost (OpenAI in ladder-beta, Anthropic in runladder) starts to bite.
+- runladder API ships and ladder-beta could reasonably consume it instead of OpenAI.
+
+No commitment to a quarter. Track here, revisit when a trigger fires.
+
+## Hiring trigger
+
+Engineering is Ward + Sara as AI pair + Chester and Michael with Ward's approval on web/plugin/Skill + Sean for weekly audit. See [Decisions Log → Engineering model](/hq/decisions#engineering-model-current-state).
+
+Triggers that would move "engineering hire" from future to active:
+
+- Pulse pipeline scale issues that need dedicated time.
+- API uptime SLA after public launch.
+- Anthropic skill marketplace traction that creates broader API demand.
+- Sean's audit hours stop being enough.
+
+No active recruiting until one of those fires.
 
 ## Standing items
 
 These never close. They show up in the review when they need attention.
 
-- **Documentation drift.** Any `/hq` page untouched in 30 days gets a refresh nudge.
+- **Documentation drift.** Any `/hq` page untouched in 30 days gets a refresh nudge during weekly review.
 - **Prompt-leak check.** `scripts/check-no-prompt-leak.mjs` runs pre-build. A trip is a P0.
 - **Versioning sync.** Web app, API, and Skill versions all bump independently. Always pair a version bump with a `CHANGELOG.md` entry.
 - **Decisions Log review.** When the world changes (pricing experiment results, customer feedback, market shift), revisit the affected entry. Update or remove the stale memory.
+- **Evidence audit.** Every claim of "Live" in `/hq/features` must point to a file, route, or PR. See [Decisions Log → Every claim of live must point to evidence](/hq/decisions#every-claim-of-live-in-hq-must-point-to-a-route-file-or-pr).
 
 ## Weekly review
 

--- a/src/content/hq/roadmap.mdx
+++ b/src/content/hq/roadmap.mdx
@@ -28,7 +28,7 @@ Until all three flip, no paid acquisition push. Soft launches with the design co
 | Priority | Surface | Status |
 | --- | --- | --- |
 | HQ audit corrections + GTM strategy + roadmap expansion | `/hq` | In flight (this PR) |
-| Pricing page overhaul (Free 5-lifetime, Pro $250, Teams contact) | Web | In flight |
+| Pricing page polish (Pulse tier card + API tier display) | Web | In flight |
 | Pulse pipeline for Lumin Digital | Pulse (ladder-beta) | Ongoing (Sept 2025 to Sept 2026 engagement) |
 
 ## Next 30 days

--- a/src/content/hq/roles.mdx
+++ b/src/content/hq/roles.mdx
@@ -2,7 +2,7 @@
 title: Roles
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 179
 ---
 
 ## End-user roles
@@ -12,13 +12,13 @@ These are the tiers a customer can hold. Drives every gated feature on every sur
 | Role | Bought via | What it unlocks |
 | --- | --- | --- |
 | **Anonymous** | - | Marketing pages only. No scoring. Sign-up required to score. |
-| **Free** | Sign-up | 5 lifetime scores on web. Base score only. No a11y or UX copywriting tabs. |
-| **Pro** | Stripe self-serve, $250 | 1,000 queries/month, all surfaces, a11y and UX copywriting unlocked, enhanced dashboard. |
-| **Team Member** | Invited by Team Leader | Shares the team pool (25,000 queries/month). All Pro features. Sees team leaderboard. |
-| **Team Leader** | Drawbackwards engagement | Manages seats, invites Team Members, sees team dashboard, controls billing. Comes via MSA + SOW. |
-| **Pulse User** | Pulse engagement | All Pro features + Pulse dashboard at `/dashboard/pulse`. 50,000-query pool. |
+| **Free** | Sign-up | 5 lifetime scores. Base score only. No a11y or UX copywriting tabs. |
+| **Pro** | Stripe self-serve, $1,000/mo (public) | 2,000 scores/mo, all surfaces, a11y and UX copywriting unlocked, enhanced dashboard. Hard cap at 4,000 scores/mo (2x soft cap). |
+| **Team Member** | Invited by Team Leader | Shares the team pool (25,000 pooled scores/mo). All Pro features. Sees team leaderboard. |
+| **Team Leader** | Drawbackwards engagement (Beta) | Manages seats, invites Team Members, sees team dashboard, controls billing. Comes via MSA + SOW. Public price: Custom. |
+| **Pulse User** | Pulse engagement | All Team features + Pulse data ingest and customer-feedback dashboard (lives in `ladder-beta`). Public price: Custom. |
 
-See [Decisions Log → Pricing](/hq/decisions#pricing-free-5-lifetime-pro-250-self-serve-teams-contact-only) for the rationale.
+See [Decisions Log -- Public pricing](/hq/decisions#public-pricing-free-5-lifetime-pro-1000mo-self-serve-team-and-pulse-custom) for the rationale.
 
 ## Internal roles
 
@@ -34,12 +34,12 @@ These gate access to platform internals. Email-based allowlist defined in `src/l
 
 | Capability | Free | Pro | Team Member | Team Leader | Pulse | Admin | Super Admin |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Score a screen | 5/lifetime | 1K/mo | Pool | Pool | Pool | Yes | Yes |
+| Score a screen | 5 lifetime | 2K/mo (4K hard cap) | Pool | Pool | Pool | Yes | Yes |
 | A11y audit | - | Yes | Yes | Yes | Yes | Yes | Yes |
 | UX copywriting | - | Yes | Yes | Yes | Yes | Yes | Yes |
 | Personal dashboard | Basic | Enhanced | Enhanced | Enhanced | Enhanced | Yes | Yes |
 | Team dashboard + leaderboard | - | - | View | Manage | - | View | Manage |
-| Pulse dashboard | - | - | - | - | Yes | View | View |
+| Pulse dashboard (in `ladder-beta`) | - | - | - | - | Yes | View | View |
 | Invite team members | - | - | - | Yes | - | - | Yes |
 | `/admin` console | - | - | - | - | - | Yes | Yes |
 | `/hq` team hub | - | - | - | - | - | Yes | Yes (Chester, Sean via TEAM_EMAILS) |

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.5.1";
+export const CURRENT_APP_VERSION = "0.5.2";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
## Summary

v0.5.2 covers four threads after the v0.5.1 audit revealed `/hq` had invented features and quoted stale pricing:

1. **Audit corrections.** Every claim in `/hq` now points to a route, file, or PR. Removed fictional `api.runladder.com` URLs, fictional MCP tools, fictional `POST /v1/score` shape, fictional `/dashboard/settings` references.
2. **Full platform roadmap** at [/hq/roadmap](https://runladder.com/hq/roadmap) including the Skill distribution path and the `api.runladder.com` phased plan.
3. **Go-to-Market strategy** as a new page at [/hq/gtm](https://runladder.com/hq/gtm) in CRO voice, with internal revenue projections kept out of `/hq` and routed to non-`/hq` memory instead.
4. **Pricing scrub.** Pro was $250 across `/hq` but Pro actually went to $1,000/mo in v0.4.8 (PR #166) and is live on Stripe. All references corrected. Team / Pulse / Ladder Lift specifics removed from `/hq` since the team-hub is read by engineering-audit and design roles who don't need internal sales numbers.

## Page-by-page

- **`/hq/architecture`**: codebase map showing three repos (`runladder` here, `ladder-beta` on Fly.io for Pulse, `ladder` for original Rails). Mermaid diagram framed as future-target, not current.
- **`/hq/api`**: rewritten. Real endpoint table from `src/app/api/`. Real `POST /api/score` shape from the route file. Honest separation of today vs `api.runladder.com` roadmap. Pulse pool marked Custom (not public on `/pricing`).
- **`/hq/journeys`**: every flow tagged Live / In flight / Roadmap. Pulse flow notes `ladder-beta`. Stripe checkout reference updated to $1,000/mo.
- **`/hq/features`**: every row has an Evidence column pointing to a file/route/PR. Pulse and Original Ladder get their own sections. Pricing page row corrected to current state.
- **`/hq/decisions`**: three new entries at the top. (1) /hq documents PUBLIC pricing only. (2) Every claim of `Live` must point to evidence. (3) Pulse + original Ladder stay in separate repos for now. Existing Pricing entry updated to Pro $1,000/mo. Ladder Lift entry reframed as internal concept.
- **`/hq/roadmap`**: expanded with Skill distribution roadmap (3 phases: marketplace.json, anthropics/skills, Teams enterprise), api.runladder.com roadmap (6 phases: DNS, architecture, key UI, MCP, OpenAPI, launch), Pulse consolidation triggers, hiring triggers.
- **`/hq/gtm`** (NEW): North star, ICP, funnel by surface, three-motion sales (PLG / sales-assisted / enterprise), channels, public-launch day-by-day sequence, metrics, risks. Specific revenue projections live in non-`/hq` memory.
- **`/hq/roles`**: Pro updated to $1,000/mo with 2,000 scores/mo soft + 4,000 hard cap. Team and Pulse marked Custom.
- **`/hq/glossary`**: Pro definition corrected, Lift reframed as internal concept, pool definition updated.

## What did NOT get committed

Specific internal pricing numbers (Team target floor, Pulse engagement ACVs, Ladder Lift price bands, customer dollar values). They live in Ward and Michael's working memory and the Drawbackwards sales pipeline. The new `feedback_hq_public_pricing_only` memory enforces this rule for future Sara sessions.

## Test plan

- [ ] Visit [/hq](https://runladder.com/hq), confirm 12 sidebar links (Go-to-Market added)
- [ ] Visit [/hq/gtm](https://runladder.com/hq/gtm), confirm 11 sections + 3 tables render and no specific Team/Pulse/Lift dollar amounts appear
- [ ] Visit [/hq/roadmap](https://runladder.com/hq/roadmap), confirm Skill distribution + api.runladder.com sections render with phases
- [ ] Visit [/hq/architecture](https://runladder.com/hq/architecture), confirm codebase map table shows 4 repos
- [ ] Visit [/hq/features](https://runladder.com/hq/features), confirm every row has Evidence column and pricing row reflects Pro $1,000/mo
- [ ] Visit [/hq/journeys](https://runladder.com/hq/journeys), confirm Pulse flow notes ladder-beta
- [ ] Visit [/hq/api](https://runladder.com/hq/api), confirm real endpoint table from `src/app/api/` and Pulse pool marked Custom
- [ ] Visit [/hq/decisions](https://runladder.com/hq/decisions), confirm three new entries at top (public-pricing-only, evidence-required, separate-repos) and Pricing entry shows $1,000/mo
- [ ] Visit [/hq/roles](https://runladder.com/hq/roles), confirm Pro shows $1,000/mo and Team/Pulse show Custom
- [ ] Visit [/hq/glossary](https://runladder.com/hq/glossary), confirm Pro definition is $1,000/mo and Lift is described as internal concept

🤖 Generated with [Claude Code](https://claude.com/claude-code)