### PR TITLE
Auth + onboarding fixes: redirects, gate bypass, login UI cleanup (v0.5.4)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,89 @@
+# =============================================================================
+# Ladder / runladder.com — local environment variables
+# =============================================================================
+# Copy this file to `.env.local` and fill in real values.
+# Never commit `.env.local`. This example file is safe to commit.
+#
+# Source of secrets: Ward / Drawbackwards 1Password vault. If you don't have
+# access yet, contact Sean (weekly engineering audit) or Michael (full-surface
+# scope) for onboarding while Ward is unavailable.
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# Clerk (auth) — REQUIRED for any auth flow to render
+# -----------------------------------------------------------------------------
+# Dev instance: choice-buck-27.accounts.dev
+# Dashboard:    https://dashboard.clerk.com
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+
+# Webhook signing secret for /api/webhooks/clerk (org membership events).
+# Only needed when testing the webhook locally via `svix listen` or a tunnel.
+CLERK_WEBHOOK_SECRET=whsec_...
+
+
+# -----------------------------------------------------------------------------
+# App URL — REQUIRED
+# -----------------------------------------------------------------------------
+# Used by Stripe callbacks and any absolute URL generation.
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+
+# -----------------------------------------------------------------------------
+# Upstash Redis — REQUIRED for usage limits, skill tokens, pending comps
+# -----------------------------------------------------------------------------
+# Without these, signed-in features (dashboard, scoring quota, skill token
+# rotation) will throw. Public pages (/, /framework, /pricing) still render.
+UPSTASH_REDIS_REST_URL=https://...upstash.io
+UPSTASH_REDIS_REST_TOKEN=...
+
+
+# -----------------------------------------------------------------------------
+# Admin & team allowlists — REQUIRED to access /admin and /hq
+# -----------------------------------------------------------------------------
+# Comma-separated emails. Super admins (ward@drawbackwards.com,
+# ward.andrews@gmail.com) are hardcoded in src/lib/admin.ts and don't need
+# to be in ADMIN_EMAILS.
+ADMIN_EMAILS=
+TEAM_EMAILS=
+
+
+# -----------------------------------------------------------------------------
+# Stripe (billing) — OPTIONAL for non-billing dev work
+# -----------------------------------------------------------------------------
+# Required only if exercising /pricing checkout, /api/stripe/* routes, or the
+# Customer Portal. See README.md for full Stripe setup.
+STRIPE_SECRET_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRO_PRICE_ID=price_...
+
+
+# -----------------------------------------------------------------------------
+# Anthropic (scoring engine) — REQUIRED for /score and any scoring API
+# -----------------------------------------------------------------------------
+# Read by @anthropic-ai/sdk.
+ANTHROPIC_API_KEY=sk-ant-...
+
+
+# -----------------------------------------------------------------------------
+# Resend (transactional email) — OPTIONAL
+# -----------------------------------------------------------------------------
+RESEND_API_KEY=re_...
+
+
+# -----------------------------------------------------------------------------
+# Internal integrations — OPTIONAL
+# -----------------------------------------------------------------------------
+# Beta password wall. Set to enable PasswordGate on every page.
+SITE_PASSWORD=
+
+# Admin-only routes / scripts (legacy)
+ADMIN_KEY=
+
+# Bridge to the ai-design-assistant Figma plugin backend.
+PLUGIN_ADMIN_KEY=
+PLUGIN_BACKEND_URL=
+
+# Service token for inter-service auth (Ladder Rails, Pulse).
+LADDER_SERVICE_TOKEN=

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
+!.env.local.example
 
 # vercel
 .vercel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.4 / api 1.0.0 (2026-05-26)
+
+**Auth + onboarding fixes ahead of the Ladder Team sale.**
+
+- **Post-auth redirects.** `ClerkProvider` now sets `signInUrl`/`signUpUrl`, `signInFallbackRedirectUrl`/`signUpFallbackRedirectUrl`, and `afterSignOutUrl`, so any Clerk flow (not just the embedded login/signup pages) has a redirect target. The org-invitation redirect on Clerk's hosted portal is governed by the dashboard Home URL and is tracked separately (#181).
+- **Password gate bypasses signed-in users.** `PasswordGate` lets any signed-in user through the `SITE_PASSWORD` wall, including invitees returning from Clerk's hosted portal with a session. This unblocks the Team onboarding flow; cold visitors still see the wall. The gate is dead code once `SITE_PASSWORD` is removed from Vercel (cleanup TODO added). New Decisions Log entry codifies the rationale.
+- **OTP form background fix.** An over-broad `globals.css` selector (`[class*="bg"]`) was matching Clerk's hashed internal classes and painting a dark background behind the OTP digits. Scoped `.cl-form` transparent and excluded it from the catch-all rule.
+- **Login UI cleanup.** Removed the dark background behind the identity-preview email field and removed the redundant Ladder logo above the auth form (the nav already shows it).
+- **Onboarding env docs.** Added `.env.local.example` documenting every env var needed for local onboarding work.
+- `/hq` updated: Decisions Log (gate bypass) and User Journeys (Team manager flow access note + invite-redirect known issue). PR #198.
+
+---
+
 ## app 0.5.3 / api 1.0.0 (2026-05-19)
 
 **Engineering model update + post-merge /hq verification protocol.**

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -269,6 +269,13 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: 0 !important;
 }
 
+/* Keep the sign-in form transparent so the page background shows through
+   behind the OTP digits and resend link (see the .cl-form exclusion on the
+   internal-bg catch-all rule below). */
+.cl-form {
+  background: transparent !important;
+}
+
 .cl-formFieldInput:focus,
 .cl-phoneNumberInput:focus {
   border-color: #6AC89B !important;
@@ -289,6 +296,11 @@ h1, h2, h3, h4, h5, h6 {
 
 .cl-formButtonPrimary:hover {
   background: #5ab88b !important;
+}
+
+/* Hide the trailing arrow icon Clerk adds to its primary submit buttons. */
+.cl-formButtonPrimary .cl-buttonArrowIcon {
+  display: none !important;
 }
 
 .cl-formButtonReset,
@@ -421,8 +433,13 @@ h1, h2, h3, h4, h5, h6 {
   color: #ccc !important;
 }
 
-[class*="cl-internal"][class*="bg"],
-[class*="cl-internal"][style*="background"] {
+/* NOTE: [class*="bg"] matches the substring "bg" anywhere in a class name,
+   including Clerk's random hashed classes (e.g. cl-internal-2l8bgd). That
+   accidentally forced a dark background onto the sign-in form. Exclude
+   .cl-form so the OTP screen's form stays transparent. The broad selector
+   is a smell worth replacing later with Clerk's actual bg class names. */
+[class*="cl-internal"][class*="bg"]:not(.cl-form),
+[class*="cl-internal"][style*="background"]:not(.cl-form) {
   background: #111 !important;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -53,6 +53,11 @@ export default function RootLayout({
 
   return (
     <ClerkProvider
+      signInUrl="/login"
+      signUpUrl="/sign-up"
+      signInFallbackRedirectUrl="/dashboard"
+      signUpFallbackRedirectUrl="/score"
+      afterSignOutUrl="/"
       appearance={{
         variables: {
           colorPrimary: "#6AC89B",

--- a/src/components/AuthShell.tsx
+++ b/src/components/AuthShell.tsx
@@ -1,6 +1,3 @@
-import Link from "next/link";
-import { LadderLogo } from "./LadderLogo";
-
 export function AuthShell({
   children,
   footer,
@@ -26,9 +23,6 @@ export function AuthShell({
         }}
       />
       <div className="relative w-full max-w-[28rem] flex flex-col items-center my-auto overflow-x-hidden">
-        <Link href="/" aria-label="Ladder home" className="mb-10 mt-4">
-          <LadderLogo height={26} className="text-white" />
-        </Link>
         <div className="w-full">{children}</div>
         <div className="text-muted text-sm text-center mt-8">{footer}</div>
       </div>

--- a/src/components/PasswordGate.tsx
+++ b/src/components/PasswordGate.tsx
@@ -1,10 +1,18 @@
 "use client";
 
+// TODO: delete this file (plus src/app/api/auth-gate/route.ts and the
+// gateEnabled conditional in src/app/layout.tsx) once SITE_PASSWORD is
+// permanently removed from Vercel. The whole gate becomes dead code at
+// that point — the layout never renders <PasswordGate> when the env var
+// is unset, so removal is a pure cleanup.
+
 import { useState, useEffect } from "react";
+import { useAuth } from "@clerk/nextjs";
 
 const STORAGE_KEY = "ladder_site_access";
 
 export function PasswordGate({ children }: { children: React.ReactNode }) {
+  const { isLoaded: clerkLoaded, isSignedIn } = useAuth();
   const [unlocked, setUnlocked] = useState(false);
   const [input, setInput] = useState("");
   const [error, setError] = useState(false);
@@ -30,7 +38,17 @@ export function PasswordGate({ children }: { children: React.ReactNode }) {
     }
   }, []);
 
-  if (!loaded) return null;
+  // Hold the render until both Clerk and the sessionStorage check have
+  // resolved. Otherwise a signed-in user briefly sees the password wall
+  // on every page load before Clerk hydrates and bypasses it.
+  if (!clerkLoaded || !loaded) return null;
+
+  // Signed-in users (including freshly-onboarded invitees returning from
+  // Clerk's hosted account portal with an active session) skip the wall.
+  // This keeps the gate effective against cold visitors while unblocking
+  // the customer onboarding flow.
+  if (isSignedIn) return <>{children}</>;
+
   if (unlocked) return <>{children}</>;
 
   async function submit(e: React.FormEvent) {

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -1,8 +1,8 @@
 ---
 title: Decisions Log
-updatedAt: 2026-05-19
+updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 180
+lastPr: 198
 ---
 
 ## How to use this page
@@ -10,6 +10,16 @@ lastPr: 180
 The why behind big choices. Read this before you push back on a feature, a price, or a roadmap call. Most decisions look arbitrary until you know the constraint that drove them. New entries go at the top with a date and one-line rule.
 
 If you want to challenge a decision, file an issue in GitHub with the proposed change and link the entry. We update entries when the world changes, never silently.
+
+---
+
+## Site password gate bypasses signed-in users (2026-05-26)
+
+**The runladder.com password wall (`SITE_PASSWORD`) is bypassed for any signed-in user, including invitees returning from Clerk's hosted portal with an active session. Cold visitors still hit the wall.**
+
+Why: the gate (`PasswordGate.tsx`) wraps the whole app and blocked the Team onboarding flow. An invited customer would accept a Clerk invite, return to runladder.com, and hit the password wall before reaching `/dashboard`. Bypassing signed-in users keeps the gate effective against casual visitors while letting real customers onboard. The decision is reversible and low-risk: the entire gate is dead code once `SITE_PASSWORD` is removed from Vercel, since the layout never renders it when the env var is unset.
+
+How to apply: do not treat the password gate as a security boundary. It is a client-side speed bump, and `/api/*` routes are not behind it. Real access control is Clerk auth plus the admin/team allowlists. Remove the gate (`PasswordGate.tsx`, `/api/auth-gate`, the layout conditional) once marketing edits land and `SITE_PASSWORD` is dropped. Shipped in PR #198.
 
 ---
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-05-19
+updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 179
+lastPr: 198
 ---
 
 ## How to read this page
@@ -49,6 +49,10 @@ After a Drawbackwards Teams engagement closes, the manager gets an admin invite.
 5. Reviews flow: designer requests review, manager accepts or declines, designer scores iterations in `/dashboard/reviews/[slug]`, manager and peers add Team Takes and pin annotations.
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
+
+**Onboarding access note (v0.5.4, PR #198):** signed-in users, including invitees returning from Clerk's hosted portal with an active session, bypass the site password gate (`SITE_PASSWORD`), so the invite flow isn't blocked by the wall. Cold visitors still see it. See [Decisions → Site password gate bypasses signed-in users](/hq/decisions).
+
+**Known issue (In flight, blocked on Clerk dashboard):** accepting an org invitation on Clerk's hosted portal currently dead-ends on Clerk's generic "Welcome" page instead of redirecting to runladder.com. The redirect is governed by the Clerk dashboard Home URL, which is unset because production still runs on a development Clerk instance (`pk_test_` across all Vercel environments). The fix needs Clerk dashboard access plus a production Clerk instance with DNS verification. Tracked in [#181](https://github.com/drawbackwards/runladder/issues/181). The in-app redirect config (`ClerkProvider` fallback URLs) shipped in PR #198 covers the embedded login/signup pages.
 
 ## Figma plugin: Live (in marketplace re-review per memory)
 

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -39,7 +39,7 @@ export const authAppearance = {
     formFieldInputShowPasswordButton: "!text-muted hover:!text-foreground",
     formResendCodeLink: "!text-ladder-green hover:!text-[#5ab88b]",
     identityPreview:
-      "!bg-card !border !border-border !rounded-lg !text-foreground",
+      "!bg-transparent !border-0 !text-foreground",
     identityPreviewText: "!text-foreground !text-sm",
     identityPreviewEditButton: "!text-ladder-green hover:!text-[#5ab88b]",
     otpCodeFieldInput:


### PR DESCRIPTION
## Summary

Fixes the broken onboarding flow blocking the upcoming Ladder Team sale. Addresses parts of #181 (Clerk config), #186 (password gate), and unblocks #190 (Team invite QA).

- **Post-auth redirects.** `ClerkProvider` now sets `signInUrl`/`signUpUrl`, fallback redirect URLs, and `afterSignOutUrl` so every Clerk flow has a redirect target, not just the embedded login/signup pages.
- **Password gate bypass.** Signed-in users (including invitees returning from Clerk's hosted portal with a session) skip the password wall, unblocking customer onboarding. Cold visitors still see the wall. The gate becomes dead code once `SITE_PASSWORD` is removed from Vercel (TODO added).
- **OTP form background.** Fixed an over-broad `globals.css` selector (`[class*="bg"]`) that accidentally matched Clerk's hashed internal classes and painted a dark background behind the OTP digits.
- **Login UI cleanup.** Removed the dark background behind the identity-preview email field, and removed the redundant Ladder logo above the auth form (the nav already shows it).
- **Env docs.** Added `.env.local.example` documenting all env vars needed for local onboarding work.

## Known follow-ups (not in this PR)

- **Org-invitation redirect** on Clerk's hosted portal is governed by the dashboard **Home URL** setting, not code. Needs Clerk dashboard access (tracked separately).
- **Production is on a dev Clerk instance** (`pk_test_` across all Vercel envs). A production Clerk instance + DNS verification is needed before selling to a customer.
- Pre-existing `react-hooks/set-state-in-effect` lint error in `PasswordGate.tsx` (present on main; not addressed here to keep scope focused).

## Test plan

- [x] `npm test` — 93/93 pass
- [x] `npm run build` — succeeds
- [x] `tsc --noEmit` — clean
- [x] Local: login redirects to /dashboard, signup to /score, signout to /, protected route to /login
- [x] Local: OTP form background, email field background, and logo fixes verified in browser
- [ ] Org-invitation flow end to end (blocked on Clerk dashboard Home URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)