### PR TITLE
HQ: Michael full-surface eng scope + post-merge verification protocol (v0.5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.3 / api 1.0.0 (2026-05-19)
+
+**Engineering model update + post-merge /hq verification protocol.**
+
+- **Michael graduates to full-surface engineering scope.** Was previously web/plugin/Skill only; now can build on any surface (API, MCP, Pulse, admin included) with Ward's prior approval. Chester stays scoped to web/plugin/Skill where his design lens applies directly. `/hq/decisions` Engineering model entry updated, `/hq/team` matrix updated to show Michael as build support on every surface, project CLAUDE.md reflects the new model.
+- **Post-merge `/hq` verification protocol.** New unbreakable rule: after ANY PR ships live in any of the four Ladder platform repos (`runladder`, `ai-design-assistant`, `ladder-beta`, `ladder`), Sara verifies `/hq` is current and prints a confirmation to Ward. Confirmation format includes pages updated, pages spot-checked, and a link to /hq. Silence after a deploy is not acceptable; "no updates needed, all current" must still be said explicitly. New Decisions Log entry codifies it. CLAUDE.md gains a dedicated section. New `feedback-hq-post-merge-verification` memory enforces it across future Sara sessions.
+
+---
+
 ## app 0.5.2 / api 1.0.0 (2026-05-19)
 
 **Ladder HQ: audit corrections, full platform roadmap, Go-to-Market strategy, Skill distribution plan, pricing scrub.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,41 @@ Map of code areas to docs:
 
 If a code change has no doc consequence, say so in the commit body. Otherwise the doc update is part of the PR. Sara enforces this for AI-paired work. Ward, Chester, and Michael enforce it for their own PRs.
 
+## Post-merge /hq verification (UNBREAKABLE, all Ladder platform repos)
+
+After ANY PR ships live in any of the four Ladder platform repos, Sara verifies `/hq` is current and prints a confirmation to Ward. The four repos:
+
+1. `drawbackwards/runladder` (this repo)
+2. `drawbackwards/ai-design-assistant` (Figma plugin + first-gen API)
+3. `drawbackwards/ladder-beta` (Pulse)
+4. `drawbackwards/ladder` (original Rails)
+
+When a PR ships live, walk the `/hq` pages most likely affected (the same map as the lockstep section above). If updates are needed, open a follow-up PR. Then print the confirmation in this shape:
+
+```
+HQ verified for PR #N (vX.Y.Z).
+- Pages updated: list (or "none, all current")
+- Pages spot-checked: list
+- Live at runladder.com/hq
+```
+
+Silence after a deploy is not acceptable. Even if no `/hq` update was needed, say so explicitly. The handshake is the discipline.
+
+Documentation-only PRs to non-platform repos (engineering-standards, drawbackwards-knowledge, etc.) do not trigger the rule.
+
+## Engineering model
+
+- **Ward** leads engineering with Claude (Sara) as AI pair.
+- **Michael** can build any surface (web, plugin, Skill, API, MCP, Pulse, admin) with Ward's prior approval on scope.
+- **Chester** can build on web, plugin, and Skill with Ward's prior approval.
+- **Sean** does a one-hour weekly engineering audit and on-demand reviews.
+
+Ward's approval is the merge gate for every non-trivial Chester or Michael PR. See `/hq/decisions` for the full rationale.
+
 ## Related Repos
 
 - **drawbackwards/ai-design-assistant** — Figma plugin + current API (will migrate API here over time)
+- **drawbackwards/ladder-beta** — Pulse codebase (Next.js + Prisma on Fly.io)
+- **drawbackwards/ladder** — original Ladder Rails backend
 - **drawbackwards/db-website-2026** — Drawbackwards agency website
+- **drawbackwards/engineering-standards** — engineering standards, security, dev workflows

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 179
+lastPr: 180
 ---
 
 ## How to use this page
@@ -10,6 +10,32 @@ lastPr: 179
 The why behind big choices. Read this before you push back on a feature, a price, or a roadmap call. Most decisions look arbitrary until you know the constraint that drove them. New entries go at the top with a date and one-line rule.
 
 If you want to challenge a decision, file an issue in GitHub with the proposed change and link the entry. We update entries when the world changes, never silently.
+
+---
+
+## Post-merge /hq verification across all Ladder platform repos (2026-05-19)
+
+**UNBREAKABLE rule.** Every time a PR ships live in any of the four Ladder platform repos (`runladder`, `ai-design-assistant`, `ladder-beta`, `ladder`), Sara verifies `/hq` is current and prints a confirmation to Ward.
+
+The confirmation shape:
+
+> **HQ verified for PR #N (vX.Y.Z).**
+> - Pages updated: list (or "none, all current")
+> - Pages spot-checked: list
+> - Live at runladder.com/hq
+
+Silence after a deploy is not acceptable. Even if no `/hq` update was needed, say so explicitly. The handshake is the discipline.
+
+Why: the v0.5.1 audit revealed `/hq` had drifted because doc updates were happening reactively. The post-merge verification print forces the check to happen at the natural moment (just shipped) and makes the discipline visible to Ward.
+
+How to apply:
+
+- After every Ladder-platform PR merge, walk the `/hq` pages most likely affected (Features, Journeys, API, Decisions, Roles, Roadmap, Architecture, Glossary, Brand, GTM).
+- If updates are needed, open a follow-up PR. Bump `lastPr` per [the lockstep protocol](/hq/decisions#hq-stays-in-lockstep-with-the-code).
+- If no updates needed, print the confirmation with "Pages updated: none, all current."
+- Documentation-only PRs to non-platform repos (engineering-standards, drawbackwards-knowledge, etc.) do not trigger this rule.
+
+This rule sits alongside [the lockstep protocol](/hq/decisions#hq-stays-in-lockstep-with-the-code) and [the public-pricing rule](/hq/decisions#hq-documents-public-pricing-only). All three are part of the same hygiene system.
 
 ---
 
@@ -197,13 +223,13 @@ How to apply: free-tier surfaces show a11y and UX copywriting as locked tabs wit
 
 ## Engineering model (current state)
 
-**Ward leads engineering with Claude (Sara) as AI pair. Chester and Michael can also build with Claude on the web app, Figma plugin, and Claude Skill, with Ward's prior approval. Sean does a one-hour weekly engineering audit and on-demand reviews.**
+**Ward leads engineering with Claude (Sara) as AI pair. Michael can build any surface (web, plugin, Skill, API, MCP, Pulse, admin). Chester can build on web, plugin, and Skill. All non-trivial PRs need Ward's prior approval. Sean does a one-hour weekly engineering audit and on-demand reviews.**
 
-**Restricted surfaces:** the Ladder API, MCP server, Pulse data pipeline, and admin console stay Ward-only on the engineering side. Higher blast radius (auth keys, billing, customer data, prompts).
+Updated 2026-05-19 to give Michael full-surface scope (was previously web/plugin/Skill only). Chester stays scoped to web/plugin/Skill, the surfaces where his design and interaction lens applies directly.
 
-Why: Ladder is small enough that the founder + AI pair model ships faster than hiring would. Expanding the build capacity to Chester and Michael (also using Claude) is the practical way to scale engineering without breaking the agent-native story or paying for a hire. Sensitive surfaces stay gated because a bad change on API or Pulse has much higher cost than on web/plugin/skill.
+Why: Ladder is small enough that the founder + AI pair model ships faster than hiring would. Michael is the PM, drives day-to-day coordination, and has cross-surface context, so restricting him to three surfaces created bottlenecks. The Ward-approval gate stays in place on every non-trivial PR to keep blast radius controlled on sensitive surfaces (API, MCP, Pulse, admin).
 
-How to apply: default to Ward + Sara on engineering. For non-trivial web/plugin/skill work, Ward can hand off to Chester or Michael after he approves the scope. Sean's review is engineering audit, not a PR gate. Ward's approval is the gate that lets a Chester or Michael PR merge. Hiring trigger is tracked on the [Roadmap](/hq/roadmap).
+How to apply: default to Ward + Sara on engineering. For any surface, Ward can hand off to Michael after approving scope. For web/plugin/Skill, Chester is also an option. Sean's review is engineering audit, not a PR gate. Ward's approval is the gate that lets a Michael or Chester PR merge. Hiring trigger is tracked on the [Roadmap](/hq/roadmap).
 
 ---
 

--- a/src/content/hq/team.mdx
+++ b/src/content/hq/team.mdx
@@ -2,7 +2,7 @@
 title: Team Assignments
 updatedAt: 2026-05-19
 updatedBy: Sara
-lastPr: 178
+lastPr: 180
 ---
 
 ## Roster
@@ -10,8 +10,8 @@ lastPr: 178
 | Name | Role | Notes |
 | --- | --- | --- |
 | **Ward Andrews** | Founder. Vision, brand, strategy, engineering lead | Final call on everything. Available via Slack and direct |
-| **Michael Sidler** | Project manager. Owns blog, teardowns, framework pages | Day-to-day coordinator. First escalation point |
-| **Chester Schendel** | Scoring quality, visual + interaction design | Owns the rubric review loop and design refinement |
+| **Michael Sidler** | Project manager. Owns blog, teardowns, framework pages. Engineering across all surfaces with Ward's approval | Day-to-day coordinator. First escalation point. Full-surface eng access added 2026-05-19 |
+| **Chester Schendel** | Scoring quality, visual + interaction design. Engineering on web, plugin, Skill with Ward's approval | Owns the rubric review loop and design refinement |
 | **Jordan Hunke** | UI/UX design, marketing content (video, art) | Marketing surface + product polish |
 | **Sean Coleman** | Engineering audit | 1 hour per week, on-demand when Ward or Michael ask for it |
 
@@ -24,10 +24,10 @@ Owner is the person accountable for the surface shipping and staying healthy. Su
 | Web app (runladder.com) | Ward (eng), Chester (design) | Chester (build), Michael (build), Jordan | Sean |
 | Figma plugin | Ward (eng), Chester (design) | Chester (build), Michael (build), Jordan | Sean |
 | Claude Skill | Ward | Chester (build), Michael (build) | Sean |
-| API + MCP | Ward | - | Sean |
-| Pulse | Ward | Chester (scoring) | Sean |
-| Admin console | Ward | - | Sean |
-| Scoring engine + quality | Chester | Ward | Sean |
+| API + MCP | Ward | Michael (build) | Sean |
+| Pulse | Ward | Michael (build), Chester (scoring) | Sean |
+| Admin console | Ward | Michael (build) | Sean |
+| Scoring engine + quality | Chester | Ward, Michael | Sean |
 | Blog + teardowns + framework | Michael | Jordan, Ward | Ward |
 | Marketing content (video, art) | Jordan | Michael | Ward |
 | Brand identity | Ward | Jordan | - |
@@ -36,13 +36,15 @@ Owner is the person accountable for the surface shipping and staying healthy. Su
 
 ## Engineering model
 
-Ward leads engineering with Claude (Sara) as AI pair. **Chester and Michael can also build in Claude on the web app, Figma plugin, and Claude Skill, with Ward's prior approval on scope.** Sean does the weekly audit and on-demand review.
+Ward leads engineering with Claude (Sara) as AI pair. **Michael can build any surface (web, plugin, Skill, API, MCP, Pulse, admin) with Ward's prior approval on scope. Chester can build on web, plugin, and Skill with Ward's prior approval.** Sean does the weekly audit and on-demand review.
 
-The API, MCP server, Pulse data pipeline, and admin console stay Ward-only on the engineering side. Higher blast radius (auth keys, billing, customer data, prompts) means a tighter gate.
+The Ward-approval gate stays in place for every non-trivial PR on every surface. This is intentional and consistent with Ladder's agent-native positioning. See [Decisions Log -- Engineering model](/hq/decisions#engineering-model-current-state) for the full rationale and the 2026-05-19 update that gave Michael full-surface scope. Hiring trigger is tracked on the [Roadmap](/hq/roadmap).
 
-This model is intentional and consistent with Ladder's agent-native positioning. See [Decisions Log → Engineering model](/hq/decisions#engineering-model-current-state) for the full rationale. Hiring trigger is tracked on the [Roadmap](/hq/roadmap).
+**For Michael and Chester:** before you open a PR, post in #ladder-platform with the proposed scope and tag Ward. Once he gives a green light, build and open the PR. Sean's weekly audit catches any engineering smells. Ward's approval is the gate that lets the PR merge.
 
-**For Chester and Michael:** before you open a PR, post in #ladder-platform with the proposed scope and tag Ward. Once he gives a green light, build and open the PR. Sean's weekly audit catches any engineering smells. Ward's approval is the gate that lets the PR merge.
+## Post-merge `/hq` verification
+
+Every PR that ships live in any Ladder platform repo triggers a Sara-driven `/hq` check and a confirmation message back to Ward. See [Decisions Log -- Post-merge /hq verification](/hq/decisions#post-merge-hq-verification-across-all-ladder-platform-repos).
 
 ## Day-to-day
 
@@ -52,7 +54,7 @@ This model is intentional and consistent with Ladder's agent-native positioning.
 
 **PR review.** Engineering PRs go through Sean for one-hour weekly review. Non-blocking PRs (typos, copy fixes, content) merge after a one-emoji approval from any teammate.
 
-**Escalation path.** Michael → Ward. Don't go around Michael unless it's a production fire on a surface he doesn't own.
+**Escalation path.** Michael to Ward. Don't go around Michael unless it's a production fire on a surface he doesn't own.
 
 ## Updating this page
 

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -11,7 +11,7 @@
  */
 
 // runladder.com (this web app). Visible in the footer.
-export const CURRENT_APP_VERSION = "0.5.2";
+export const CURRENT_APP_VERSION = "0.5.3";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
## Summary

Two unbreakable changes Ward asked for.

### 1. Michael graduates to full-surface engineering scope

Was previously web/plugin/Skill only with Ward's approval. Now Michael can build on **any surface** (web, plugin, Skill, API, MCP, Pulse, admin) with Ward's prior approval. Chester stays scoped to web/plugin/Skill where his design lens applies directly. Sean remains the weekly audit.

### 2. Post-merge `/hq` verification protocol across all Ladder platform repos

After ANY PR ships live in any of the four Ladder platform repos, Sara verifies `/hq` is current and prints a confirmation to Ward.

Confirmation format:

```
HQ verified for PR #N (vX.Y.Z).
- Pages updated: list (or "none, all current")
- Pages spot-checked: list
- Live at runladder.com/hq
```

The four repos:

- `drawbackwards/runladder` (this repo)
- `drawbackwards/ai-design-assistant` (Figma plugin + first-gen API)
- `drawbackwards/ladder-beta` (Pulse)
- `drawbackwards/ladder` (original Rails)

Silence after a deploy is not acceptable. Even if no `/hq` update was needed, "Pages updated: none, all current" gets printed. The handshake is the discipline.

## Files

- `/hq/decisions`: new top entry codifies the post-merge protocol. Engineering model entry updated (Michael full scope, Chester web/plugin/Skill).
- `/hq/team`: roster note for Michael, surface matrix adds Michael (build) to API + MCP, Pulse, admin, Scoring engine. New section calls out the post-merge handshake.
- `CLAUDE.md`: Post-merge `/hq` verification section + Engineering model section. Related Repos list expanded to all four Ladder platform repos.
- `src/lib/app-version.ts`: 0.5.2 to 0.5.3.
- `CHANGELOG.md`: new entry covers both changes.

## Test plan

- [ ] Visit [/hq/decisions](https://runladder.com/hq/decisions), confirm "Post-merge /hq verification" is the top entry and Engineering model entry shows Michael full scope.
- [ ] Visit [/hq/team](https://runladder.com/hq/team), confirm Michael's roster row mentions cross-surface eng, and the matrix shows Michael (build) on API + MCP, Pulse, admin.
- [ ] First post-merge confirmation prints back when this PR merges (Sara will demonstrate the new protocol on this very merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)