### PR TITLE
Team provisioning: in-app Manage Clients page + org lifecycle (#190)

### DIFF
--- a/src/app/admin/clients/new/page.tsx
+++ b/src/app/admin/clients/new/page.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+/**
+ * Add Client — provisions a Team org and invites the Team Lead as org:admin.
+ * Lives on its own page (linked from the "Add Client" button on
+ * /admin/clients). On success we return to the clients list so the new org
+ * shows up. The POST is admin-gated server-side; we also gate the page via
+ * /api/admin/status so non-admins never see the form.
+ */
+export default function AddClientPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const router = useRouter();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  const [orgName, setOrgName] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    let active = true;
+    fetch("/api/admin/status")
+      .then((r) => (r.ok ? r.json() : { admin: false }))
+      .then((d) => {
+        if (active) setAuthorized(d.admin === true);
+      })
+      .catch(() => {
+        if (active) setAuthorized(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [isSignedIn]);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await fetch("/api/admin/clients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgName: orgName.trim(),
+          leadFirstName: firstName.trim(),
+          leadLastName: lastName.trim(),
+          leadEmail: email.trim(),
+        }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(j.error || `Provision failed (${res.status})`);
+      router.push("/admin/clients");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Provision failed");
+      setBusy(false);
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (authorized === false) {
+    return (
+      <div className="pt-20 max-w-2xl mx-auto px-6 py-20">
+        <h1 className="text-xl font-bold font-sans mb-3">Admin access required</h1>
+        <p className="text-sm text-muted font-sans">
+          Your Clerk account is signed in but not on the admin allowlist. If this
+          is a mistake, check <code className="text-foreground">ADMIN_EMAILS</code>{" "}
+          in runladder&apos;s Vercel env vars.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-xl text-foreground font-sans">Add Client</h1>
+          <p className="text-xs text-muted font-sans mt-1">
+            Create a Team org and invite the Team Lead
+          </p>
+        </div>
+
+        <form
+          onSubmit={submit}
+          className="border border-[#333] bg-[#1e1e1e] p-4"
+        >
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Organization name
+              </label>
+              <input
+                value={orgName}
+                onChange={(e) => setOrgName(e.target.value)}
+                placeholder="Acme Inc."
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Team Lead email
+              </label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="lead@acme.com"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Team Lead first name
+              </label>
+              <input
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="Jane"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+            <div>
+              <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+                Team Lead last name
+              </label>
+              <input
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Doe"
+                className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+              />
+            </div>
+          </div>
+          {err && <p className="mt-3 text-xs text-ladder-red font-sans">{err}</p>}
+          <div className="mt-4 flex items-center justify-end gap-4">
+            <Link
+              href="/admin/clients"
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Cancel
+            </Link>
+            <button
+              type="submit"
+              disabled={busy}
+              className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+            >
+              {busy ? "Provisioning…" : "Create org + invite Lead"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type FormEvent } from "react";
+import { useEffect, useState } from "react";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import Link from "next/link";
 
@@ -8,7 +8,7 @@ type TeamClient = {
   id: string;
   name: string;
   membersCount: number;
-  status: "active" | "suspended";
+  status: "pending" | "active" | "suspended";
   internal: boolean;
   teamLead: { firstName?: string; lastName?: string; email?: string } | null;
   createdAt: number;
@@ -33,118 +33,6 @@ function fmtDate(ms: number | null | undefined) {
   });
 }
 
-function ProvisionForm({ onDone }: { onDone: () => void }) {
-  const [orgName, setOrgName] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [email, setEmail] = useState("");
-  const [busy, setBusy] = useState(false);
-  const [err, setErr] = useState<string | null>(null);
-  const [ok, setOk] = useState<string | null>(null);
-
-  async function submit(e: FormEvent) {
-    e.preventDefault();
-    if (busy) return;
-    setBusy(true);
-    setErr(null);
-    setOk(null);
-    try {
-      const res = await fetch("/api/admin/clients", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          orgName: orgName.trim(),
-          leadFirstName: firstName.trim(),
-          leadLastName: lastName.trim(),
-          leadEmail: email.trim(),
-        }),
-      });
-      const j = await res.json().catch(() => ({}));
-      if (!res.ok) throw new Error(j.error || `Provision failed (${res.status})`);
-      setOk(`Created “${orgName.trim()}” and invited ${email.trim()} as Team Lead.`);
-      setOrgName("");
-      setFirstName("");
-      setLastName("");
-      setEmail("");
-      onDone();
-    } catch (e) {
-      setErr(e instanceof Error ? e.message : "Provision failed");
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  return (
-    <form onSubmit={submit} className="border border-[#333] bg-[#1e1e1e] p-4 mb-3">
-      <div className="text-[10px] uppercase tracking-widest text-muted mb-3">
-        Provision a Team client
-      </div>
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-        <div>
-          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
-            Organization name
-          </label>
-          <input
-            value={orgName}
-            onChange={(e) => setOrgName(e.target.value)}
-            placeholder="Acme Inc."
-            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
-          />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
-            Team Lead email
-          </label>
-          <input
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder="lead@acme.com"
-            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
-          />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
-            Team Lead first name
-          </label>
-          <input
-            value={firstName}
-            onChange={(e) => setFirstName(e.target.value)}
-            placeholder="Jane"
-            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
-          />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
-            Team Lead last name
-          </label>
-          <input
-            value={lastName}
-            onChange={(e) => setLastName(e.target.value)}
-            placeholder="Doe"
-            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
-          />
-        </div>
-      </div>
-      {err && (
-        <p className="mt-3 text-xs text-ladder-red font-sans">{err}</p>
-      )}
-      {ok && (
-        <p className="mt-3 text-xs text-ladder-green font-sans">{ok}</p>
-      )}
-      <div className="mt-3">
-        <button
-          type="submit"
-          disabled={busy}
-          className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
-        >
-          {busy ? "Provisioning…" : "Create org + invite Lead"}
-        </button>
-      </div>
-    </form>
-  );
-}
-
 export default function ManageClientsPage() {
   const { isSignedIn, isLoaded } = useAuth();
   const [authorized, setAuthorized] = useState<boolean | null>(null);
@@ -153,6 +41,10 @@ export default function ManageClientsPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyOrg, setBusyOrg] = useState<string | null>(null);
+  // Branded delete-confirmation modal state.
+  const [deleteTarget, setDeleteTarget] = useState<TeamClient | null>(null);
+  const [confirmText, setConfirmText] = useState("");
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   async function refresh() {
     setLoading(true);
@@ -201,26 +93,36 @@ export default function ManageClientsPage() {
     }
   }
 
-  async function deleteOrg(orgId: string, name: string) {
-    const typed = window.prompt(
-      `This permanently deletes “${name}” and removes all members. Type the org name to confirm:`,
-    );
-    if (typed === null) return;
-    setBusyOrg(orgId);
-    setError(null);
+  function openDelete(client: TeamClient) {
+    setDeleteTarget(client);
+    setConfirmText("");
+    setDeleteError(null);
+  }
+
+  function closeDelete() {
+    setDeleteTarget(null);
+    setConfirmText("");
+    setDeleteError(null);
+  }
+
+  async function confirmDelete() {
+    if (!deleteTarget) return;
+    setBusyOrg(deleteTarget.id);
+    setDeleteError(null);
     try {
-      const res = await fetch(`/api/admin/clients/${orgId}`, {
+      const res = await fetch(`/api/admin/clients/${deleteTarget.id}`, {
         method: "DELETE",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ confirmName: typed }),
+        body: JSON.stringify({ confirmName: confirmText }),
       });
       if (!res.ok) {
         const j = await res.json().catch(() => ({}));
         throw new Error(j.error || `Delete failed (${res.status})`);
       }
+      closeDelete();
       await refresh();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Delete failed");
+      setDeleteError(e instanceof Error ? e.message : "Delete failed");
     } finally {
       setBusyOrg(null);
     }
@@ -253,12 +155,6 @@ export default function ManageClientsPage() {
             </p>
           </div>
           <div className="flex items-center gap-4">
-            <Link
-              href="/admin"
-              className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
-            >
-              Admin
-            </Link>
             <button
               onClick={refresh}
               disabled={loading}
@@ -266,6 +162,12 @@ export default function ManageClientsPage() {
             >
               {loading ? "Loading…" : "Refresh"}
             </button>
+            <Link
+              href="/admin/clients/new"
+              className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors"
+            >
+              Add Client
+            </Link>
           </div>
         </div>
 
@@ -284,18 +186,16 @@ export default function ManageClientsPage() {
             <span className="text-[10px] text-muted">{teamClients.length} total</span>
           </div>
 
-          <ProvisionForm onDone={refresh} />
-
           <div className="border border-[#333] bg-[#1e1e1e]">
-            <table className="w-full text-xs">
+            <table className="w-full text-xs table-fixed">
               <thead>
                 <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
-                  <th className="text-left p-3">Org</th>
+                  <th className="text-left p-3 w-1/4">Org</th>
                   <th className="text-left p-3">Team Lead</th>
-                  <th className="text-right p-3">Members</th>
+                  <th className="text-left p-3">Members</th>
                   <th className="text-left p-3">Status</th>
-                  <th className="text-left p-3">Created</th>
-                  <th className="text-right p-3">Actions</th>
+                  <th className="text-left p-3">Joined</th>
+                  <th className="text-left p-3">Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -324,19 +224,21 @@ export default function ManageClientsPage() {
                             </span>
                           )}
                         </td>
-                        <td className="p-3 text-muted">{leadLabel}</td>
-                        <td className="p-3 text-right tabular-nums text-muted">
+                        <td className="p-3 text-muted truncate">{leadLabel}</td>
+                        <td className="p-3 text-left tabular-nums text-muted">
                           {c.membersCount}
                         </td>
                         <td className="p-3">
                           {c.status === "suspended" ? (
                             <span className="text-ladder-orange">Suspended</span>
+                          ) : c.status === "pending" ? (
+                            <span className="text-ladder-yellow">Pending</span>
                           ) : (
                             <span className="text-ladder-green">Active</span>
                           )}
                         </td>
                         <td className="p-3 text-muted">{fmtDate(c.createdAt)}</td>
-                        <td className="p-3 text-right whitespace-nowrap">
+                        <td className="p-3 text-left whitespace-nowrap">
                           {c.internal ? (
                             <span className="text-[10px] text-muted">Protected</span>
                           ) : (
@@ -356,7 +258,7 @@ export default function ManageClientsPage() {
                                 {c.status === "suspended" ? "Reactivate" : "Suspend"}
                               </button>
                               <button
-                                onClick={() => deleteOrg(c.id, c.name)}
+                                onClick={() => openDelete(c)}
                                 disabled={busyOrg === c.id}
                                 className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
                               >
@@ -384,13 +286,13 @@ export default function ManageClientsPage() {
           </div>
 
           <div className="border border-[#333] bg-[#1e1e1e]">
-            <table className="w-full text-xs">
+            <table className="w-full text-xs table-fixed">
               <thead>
                 <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
-                  <th className="text-left p-3">Email</th>
+                  <th className="text-left p-3 w-1/4">Email</th>
                   <th className="text-left p-3">Name</th>
-                  <th className="text-left p-3">Source</th>
-                  <th className="text-left p-3">Since</th>
+                  <th className="text-left p-3">Payment</th>
+                  <th className="text-left p-3">Joined</th>
                 </tr>
               </thead>
               <tbody>
@@ -420,6 +322,63 @@ export default function ManageClientsPage() {
           </div>
         </section>
       </div>
+
+      {/* Branded delete-confirmation modal (placeholder until a shared
+          Dialog component exists). Type-the-name to confirm; destructive
+          action gets a red button. */}
+      {deleteTarget && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-6"
+          onClick={closeDelete}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="w-full max-w-md border border-[#2a2a2a] bg-[#161616] p-5 shadow-2xl shadow-black/50"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-sans font-semibold text-foreground mb-2">
+              Delete Organization
+            </h2>
+            <p className="text-xs text-muted font-sans mb-4 leading-relaxed">
+              This permanently deletes{" "}
+              <span className="text-foreground">{deleteTarget.name}</span> and
+              removes all members. This cannot be undone. Type the org name to
+              confirm.
+            </p>
+            <input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={deleteTarget.name}
+              autoFocus
+              className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+            />
+            {deleteError && (
+              <p className="mt-3 text-xs text-ladder-red font-sans">
+                {deleteError}
+              </p>
+            )}
+            <div className="mt-5 flex items-center justify-end gap-4">
+              <button
+                onClick={closeDelete}
+                className="text-xs font-semibold text-muted hover:text-foreground transition-colors px-4 py-1.5"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmDelete}
+                disabled={
+                  busyOrg === deleteTarget.id ||
+                  confirmText.trim() !== deleteTarget.name
+                }
+                className="text-xs font-semibold bg-ladder-red text-white px-4 py-1.5 rounded-sm hover:bg-ladder-red/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                {busyOrg === deleteTarget.id ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/admin/clients/page.tsx
+++ b/src/app/admin/clients/page.tsx
@@ -1,0 +1,425 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import Link from "next/link";
+
+type TeamClient = {
+  id: string;
+  name: string;
+  membersCount: number;
+  status: "active" | "suspended";
+  internal: boolean;
+  teamLead: { firstName?: string; lastName?: string; email?: string } | null;
+  createdAt: number;
+};
+
+type ProClient = {
+  id: string;
+  email: string;
+  name: string | null;
+  comp: boolean;
+  since: number;
+};
+
+function fmtDate(ms: number | null | undefined) {
+  if (!ms) return "—";
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function ProvisionForm({ onDone }: { onDone: () => void }) {
+  const [orgName, setOrgName] = useState("");
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [ok, setOk] = useState<string | null>(null);
+
+  async function submit(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    setBusy(true);
+    setErr(null);
+    setOk(null);
+    try {
+      const res = await fetch("/api/admin/clients", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          orgName: orgName.trim(),
+          leadFirstName: firstName.trim(),
+          leadLastName: lastName.trim(),
+          leadEmail: email.trim(),
+        }),
+      });
+      const j = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(j.error || `Provision failed (${res.status})`);
+      setOk(`Created “${orgName.trim()}” and invited ${email.trim()} as Team Lead.`);
+      setOrgName("");
+      setFirstName("");
+      setLastName("");
+      setEmail("");
+      onDone();
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Provision failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="border border-[#333] bg-[#1e1e1e] p-4 mb-3">
+      <div className="text-[10px] uppercase tracking-widest text-muted mb-3">
+        Provision a Team client
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <div>
+          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+            Organization name
+          </label>
+          <input
+            value={orgName}
+            onChange={(e) => setOrgName(e.target.value)}
+            placeholder="Acme Inc."
+            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+          />
+        </div>
+        <div>
+          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+            Team Lead email
+          </label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="lead@acme.com"
+            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+          />
+        </div>
+        <div>
+          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+            Team Lead first name
+          </label>
+          <input
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            placeholder="Jane"
+            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+          />
+        </div>
+        <div>
+          <label className="block text-[10px] uppercase tracking-widest text-muted mb-1">
+            Team Lead last name
+          </label>
+          <input
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            placeholder="Doe"
+            className="w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-1.5 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans"
+          />
+        </div>
+      </div>
+      {err && (
+        <p className="mt-3 text-xs text-ladder-red font-sans">{err}</p>
+      )}
+      {ok && (
+        <p className="mt-3 text-xs text-ladder-green font-sans">{ok}</p>
+      )}
+      <div className="mt-3">
+        <button
+          type="submit"
+          disabled={busy}
+          className="text-xs font-semibold bg-ladder-green text-background px-4 py-1.5 rounded-sm hover:bg-ladder-green/90 transition-colors disabled:opacity-40"
+        >
+          {busy ? "Provisioning…" : "Create org + invite Lead"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+export default function ManageClientsPage() {
+  const { isSignedIn, isLoaded } = useAuth();
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+  const [teamClients, setTeamClients] = useState<TeamClient[]>([]);
+  const [proClients, setProClients] = useState<ProClient[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyOrg, setBusyOrg] = useState<string | null>(null);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/admin/clients");
+      if (res.status === 403) {
+        setAuthorized(false);
+        return;
+      }
+      setAuthorized(true);
+      if (!res.ok) throw new Error(`Clients fetch ${res.status}`);
+      const j = await res.json();
+      setTeamClients(j.teamClients || []);
+      setProClients(j.proClients || []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    if (!isSignedIn) return;
+    refresh();
+  }, [isSignedIn]);
+
+  async function patch(orgId: string, action: string) {
+    setBusyOrg(orgId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/clients/${orgId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Action failed (${res.status})`);
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Action failed");
+    } finally {
+      setBusyOrg(null);
+    }
+  }
+
+  async function deleteOrg(orgId: string, name: string) {
+    const typed = window.prompt(
+      `This permanently deletes “${name}” and removes all members. Type the org name to confirm:`,
+    );
+    if (typed === null) return;
+    setBusyOrg(orgId);
+    setError(null);
+    try {
+      const res = await fetch(`/api/admin/clients/${orgId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmName: typed }),
+      });
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}));
+        throw new Error(j.error || `Delete failed (${res.status})`);
+      }
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Delete failed");
+    } finally {
+      setBusyOrg(null);
+    }
+  }
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  if (authorized === false) {
+    return (
+      <div className="pt-20 max-w-2xl mx-auto px-6 py-20">
+        <h1 className="text-xl font-bold font-sans mb-3">Admin access required</h1>
+        <p className="text-sm text-muted font-sans">
+          Your Clerk account is signed in but not on the admin allowlist. If this
+          is a mistake, check <code className="text-foreground">ADMIN_EMAILS</code>{" "}
+          in runladder&apos;s Vercel env vars.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <div className="mb-8 flex items-baseline justify-between">
+          <div>
+            <h1 className="text-xl text-foreground font-sans">Manage Clients</h1>
+            <p className="text-xs text-muted font-sans mt-1">
+              Team orgs (provisioned) and Pro subscribers
+            </p>
+          </div>
+          <div className="flex items-center gap-4">
+            <Link
+              href="/admin"
+              className="text-xs font-semibold border border-ladder-green text-ladder-green px-4 py-1.5 rounded-sm hover:bg-ladder-green/10 transition-colors"
+            >
+              Admin
+            </Link>
+            <button
+              onClick={refresh}
+              disabled={loading}
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              {loading ? "Loading…" : "Refresh"}
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* ── Team clients ──────────────────────────────────────── */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Team clients
+            </span>
+            <span className="text-[10px] text-muted">{teamClients.length} total</span>
+          </div>
+
+          <ProvisionForm onDone={refresh} />
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3">Org</th>
+                  <th className="text-left p-3">Team Lead</th>
+                  <th className="text-right p-3">Members</th>
+                  <th className="text-left p-3">Status</th>
+                  <th className="text-left p-3">Created</th>
+                  <th className="text-right p-3">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {teamClients.length === 0 ? (
+                  <tr>
+                    <td colSpan={6} className="p-6 text-center text-muted font-sans">
+                      No Team clients yet.
+                    </td>
+                  </tr>
+                ) : (
+                  teamClients.map((c) => {
+                    const lead = c.teamLead;
+                    const leadLabel = lead
+                      ? `${[lead.firstName, lead.lastName].filter(Boolean).join(" ")}${lead.email ? ` · ${lead.email}` : ""}`
+                      : "—";
+                    return (
+                      <tr
+                        key={c.id}
+                        className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                      >
+                        <td className="p-3 text-foreground">
+                          {c.name}
+                          {c.internal && (
+                            <span className="ml-2 text-[9px] uppercase tracking-widest text-ladder-green border border-ladder-green/40 bg-ladder-green/5 px-1.5 py-0.5">
+                              Internal
+                            </span>
+                          )}
+                        </td>
+                        <td className="p-3 text-muted">{leadLabel}</td>
+                        <td className="p-3 text-right tabular-nums text-muted">
+                          {c.membersCount}
+                        </td>
+                        <td className="p-3">
+                          {c.status === "suspended" ? (
+                            <span className="text-ladder-orange">Suspended</span>
+                          ) : (
+                            <span className="text-ladder-green">Active</span>
+                          )}
+                        </td>
+                        <td className="p-3 text-muted">{fmtDate(c.createdAt)}</td>
+                        <td className="p-3 text-right whitespace-nowrap">
+                          {c.internal ? (
+                            <span className="text-[10px] text-muted">Protected</span>
+                          ) : (
+                            <>
+                              <button
+                                onClick={() =>
+                                  patch(
+                                    c.id,
+                                    c.status === "suspended"
+                                      ? "reactivate"
+                                      : "suspend",
+                                  )
+                                }
+                                disabled={busyOrg === c.id}
+                                className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors mr-3 disabled:opacity-40"
+                              >
+                                {c.status === "suspended" ? "Reactivate" : "Suspend"}
+                              </button>
+                              <button
+                                onClick={() => deleteOrg(c.id, c.name)}
+                                disabled={busyOrg === c.id}
+                                className="text-[10px] uppercase tracking-widest text-muted hover:text-ladder-red transition-colors disabled:opacity-40"
+                              >
+                                Delete
+                              </button>
+                            </>
+                          )}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Pro clients (read-only) ───────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Pro clients
+            </span>
+            <span className="text-[10px] text-muted">{proClients.length} total</span>
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3">Email</th>
+                  <th className="text-left p-3">Name</th>
+                  <th className="text-left p-3">Source</th>
+                  <th className="text-left p-3">Since</th>
+                </tr>
+              </thead>
+              <tbody>
+                {proClients.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="p-6 text-center text-muted font-sans">
+                      No Pro clients yet.
+                    </td>
+                  </tr>
+                ) : (
+                  proClients.map((p) => (
+                    <tr
+                      key={p.id}
+                      className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                    >
+                      <td className="p-3 text-foreground">{p.email}</td>
+                      <td className="p-3 text-muted">{p.name || "—"}</td>
+                      <td className="p-3 text-muted uppercase tracking-widest text-[10px]">
+                        {p.comp ? "Comp" : "Stripe"}
+                      </td>
+                      <td className="p-3 text-muted">{fmtDate(p.since)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/clients/[orgId]/route.ts
+++ b/src/app/api/admin/clients/[orgId]/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { getAdminEmail } from "@/lib/admin";
+import { isInternalOrg, orgMeta } from "@/lib/orgs";
+
+/**
+ * Org lifecycle management (#190).
+ *
+ *   PATCH  /api/admin/clients/:orgId   body { action }
+ *     - "suspend" | "reactivate"      → toggle publicMetadata.status
+ *     - "markInternal" | "unmarkInternal" → toggle publicMetadata.internal
+ *   DELETE /api/admin/clients/:orgId   body { confirmName }
+ *     - hard-deletes the org; confirmName must match the org name exactly.
+ *
+ * The internal (Drawbackwards) org can never be suspended or deleted.
+ * Gated by getAdminEmail().
+ */
+
+function unauthorized() {
+  return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+}
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  const adminEmail = await getAdminEmail();
+  if (!adminEmail) return unauthorized();
+
+  const { orgId } = await params;
+  const body = await req.json().catch(() => ({}));
+  const action = typeof body.action === "string" ? body.action : "";
+
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+  const internal = isInternalOrg(org);
+  const existing = orgMeta(org);
+
+  if (action === "suspend" || action === "reactivate") {
+    if (internal) {
+      return NextResponse.json(
+        { error: "The internal Drawbackwards org cannot be suspended." },
+        { status: 403 },
+      );
+    }
+    const suspend = action === "suspend";
+    const updated = await client.organizations.updateOrganization(orgId, {
+      publicMetadata: {
+        ...existing,
+        status: suspend ? "suspended" : "active",
+        suspendedAt: suspend ? Date.now() : undefined,
+        suspendedBy: suspend ? adminEmail : undefined,
+      },
+    });
+    return NextResponse.json({
+      ok: true,
+      status: (updated.publicMetadata as { status?: string })?.status ?? "active",
+    });
+  }
+
+  if (action === "markInternal" || action === "unmarkInternal") {
+    const updated = await client.organizations.updateOrganization(orgId, {
+      publicMetadata: { ...existing, internal: action === "markInternal" },
+    });
+    return NextResponse.json({
+      ok: true,
+      internal: (updated.publicMetadata as { internal?: boolean })?.internal === true,
+    });
+  }
+
+  return NextResponse.json(
+    {
+      error:
+        "Unknown action. Expected suspend, reactivate, markInternal, or unmarkInternal.",
+    },
+    { status: 400 },
+  );
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  if (!(await getAdminEmail())) return unauthorized();
+  // Confirm a signed-in admin (kept for parity / future per-actor auditing).
+  await auth();
+
+  const { orgId } = await params;
+  const body = await req.json().catch(() => ({}));
+  const confirmName = typeof body.confirmName === "string" ? body.confirmName : "";
+
+  const client = await clerkClient();
+  const org = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+
+  if (isInternalOrg(org)) {
+    return NextResponse.json(
+      { error: "The internal Drawbackwards org cannot be deleted." },
+      { status: 403 },
+    );
+  }
+
+  if (confirmName.trim() !== org.name) {
+    return NextResponse.json(
+      { error: "Confirmation name does not match the organization name." },
+      { status: 400 },
+    );
+  }
+
+  // Deleting the org cascades organizationMembership.deleted webhooks, which
+  // revoke each member's team comp (when they have no other org).
+  await client.organizations.deleteOrganization(orgId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/admin/clients/route.ts
+++ b/src/app/api/admin/clients/route.ts
@@ -133,7 +133,9 @@ export async function POST(req: NextRequest) {
     name: orgName,
     createdBy: userId!,
     publicMetadata: {
-      status: "active",
+      // Pending until the Team Lead accepts the invite and signs in; the
+      // Clerk membership webhook flips this to "active" on their join.
+      status: "pending",
       teamLead: {
         firstName: leadFirstName,
         lastName: leadLastName,

--- a/src/app/api/admin/clients/route.ts
+++ b/src/app/api/admin/clients/route.ts
@@ -1,0 +1,161 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { getAdminEmail } from "@/lib/admin";
+import { isInternalOrg, orgMeta, orgStatus } from "@/lib/orgs";
+import type { Tier } from "@/lib/plans";
+
+/**
+ * Admin client management (#190).
+ *
+ *   GET  /api/admin/clients   — list Team orgs + Pro users (read-only)
+ *   POST /api/admin/clients   — provision a Team client: create a Clerk org
+ *                               and invite the designated Team Lead as
+ *                               org:admin. The acting admin is the org
+ *                               creator and stays as a co-admin (per the
+ *                               #190 decision; revisit later).
+ *
+ * Gated by getAdminEmail() — same pattern as /api/admin/comps.
+ */
+
+function unauthorized() {
+  return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+}
+
+type TeamClient = {
+  id: string;
+  name: string;
+  membersCount: number;
+  status: ReturnType<typeof orgStatus>;
+  internal: boolean;
+  teamLead: { firstName?: string; lastName?: string; email?: string } | null;
+  createdAt: number;
+};
+
+type ProClient = {
+  id: string;
+  email: string;
+  name: string | null;
+  comp: boolean;
+  since: number;
+};
+
+export async function GET() {
+  if (!(await getAdminEmail())) return unauthorized();
+
+  const client = await clerkClient();
+
+  // Team clients = all Clerk organizations.
+  const orgList = await client.organizations.getOrganizationList({
+    limit: 200,
+    includeMembersCount: true,
+  });
+  const teamClients: TeamClient[] = orgList.data.map((org) => {
+    const meta = orgMeta(org);
+    return {
+      id: org.id,
+      name: org.name,
+      membersCount: org.membersCount ?? 0,
+      status: orgStatus(org),
+      internal: isInternalOrg(org),
+      teamLead: meta.teamLead ?? null,
+      createdAt: org.createdAt,
+    };
+  });
+
+  // Pro clients = individual users with publicMetadata.tier === "pro".
+  // NOTE: Clerk's getUserList can't filter by metadata server-side, so we
+  // fetch and filter in memory. Fine at current scale; if the user base
+  // grows large, back this with a Redis index of pro user ids.
+  const userList = await client.users.getUserList({ limit: 500 });
+  const proClients: ProClient[] = [];
+  for (const u of userList.data) {
+    const meta = u.publicMetadata as Record<string, unknown> | undefined;
+    if ((meta?.tier as Tier | undefined) !== "pro") continue;
+    proClients.push({
+      id: u.id,
+      email: u.primaryEmailAddress?.emailAddress ?? "",
+      name: u.fullName || u.firstName || null,
+      comp: meta?.comp === true,
+      since:
+        typeof meta?.compGrantedAt === "number"
+          ? (meta.compGrantedAt as number)
+          : u.createdAt,
+    });
+  }
+
+  teamClients.sort((a, b) => b.createdAt - a.createdAt);
+  proClients.sort((a, b) => b.since - a.since);
+
+  return NextResponse.json({ teamClients, proClients });
+}
+
+export async function POST(req: NextRequest) {
+  const adminEmail = await getAdminEmail();
+  if (!adminEmail) return unauthorized();
+  // getAdminEmail() guarantees a signed-in user, so userId is non-null.
+  const { userId } = await auth();
+
+  const body = await req.json().catch(() => ({}));
+  const orgName = typeof body.orgName === "string" ? body.orgName.trim() : "";
+  const leadFirstName =
+    typeof body.leadFirstName === "string" ? body.leadFirstName.trim() : "";
+  const leadLastName =
+    typeof body.leadLastName === "string" ? body.leadLastName.trim() : "";
+  const leadEmail =
+    typeof body.leadEmail === "string"
+      ? body.leadEmail.trim().toLowerCase()
+      : "";
+
+  if (!orgName) {
+    return NextResponse.json(
+      { error: "Organization name is required." },
+      { status: 400 },
+    );
+  }
+  if (!leadFirstName || !leadLastName) {
+    return NextResponse.json(
+      { error: "Team Lead first and last name are required." },
+      { status: 400 },
+    );
+  }
+  if (!leadEmail || !leadEmail.includes("@")) {
+    return NextResponse.json(
+      { error: "A valid Team Lead email is required." },
+      { status: 400 },
+    );
+  }
+
+  const client = await clerkClient();
+
+  // 1) Create the org. The acting admin is createdBy (Clerk requires an
+  //    existing user as the first org:admin) and stays as a co-admin.
+  const org = await client.organizations.createOrganization({
+    name: orgName,
+    createdBy: userId!,
+    publicMetadata: {
+      status: "active",
+      teamLead: {
+        firstName: leadFirstName,
+        lastName: leadLastName,
+        email: leadEmail,
+      },
+      provisionedBy: adminEmail,
+      provisionedAt: Date.now(),
+    },
+  });
+
+  // 2) Invite the Team Lead as a second org:admin. On accept, the existing
+  //    organizationMembership.created webhook grants them tier:team comp.
+  const invitation = await client.organizations.createOrganizationInvitation({
+    organizationId: org.id,
+    inviterUserId: userId!,
+    emailAddress: leadEmail,
+    role: "org:admin",
+  });
+
+  return NextResponse.json({
+    ok: true,
+    orgId: org.id,
+    invitationId: invitation.id,
+  });
+}

--- a/src/app/api/admin/status/route.ts
+++ b/src/app/api/admin/status/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { getAdminEmail } from "@/lib/admin";
+
+/**
+ * GET /api/admin/status → { admin: boolean }
+ *
+ * Lets client components (e.g. the Account menu) decide whether to show
+ * admin-only navigation without exposing the ADMIN_EMAILS allowlist to the
+ * browser. The allowlist stays server-side in src/lib/admin.ts.
+ */
+export async function GET() {
+  const admin = !!(await getAdminEmail());
+  return NextResponse.json({ admin });
+}

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -220,6 +220,19 @@ export async function GET() {
   const isManager = orgRole === "org:admin";
 
   const client = await clerkClient();
+
+  // Suspended orgs (contract paused/ended) are blocked at the API too, so a
+  // suspended team can't read data by hitting this endpoint directly. Status
+  // is managed by admins via /admin/clients (#190).
+  const org = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+  if (
+    (org.publicMetadata as { status?: string } | null)?.status === "suspended"
+  ) {
+    return NextResponse.json({ error: "Team suspended" }, { status: 403 });
+  }
+
   const memberships = await client.organizations.getOrganizationMembershipList({
     organizationId: orgId,
     limit: 100,

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -157,6 +157,8 @@ type MemberSummary = {
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
+  /** True only when the member uploaded a real photo (Clerk `hasImage`). */
+  hasImage: boolean;
   role: string;
   joinedAt: number;
   stats: UserStats | null;
@@ -186,6 +188,7 @@ type ArchivedSummary = {
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
+  hasImage: boolean;
   stats: UserStats | null;
   recentScans: number;
   activity: DailyActivity[];
@@ -268,6 +271,7 @@ export async function GET() {
         firstName: m.publicUserData?.firstName ?? null,
         lastName: m.publicUserData?.lastName ?? null,
         imageUrl: m.publicUserData?.imageUrl ?? null,
+        hasImage: m.publicUserData?.hasImage ?? false,
         role: m.role,
         joinedAt: m.createdAt,
       };
@@ -344,6 +348,7 @@ export async function GET() {
           firstName: null,
           lastName: null,
           imageUrl: null,
+          hasImage: false,
           stats: null,
           recentScans: 0,
           activity: [],
@@ -356,6 +361,7 @@ export async function GET() {
           base.firstName = user.firstName ?? null;
           base.lastName = user.lastName ?? null;
           base.imageUrl = user.imageUrl ?? null;
+          base.hasImage = user.hasImage ?? false;
         } catch {
           // user account may have been deleted entirely; we still keep their
           // history under the userId, so let the row render with the unknown name.

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -80,6 +80,35 @@ export async function POST(req: NextRequest) {
       tier: "team",
       reason: orgName ? `Member of ${orgName}` : "Team member",
     });
+
+    // Flip a freshly provisioned org from "pending" to "active" once its
+    // designated Team Lead accepts the invite and joins. Other joins (the
+    // creating admin, regular members) don't change status.
+    const orgId = event.data.organization?.id;
+    if (orgId) {
+      try {
+        const client = await clerkClient();
+        const org = await client.organizations.getOrganization({
+          organizationId: orgId,
+        });
+        const meta = (org.publicMetadata ?? {}) as {
+          status?: string;
+          teamLead?: { email?: string };
+        };
+        if (meta.status === "pending" && meta.teamLead?.email) {
+          const user = await client.users.getUser(userId);
+          const email = user.primaryEmailAddress?.emailAddress?.toLowerCase();
+          if (email && email === meta.teamLead.email.toLowerCase()) {
+            await client.organizations.updateOrganization(orgId, {
+              publicMetadata: { ...meta, status: "active" },
+            });
+          }
+        }
+      } catch (e) {
+        console.error("[clerk webhook] pending→active flip failed", e);
+      }
+    }
+
     return NextResponse.json({ ok: true, action: "granted" });
   }
 

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -31,6 +31,7 @@ type TeamMember = {
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
+  hasImage: boolean;
   role: string;
   joinedAt: number;
   stats: MemberStats | null;
@@ -47,6 +48,7 @@ type ArchivedMember = {
   firstName: string | null;
   lastName: string | null;
   imageUrl: string | null;
+  hasImage: boolean;
   stats: MemberStats | null;
   recentScans: number;
   activity: DailyActivity[];
@@ -440,6 +442,7 @@ function MemberRow({
     <div className="px-4 py-4 flex items-center gap-5">
       <Avatar
         imageUrl={member.imageUrl}
+        hasImage={member.hasImage}
         name={[member.firstName, member.lastName]
           .filter(Boolean)
           .join(" ")}
@@ -599,6 +602,7 @@ function ArchivedMemberRow({
       <div className="px-4 py-4 flex items-center gap-5">
         <Avatar
           imageUrl={member.imageUrl}
+          hasImage={member.hasImage}
           name={name}
           email={member.email}
           size={36}

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -5,7 +5,6 @@ import {
   useAuth,
   useOrganization,
   useOrganizationList,
-  CreateOrganization,
   RedirectToSignIn,
 } from "@clerk/nextjs";
 import Link from "next/link";
@@ -166,23 +165,33 @@ function InviteForm({
 }
 
 function NoOrgPanel() {
+  // Self-serve org creation was removed in #190 — Team orgs are now
+  // provisioned by Drawbackwards (an admin creates the org and invites the
+  // Team Lead). A user with no org should reach out, not spin one up.
   return (
     <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-8">
       <h2 className="text-base font-sans text-foreground mb-2">
-        Start your team
+        No team yet
       </h2>
-      <p className="text-sm text-muted font-sans mb-6">
-        Create a team to invite your designers and see how they&apos;re scoring.
+      <p className="text-sm text-muted font-sans">
+        Ladder Team is set up by Drawbackwards as part of your engagement. If
+        you expected access here, contact your Drawbackwards account manager and
+        they&apos;ll get you added.
       </p>
-      <CreateOrganization
-        afterCreateOrganizationUrl="/dashboard/team"
-        appearance={{
-          elements: {
-            rootBox: "w-full",
-            card: "bg-transparent shadow-none border-0 p-0",
-          },
-        }}
-      />
+    </div>
+  );
+}
+
+function SuspendedPanel() {
+  return (
+    <div className="border border-ladder-orange/40 bg-ladder-orange/5 p-8">
+      <h2 className="text-base font-sans text-foreground mb-2">
+        Team access paused
+      </h2>
+      <p className="text-sm text-muted font-sans">
+        This team&apos;s Ladder access is currently paused. Please contact your
+        Drawbackwards account manager to reactivate.
+      </p>
     </div>
   );
 }
@@ -728,6 +737,27 @@ export default function TeamPage() {
       <div className="pt-20 font-mono">
         <div className="max-w-2xl mx-auto px-6 py-10">
           <p className="text-sm text-muted font-sans">Loading your team…</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Suspended orgs (contract paused/ended) show a notice instead of the
+  // dashboard. Lifecycle status is set by admins via /admin/clients (#190).
+  // Members keep their tier for now — comp-revocation on suspend is deferred.
+  if (
+    (organization.publicMetadata as { status?: string } | undefined)?.status ===
+    "suspended"
+  ) {
+    return (
+      <div className="pt-20 font-mono">
+        <div className="max-w-2xl mx-auto px-6 py-10">
+          <div className="mb-8">
+            <h1 className="text-xl text-foreground font-sans">
+              {organization.name}
+            </h1>
+          </div>
+          <SuspendedPanel />
         </div>
       </div>
     );

--- a/src/components/Avatar.tsx
+++ b/src/components/Avatar.tsx
@@ -1,8 +1,10 @@
 /**
  * Round avatar bubble used in team rosters and member detail headers.
- * Renders the user's Clerk image when available; falls back to an
- * initials chip in subtle Ladder green so empty avatars still feel
- * like part of the brand.
+ * Shows the user's photo only when they've uploaded a real one
+ * (`hasImage`). Clerk auto-generates a gradient `imageUrl` for every user,
+ * so we gate on `hasImage` — otherwise the gradient would always win and
+ * the branded default below would never show. The default is a brand-green
+ * circle with the user's first initial in the site background color.
  *
  * Server-friendly: no client hooks, no event handlers — safe to render
  * from server components.
@@ -10,6 +12,8 @@
 
 type AvatarProps = {
   imageUrl?: string | null;
+  /** True only when the user uploaded a real photo (Clerk `hasImage`). */
+  hasImage?: boolean;
   name?: string | null;
   email?: string | null;
   size?: number;
@@ -18,12 +22,12 @@ type AvatarProps = {
 
 function initialFor(name?: string | null, email?: string | null): string {
   const source = name?.trim() || email?.trim() || "";
-  if (!source) return "?";
-  return source[0]!.toUpperCase();
+  return source ? source[0]!.toUpperCase() : "?";
 }
 
 export function Avatar({
   imageUrl,
+  hasImage,
   name,
   email,
   size = 32,
@@ -33,24 +37,25 @@ export function Avatar({
     ring === "manager"
       ? "ring-1 ring-ladder-green ring-offset-2 ring-offset-[#1a1a1a]"
       : "";
+  const showImage = !!hasImage && !!imageUrl;
 
   return (
     <span
-      className={`relative block rounded-full overflow-hidden bg-[#1f1f1f] flex-shrink-0 ${ringClass}`}
+      className={`relative block rounded-full overflow-hidden bg-ladder-green flex-shrink-0 ${ringClass}`}
       style={{ width: size, height: size }}
       aria-hidden
     >
-      {imageUrl ? (
+      {showImage ? (
         // eslint-disable-next-line @next/next/no-img-element
         <img
-          src={imageUrl}
+          src={imageUrl!}
           alt=""
           className="w-full h-full object-cover"
           loading="lazy"
         />
       ) : (
         <span
-          className="absolute inset-0 flex items-center justify-center bg-ladder-green/15 text-ladder-green font-semibold uppercase font-sans"
+          className="absolute inset-0 flex items-center justify-center bg-ladder-green text-background font-semibold uppercase font-sans"
           style={{ fontSize: Math.round(size * 0.42) }}
         >
           {initialFor(name, email)}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,20 +9,25 @@ import { UserMenu } from "./UserMenu";
 export function Nav() {
   const { isSignedIn, isLoaded } = useAuth();
   const pathname = usePathname();
-  // Hide marketing nav inside product surfaces (dashboard, score, hq).
+  // Hide marketing nav inside product surfaces (dashboard, score, hq, admin).
   // Keeps the user focused on the task and out of the marketing site
   // once they are working in Ladder.
   const inProduct =
     pathname?.startsWith("/dashboard") ||
     pathname?.startsWith("/score") ||
     pathname?.startsWith("/hq") ||
+    pathname?.startsWith("/admin") ||
     false;
+
+  // Signed-in users go to their dashboard from the logo; signed-out (and
+  // still-loading) visitors go to the marketing home.
+  const logoHref = isSignedIn ? "/dashboard" : "/";
 
   return (
     <nav className="fixed top-0 left-0 right-0 z-50 border-b border-border bg-background/90 backdrop-blur-md">
       <div className="max-w-6xl mx-auto px-6 h-20 flex items-center justify-between">
-        <Link href="/" className="flex items-center">
-          <LadderLogo height={22} className="text-white" />
+        <Link href={logoHref} className="flex items-center">
+          <LadderLogo height={18} className="text-white" />
         </Link>
 
         {!inProduct && (

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -20,7 +20,24 @@ export function UserMenu() {
   const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
+
+  // Resolve platform-admin status once the user is known. ADMIN_EMAILS lives
+  // server-side, so we ask /api/admin/status rather than expose the allowlist.
+  useEffect(() => {
+    if (!isLoaded || !user) return;
+    let active = true;
+    fetch("/api/admin/status")
+      .then((r) => (r.ok ? r.json() : { admin: false }))
+      .then((d) => {
+        if (active) setIsAdmin(d.admin === true);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [isLoaded, user]);
 
   useEffect(() => {
     if (!open) return;
@@ -223,6 +240,43 @@ export function UserMenu() {
                 )}
               </span>
               <span className="text-ladder-green text-base group-hover:translate-x-0.5 transition-transform flex-shrink-0">
+                →
+              </span>
+            </Link>
+          )}
+
+          {isAdmin && (
+            <Link
+              href="/admin/clients"
+              onClick={() => setOpen(false)}
+              role="menuitem"
+              className="flex items-center justify-between px-4 py-3 hover:bg-[#1f1f1f] border-b border-[#2a2a2a] transition-colors group"
+            >
+              <span className="flex items-center gap-2.5">
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  aria-hidden
+                  className="text-muted group-hover:text-foreground"
+                >
+                  <rect x="2" y="2.5" width="12" height="3" />
+                  <rect x="2" y="7" width="12" height="3" />
+                  <rect x="2" y="11.5" width="12" height="3" />
+                </svg>
+                <span className="text-sm text-foreground font-sans font-medium">
+                  Manage Clients
+                </span>
+                {(pathname?.startsWith("/admin/clients") ?? false) && (
+                  <span className="text-[9px] text-ladder-green/70 font-mono uppercase tracking-widest">
+                    Current
+                  </span>
+                )}
+              </span>
+              <span className="text-muted text-base group-hover:translate-x-0.5 transition-transform">
                 →
               </span>
             </Link>

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { useUser, useClerk, useOrganization } from "@clerk/nextjs";
 import { isPaidTier, type Tier } from "@/lib/plans";
@@ -13,11 +12,132 @@ const TIER_LABEL: Record<Tier, string> = {
   pulse: "Pulse",
 };
 
+const svgProps = {
+  width: 15,
+  height: 15,
+  viewBox: "0 0 16 16",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 1.5,
+  "aria-hidden": true,
+} as const;
+
+/** One icon per menu row, all on the same 16px grid for visual consistency. */
+const ICON = {
+  dashboard: (
+    <svg {...svgProps}>
+      <rect x="2" y="2" width="5" height="5" />
+      <rect x="9" y="2" width="5" height="5" />
+      <rect x="2" y="9" width="5" height="5" />
+      <rect x="9" y="9" width="5" height="5" />
+    </svg>
+  ),
+  team: (
+    <svg {...svgProps}>
+      <circle cx="5.5" cy="5.5" r="2.5" />
+      <circle cx="11" cy="6" r="2" />
+      <path d="M2 13c0-2 1.5-3.5 3.5-3.5S9 11 9 13" />
+      <path d="M9.5 13c0-1.5 1-2.5 2.5-2.5s2.5 1 2.5 2.5" />
+    </svg>
+  ),
+  clients: (
+    <svg {...svgProps}>
+      <rect x="2" y="6" width="5" height="8" />
+      <rect x="9" y="2" width="5" height="12" />
+      <line x1="3.5" y1="9" x2="5.5" y2="9" />
+      <line x1="10.5" y1="5" x2="12.5" y2="5" />
+      <line x1="10.5" y1="8" x2="12.5" y2="8" />
+    </svg>
+  ),
+  admin: (
+    <svg {...svgProps} strokeLinejoin="round">
+      <path d="M8 2l5 2v3.5c0 3-2.1 5.2-5 6-2.9-.8-5-3-5-6V4l5-2z" />
+    </svg>
+  ),
+  billing: (
+    <svg {...svgProps}>
+      <rect x="2" y="3.5" width="12" height="9" rx="1" />
+      <line x1="2" y1="6.5" x2="14" y2="6.5" />
+      <line x1="4.5" y1="10" x2="8" y2="10" />
+    </svg>
+  ),
+  settings: (
+    <svg {...svgProps} strokeLinecap="round">
+      <line x1="2" y1="4.5" x2="14" y2="4.5" />
+      <circle cx="6" cy="4.5" r="1.5" fill="currentColor" stroke="none" />
+      <line x1="2" y1="11.5" x2="14" y2="11.5" />
+      <circle cx="10" cy="11.5" r="1.5" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+  signout: (
+    <svg {...svgProps} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M6 2.5H3v11h3" />
+      <path d="M10 5l3 3-3 3" />
+      <line x1="13" y1="8" x2="6" y2="8" />
+    </svg>
+  ),
+} as const;
+
+/**
+ * A single Account-menu row. Every row shares one layout — leading icon,
+ * label, optional "Current" marker, optional right-aligned meta — whether it
+ * navigates (href) or runs an action (onClick), so the menu reads as one
+ * consistent list.
+ */
+function MenuRow({
+  icon,
+  label,
+  href,
+  onClick,
+  meta,
+  disabled,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  href?: string;
+  onClick?: () => void;
+  meta?: React.ReactNode;
+  disabled?: boolean;
+}) {
+  const content = (
+    <>
+      <span className="flex items-center gap-2.5 min-w-0">
+        <span className="text-muted group-hover:text-foreground transition-colors flex-shrink-0 flex">
+          {icon}
+        </span>
+        <span className="text-sm text-foreground font-sans font-medium truncate">
+          {label}
+        </span>
+      </span>
+      {meta && <span className="flex-shrink-0">{meta}</span>}
+    </>
+  );
+  const cls =
+    "w-full flex items-center justify-between gap-3 px-4 py-2.5 text-left hover:bg-[#1f1f1f] transition-colors group disabled:opacity-50";
+  if (href) {
+    return (
+      <Link href={href} onClick={onClick} role="menuitem" className={cls}>
+        {content}
+      </Link>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      role="menuitem"
+      className={cls}
+    >
+      {content}
+    </button>
+  );
+}
+
 export function UserMenu() {
   const { user, isLoaded } = useUser();
   const { signOut, openUserProfile } = useClerk();
   const { organization } = useOrganization();
-  const pathname = usePathname();
   const [open, setOpen] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
@@ -70,9 +190,6 @@ export function UserMenu() {
     email[0] ||
     "?"
   ).toUpperCase();
-  const onDashboard = pathname?.startsWith("/dashboard") ?? false;
-  const onTeam = pathname?.startsWith("/dashboard/team") ?? false;
-
   async function handleManageBilling() {
     setPortalLoading(true);
     try {
@@ -92,10 +209,15 @@ export function UserMenu() {
         aria-expanded={open}
         aria-haspopup="menu"
         aria-label="Account menu"
-        className={`group flex items-center gap-2 rounded-full pl-0.5 pr-2 py-0.5 transition-colors ${
+        className={`group flex items-center gap-2 rounded-full px-2 py-0.5 transition-colors ${
           open ? "bg-[#222]" : "hover:bg-[#1f1f1f]"
         }`}
       >
+        {paid && (
+          <span className="mr-2 text-[9px] font-mono font-semibold uppercase tracking-widest text-ladder-green border border-ladder-green/40 bg-ladder-green/5 px-1.5 py-0.5 leading-none">
+            {tierLabel}
+          </span>
+        )}
         <span
           className={`relative block w-8 h-8 rounded-full overflow-hidden bg-[#1f1f1f] ${
             paid
@@ -103,7 +225,7 @@ export function UserMenu() {
               : ""
           }`}
         >
-          {user.imageUrl ? (
+          {user.hasImage ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={user.imageUrl}
@@ -111,16 +233,11 @@ export function UserMenu() {
               className="w-full h-full object-cover"
             />
           ) : (
-            <span className="absolute inset-0 flex items-center justify-center bg-ladder-green/15 text-ladder-green text-xs font-semibold uppercase">
+            <span className="absolute inset-0 flex items-center justify-center bg-ladder-green text-background text-xs font-semibold uppercase">
               {initial}
             </span>
           )}
         </span>
-        {paid && (
-          <span className="text-[9px] font-mono font-semibold uppercase tracking-widest text-ladder-green border border-ladder-green/40 bg-ladder-green/5 px-1.5 py-0.5 leading-none">
-            {tierLabel}
-          </span>
-        )}
         <svg
           width="10"
           height="10"
@@ -148,196 +265,107 @@ export function UserMenu() {
           className="absolute right-0 top-[calc(100%+10px)] w-72 border border-[#2a2a2a] bg-[#161616] shadow-2xl shadow-black/50 origin-top-right user-menu-pop"
         >
           <div className="px-4 py-3.5 border-b border-[#2a2a2a]">
-            <div className="flex items-start justify-between gap-3">
-              <div className="min-w-0">
-                <p className="text-sm text-foreground font-sans font-semibold truncate">
-                  {fullName}
-                </p>
-                {email && (
-                  <p className="text-[11px] text-muted font-sans truncate mt-0.5">
-                    {email}
-                  </p>
-                )}
-              </div>
-              <span
-                className={`flex-shrink-0 text-[9px] font-mono font-semibold uppercase tracking-widest px-1.5 py-0.5 leading-none border ${
-                  paid
-                    ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
-                    : "text-muted border-[#333]"
-                }`}
-              >
-                {tierLabel}
-              </span>
-            </div>
+            <p className="text-sm text-foreground font-sans font-semibold truncate">
+              {organization?.name ?? fullName}
+            </p>
+            {email && (
+              <p className="text-[11px] text-muted font-sans truncate mt-0.5">
+                {email}
+              </p>
+            )}
+            <span
+              className={`inline-block mt-2 text-[9px] font-mono font-semibold uppercase tracking-widest px-1.5 py-0.5 leading-none border ${
+                paid
+                  ? "text-ladder-green border-ladder-green/40 bg-ladder-green/5"
+                  : "text-muted border-[#333]"
+              }`}
+            >
+              {tierLabel}
+            </span>
           </div>
 
-          <Link
-            href="/dashboard"
-            onClick={() => setOpen(false)}
-            role="menuitem"
-            className="flex items-center justify-between px-4 py-3 bg-ladder-green/[0.06] hover:bg-ladder-green/10 border-b border-[#2a2a2a] transition-colors group"
-          >
-            <span className="flex items-center gap-2.5">
-              <svg
-                width="14"
-                height="14"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                aria-hidden
-                className="text-ladder-green"
-              >
-                <rect x="2" y="2" width="5" height="5" />
-                <rect x="9" y="2" width="5" height="5" />
-                <rect x="2" y="9" width="5" height="5" />
-                <rect x="9" y="9" width="5" height="5" />
-              </svg>
-              <span className="text-sm text-foreground font-sans font-semibold">
-                Dashboard
-              </span>
-              {onDashboard && !onTeam && (
-                <span className="text-[9px] text-ladder-green/70 font-mono uppercase tracking-widest">
-                  Current
-                </span>
-              )}
-            </span>
-            <span className="text-ladder-green text-base group-hover:translate-x-0.5 transition-transform">
-              →
-            </span>
-          </Link>
-
-          {organization && (
-            <Link
-              href="/dashboard/team"
-              onClick={() => setOpen(false)}
-              role="menuitem"
-              className="flex items-center justify-between px-4 py-3 bg-ladder-green/[0.06] hover:bg-ladder-green/10 border-b border-[#2a2a2a] transition-colors group"
-            >
-              <span className="flex items-center gap-2.5 min-w-0">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  aria-hidden
-                  className="text-ladder-green flex-shrink-0"
-                >
-                  <circle cx="5.5" cy="5.5" r="2.5" />
-                  <circle cx="11" cy="6" r="2" />
-                  <path d="M2 13c0-2 1.5-3.5 3.5-3.5S9 11 9 13" />
-                  <path d="M9.5 13c0-1.5 1-2.5 2.5-2.5s2.5 1 2.5 2.5" />
-                </svg>
-                <span className="text-sm text-foreground font-sans font-semibold truncate">
-                  {organization.name}
-                </span>
-                {onTeam && (
-                  <span className="text-[9px] text-ladder-green/70 font-mono uppercase tracking-widest flex-shrink-0">
-                    Current
-                  </span>
-                )}
-              </span>
-              <span className="text-ladder-green text-base group-hover:translate-x-0.5 transition-transform flex-shrink-0">
-                →
-              </span>
-            </Link>
-          )}
-
-          {isAdmin && (
-            <Link
-              href="/admin/clients"
-              onClick={() => setOpen(false)}
-              role="menuitem"
-              className="flex items-center justify-between px-4 py-3 hover:bg-[#1f1f1f] border-b border-[#2a2a2a] transition-colors group"
-            >
-              <span className="flex items-center gap-2.5">
-                <svg
-                  width="14"
-                  height="14"
-                  viewBox="0 0 16 16"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  aria-hidden
-                  className="text-muted group-hover:text-foreground"
-                >
-                  <rect x="2" y="2.5" width="12" height="3" />
-                  <rect x="2" y="7" width="12" height="3" />
-                  <rect x="2" y="11.5" width="12" height="3" />
-                </svg>
-                <span className="text-sm text-foreground font-sans font-medium">
-                  Manage Clients
-                </span>
-                {(pathname?.startsWith("/admin/clients") ?? false) && (
-                  <span className="text-[9px] text-ladder-green/70 font-mono uppercase tracking-widest">
-                    Current
-                  </span>
-                )}
-              </span>
-              <span className="text-muted text-base group-hover:translate-x-0.5 transition-transform">
-                →
-              </span>
-            </Link>
-          )}
-
+          {/* Personal */}
           <div className="py-1.5">
+            <MenuRow
+              icon={ICON.dashboard}
+              label="Dashboard"
+              href="/dashboard"
+              onClick={() => setOpen(false)}
+            />
+            {organization && (
+              <MenuRow
+                icon={ICON.team}
+                label="Team"
+                href="/dashboard/team"
+                onClick={() => setOpen(false)}
+              />
+            )}
             {paid ? (
-              <button
-                type="button"
+              <MenuRow
+                icon={ICON.billing}
+                label="Subscription"
                 onClick={() => {
                   setOpen(false);
                   handleManageBilling();
                 }}
                 disabled={portalLoading}
-                role="menuitem"
-                className="w-full text-left px-4 py-2 text-xs text-body font-sans hover:bg-[#1f1f1f] hover:text-foreground transition-colors flex items-center justify-between disabled:opacity-50"
-              >
-                <span>Manage subscription</span>
-                <span className="text-muted text-[10px]">
-                  {portalLoading ? "Opening…" : "Stripe ↗"}
-                </span>
-              </button>
+                meta={
+                  <span className="text-muted text-[10px]">
+                    {portalLoading ? "Opening…" : "Stripe ↗"}
+                  </span>
+                }
+              />
             ) : (
-              <Link
+              <MenuRow
+                icon={ICON.billing}
+                label="Subscription"
                 href="/pricing"
                 onClick={() => setOpen(false)}
-                role="menuitem"
-                className="px-4 py-2 text-xs text-body font-sans hover:bg-[#1f1f1f] hover:text-foreground transition-colors flex items-center justify-between"
-              >
-                <span>Upgrade to Pro</span>
-                <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
-                  $1,000/mo
-                </span>
-              </Link>
+                meta={
+                  <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
+                    $1,000/mo
+                  </span>
+                }
+              />
             )}
-
-            <button
-              type="button"
+            <MenuRow
+              icon={ICON.settings}
+              label="Account"
               onClick={() => {
                 setOpen(false);
                 openUserProfile();
               }}
-              role="menuitem"
-              className="w-full text-left px-4 py-2 text-xs text-body font-sans hover:bg-[#1f1f1f] hover:text-foreground transition-colors"
-            >
-              Account settings
-            </button>
+            />
           </div>
 
+          {/* Admin (platform admins only) */}
+          {isAdmin && (
+            <div className="py-1.5 border-t border-[#2a2a2a]">
+              <MenuRow
+                icon={ICON.clients}
+                label="Clients"
+                href="/admin/clients"
+                onClick={() => setOpen(false)}
+              />
+              <MenuRow
+                icon={ICON.admin}
+                label="Admin"
+                href="/admin"
+                onClick={() => setOpen(false)}
+              />
+            </div>
+          )}
+
+          {/* Sign out */}
           <div className="py-1.5 border-t border-[#2a2a2a]">
-            <button
-              type="button"
+            <MenuRow
+              icon={ICON.signout}
+              label="Sign out"
               onClick={() => {
                 setOpen(false);
                 signOut({ redirectUrl: "/" });
               }}
-              role="menuitem"
-              className="w-full text-left px-4 py-2 text-xs text-muted font-sans hover:bg-[#1f1f1f] hover:text-foreground transition-colors"
-            >
-              Sign out
-            </button>
+            />
           </div>
         </div>
       )}

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 199
+lastPr: 200
 ---
 
 ## How to use this page
@@ -181,7 +181,7 @@ How to apply: any "team plan signup" copy on runladder.com routes to a contact f
 
 ---
 
-## Team org provisioning is admin-driven and in-app (v0.5.5, PR #199)
+## Team org provisioning is admin-driven and in-app (v0.5.5, PR #200)
 
 **A Drawbackwards platform admin provisions each Team org from `/admin/clients`; clients can no longer self-serve.** The admin enters the org name and the Team Lead's name + email; we create the Clerk org and invite the Lead as `org:admin`. Self-serve `CreateOrganization` on `/dashboard/team` is removed.
 

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 207
+lastPr: 199
 ---
 
 ## How to use this page
@@ -178,6 +178,21 @@ How to apply: don't offer ad-hoc discounts on Pro. Don't offer self-serve Team. 
 Why: Teams buyers are companies with design quality problems, not seat-buyers. The deal includes humans (workshop, audit, onboarding) that don't fit a SaaS contract. Selling Teams as SaaS undervalues the engagement and starves the agency.
 
 How to apply: any "team plan signup" copy on runladder.com routes to a contact form, not Stripe checkout. Sales runs through Ward + Michael.
+
+---
+
+## Team org provisioning is admin-driven and in-app (v0.5.5, PR #199)
+
+**A Drawbackwards platform admin provisions each Team org from `/admin/clients`; clients can no longer self-serve.** The admin enters the org name and the Team Lead's name + email; we create the Clerk org and invite the Lead as `org:admin`. Self-serve `CreateOrganization` on `/dashboard/team` is removed.
+
+Decisions baked in:
+
+- **Creator stays a co-admin.** Clerk requires an existing user as the org creator (first `org:admin`), so the acting admin is `createdBy` and remains in the client org for now. Auto-removing them after the Lead accepts is deferred.
+- **Drawbackwards is an internal Team org.** We dogfood Team like any client, but the Drawbackwards org is flagged internal (`publicMetadata.internal`, with a "Drawbackwards" name fallback) and can never be suspended or deleted via the tooling. The "mark internal" toggle sets the flag without Clerk dashboard access.
+- **Suspend = block dashboard only (for now).** Suspending an org (contract paused/ended) blocks `/dashboard/team` and the team API but leaves member tier intact. **Revoking Team comp on suspend is deferred pending Ward's input.**
+- **Delete is type-to-confirm**, available to any platform admin, for QA cleanup. Internal org is exempt.
+
+Why: provisioning was a manual Clerk-dashboard step only Ward could do. Moving it in-app lets any platform admin onboard a client and unblocks selling Team without dashboard access.
 
 ---
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 207
+lastPr: 199
 ---
 
 ## How to read this page
@@ -132,6 +132,11 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Plugin backend proxy (`pluginFetch`) | Admin | Live | `src/lib/admin.ts` |
 | Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Live | `src/lib/admin.ts`, hardcoded, passphrase-gated |
 | Webhook handler for Clerk org join | Auto | Live (v0.3.0) | `src/app/api/webhooks/clerk/route.ts` |
+| Manage Clients page (Team orgs + Pro list) | Admin | Live (v0.5.5) | `src/app/admin/clients/page.tsx`, [#199](https://github.com/drawbackwards/runladder/pull/199) |
+| Provision Team org + invite Team Lead as `org:admin` | Admin | Live (v0.5.5) | `src/app/api/admin/clients/route.ts` |
+| Org lifecycle: suspend / reactivate / delete (type-to-confirm) | Admin | Live (v0.5.5) | `src/app/api/admin/clients/[orgId]/route.ts` |
+| Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |
+| Admin-only "Manage Clients" nav in Account menu | Admin | Live (v0.5.5) | `src/components/UserMenu.tsx`, `src/app/api/admin/status/route.ts` |
 
 ## Ladder HQ (`/hq`)
 
@@ -169,3 +174,4 @@ Built on top of Pro. Sold as a Drawbackwards engagement (MSA + SOW), not self-se
 - Reviews + interactive pins + Team Take aggregate scoring
 - 25,000-query monthly pool
 - Manager-controlled seat invites via Clerk Organizations
+- Admin-provisioned orgs (self-serve org creation disabled in v0.5.5); suspend on contract end

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 199
+lastPr: 200
 ---
 
 ## How to read this page
@@ -132,7 +132,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Plugin backend proxy (`pluginFetch`) | Admin | Live | `src/lib/admin.ts` |
 | Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Live | `src/lib/admin.ts`, hardcoded, passphrase-gated |
 | Webhook handler for Clerk org join | Auto | Live (v0.3.0) | `src/app/api/webhooks/clerk/route.ts` |
-| Manage Clients page (Team orgs + Pro list) | Admin | Live (v0.5.5) | `src/app/admin/clients/page.tsx`, [#199](https://github.com/drawbackwards/runladder/pull/199) |
+| Manage Clients page (Team orgs + Pro list) | Admin | Live (v0.5.5) | `src/app/admin/clients/page.tsx`, [#200](https://github.com/drawbackwards/runladder/pull/200) |
 | Provision Team org + invite Team Lead as `org:admin` | Admin | Live (v0.5.5) | `src/app/api/admin/clients/route.ts` |
 | Org lifecycle: suspend / reactivate / delete (type-to-confirm) | Admin | Live (v0.5.5) | `src/app/api/admin/clients/[orgId]/route.ts` |
 | Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 207
+lastPr: 199
 ---
 
 ## How to read this page
@@ -38,9 +38,18 @@ Triggers for the upgrade conversation:
 
 The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
 
+### Team provisioning (Live, admin-side — v0.5.5, PR #199)
+
+Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a platform admin (an `ADMIN_EMAILS` member) provisions the client from **Account menu → Manage Clients** (`/admin/clients`), instead of doing it by hand in the Clerk dashboard:
+
+1. Admin enters the org name plus the Team Lead's first name, last name, and email.
+2. We create a Clerk Organization (the acting admin is `createdBy` and stays as a co-admin for now) and send the Team Lead an `org:admin` invitation.
+3. Self-serve org creation is disabled — clients can no longer spin up their own orgs.
+4. Lifecycle: admins can **suspend/reactivate** an org when a contract pauses/ends (suspended orgs see a "team access paused" notice; members keep their tier for now) and **delete** test orgs (type-the-name to confirm). The internal **Drawbackwards** org is protected from both.
+
 ### Team manager flow (Live, post-engagement)
 
-After a Drawbackwards Teams engagement closes, the manager gets an admin invite. From there:
+After provisioning, the Team Lead (manager) gets the `org:admin` invite. From there:
 
 1. Land on `/dashboard/team` with an empty roster.
 2. Invite designers by email. Clerk Organization handles the invite.

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -42,8 +42,8 @@ The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo toda
 
 Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a platform admin (an `ADMIN_EMAILS` member) provisions the client from **Account menu → Manage Clients** (`/admin/clients`), instead of doing it by hand in the Clerk dashboard:
 
-1. Admin enters the org name plus the Team Lead's first name, last name, and email.
-2. We create a Clerk Organization (the acting admin is `createdBy` and stays as a co-admin for now) and send the Team Lead an `org:admin` invitation.
+1. On **Manage Clients**, the admin clicks **Add Client** and enters the org name plus the Team Lead's first name, last name, and email.
+2. We create a Clerk Organization (the acting admin is `createdBy` and stays as a co-admin for now) and send the Team Lead an `org:admin` invitation. The org shows as **Pending** until the Team Lead accepts and signs in, at which point the Clerk membership webhook flips it to **Active**.
 3. Self-serve org creation is disabled — clients can no longer spin up their own orgs.
 4. Lifecycle: admins can **suspend/reactivate** an org when a contract pauses/ends (suspended orgs see a "team access paused" notice; members keep their tier for now) and **delete** test orgs (type-the-name to confirm). The internal **Drawbackwards** org is protected from both.
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-26
 updatedBy: Sara
-lastPr: 199
+lastPr: 200
 ---
 
 ## How to read this page
@@ -38,7 +38,7 @@ Triggers for the upgrade conversation:
 
 The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
 
-### Team provisioning (Live, admin-side — v0.5.5, PR #199)
+### Team provisioning (Live, admin-side — v0.5.5, PR #200)
 
 Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a platform admin (an `ADMIN_EMAILS` member) provisions the client from **Account menu → Manage Clients** (`/admin/clients`), instead of doing it by hand in the Clerk dashboard:
 

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -1,0 +1,60 @@
+/**
+ * Organization helpers for the admin client-management tooling (#190).
+ *
+ * Team clients are Clerk Organizations. Drawbackwards is itself a Team org
+ * (we dogfood the product) but must be protected from suspend/delete and
+ * labeled "Internal" in the admin UI. We identify it two ways:
+ *
+ *   1. publicMetadata.internal === true — the durable signal, set via the
+ *      "mark internal" toggle in /admin/clients (works without Clerk
+ *      dashboard access, since our backend has CLERK_SECRET_KEY).
+ *   2. name === "Drawbackwards" — a default guard so the org is protected
+ *      even before the flag has been set.
+ */
+
+export type OrgStatus = "active" | "suspended";
+
+export type TeamLeadMeta = {
+  firstName?: string;
+  lastName?: string;
+  email?: string;
+};
+
+/** Shape we store on an org's publicMetadata. All fields optional/defaulted. */
+export type OrgPublicMetadata = {
+  status?: OrgStatus;
+  internal?: boolean;
+  teamLead?: TeamLeadMeta;
+  provisionedBy?: string;
+  provisionedAt?: number;
+  suspendedAt?: number;
+  suspendedBy?: string;
+};
+
+/** Minimal org shape these helpers need — satisfied by a Clerk Organization. */
+type OrgLike = {
+  name?: string | null;
+  publicMetadata?: Record<string, unknown> | null;
+};
+
+const INTERNAL_ORG_NAME = "drawbackwards";
+
+/** Read publicMetadata as our typed shape (safe on null/undefined). */
+export function orgMeta(org: OrgLike): OrgPublicMetadata {
+  return (org.publicMetadata ?? {}) as OrgPublicMetadata;
+}
+
+/**
+ * True if this org is the internal Drawbackwards org and must never be
+ * suspended or deleted through the admin tooling.
+ */
+export function isInternalOrg(org: OrgLike): boolean {
+  const meta = orgMeta(org);
+  if (meta.internal === true) return true;
+  return (org.name ?? "").trim().toLowerCase() === INTERNAL_ORG_NAME;
+}
+
+/** Lifecycle status, defaulting to "active" when unset. */
+export function orgStatus(org: OrgLike): OrgStatus {
+  return orgMeta(org).status === "suspended" ? "suspended" : "active";
+}

--- a/src/lib/orgs.ts
+++ b/src/lib/orgs.ts
@@ -12,7 +12,7 @@
  *      even before the flag has been set.
  */
 
-export type OrgStatus = "active" | "suspended";
+export type OrgStatus = "pending" | "active" | "suspended";
 
 export type TeamLeadMeta = {
   firstName?: string;
@@ -54,7 +54,12 @@ export function isInternalOrg(org: OrgLike): boolean {
   return (org.name ?? "").trim().toLowerCase() === INTERNAL_ORG_NAME;
 }
 
-/** Lifecycle status, defaulting to "active" when unset. */
+/**
+ * Lifecycle status. A freshly provisioned org is "pending" until its Team
+ * Lead accepts the invite and signs in (flipped to "active" by the Clerk
+ * membership webhook). Defaults to "active" for anything unset/unknown.
+ */
 export function orgStatus(org: OrgLike): OrgStatus {
-  return orgMeta(org).status === "suspended" ? "suspended" : "active";
+  const s = orgMeta(org).status;
+  return s === "suspended" || s === "pending" ? s : "active";
 }

--- a/src/test/auth-gate.test.ts
+++ b/src/test/auth-gate.test.ts
@@ -87,6 +87,8 @@ vi.mock("@/lib/redis", () => ({
  */
 const PROTECTED_ROUTES = [
   // /api/admin/*
+  "src/app/api/admin/clients/[orgId]/route.ts",
+  "src/app/api/admin/clients/route.ts",
   "src/app/api/admin/comps/route.ts",
   "src/app/api/admin/debug-log/route.ts",
   "src/app/api/admin/evaluations/[id]/analyze/route.ts",
@@ -103,6 +105,17 @@ const PROTECTED_ROUTES = [
   "src/app/api/dashboard/team/members/[userId]/route.ts",
   "src/app/api/dashboard/team/route.ts",
 ];
+
+/**
+ * Routes under /api/admin that are intentionally PUBLIC (no auth gate) and
+ * therefore exempt from the protected-route coverage check below. Keep this
+ * list tiny and obvious.
+ *
+ * - status: returns `{ admin: false }` (200) to anonymous callers so the
+ *   client UI can decide whether to show admin nav without exposing the
+ *   ADMIN_EMAILS allowlist. It leaks nothing.
+ */
+const PUBLIC_ADMIN_ROUTES = ["src/app/api/admin/status/route.ts"];
 
 // ─── Helper: exercise every HTTP method on a route handler ───────────────────
 const HTTP_METHODS = ["GET", "POST", "PUT", "PATCH", "DELETE"] as const;
@@ -157,6 +170,10 @@ async function expectAllMethodsRejectAnon(importPath: string): Promise<void> {
 describe("auth gate: /api/admin/*", () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it("clients", () =>
+    expectAllMethodsRejectAnon("@/app/api/admin/clients/route"));
+  it("clients/[orgId]", () =>
+    expectAllMethodsRejectAnon("@/app/api/admin/clients/[orgId]/route"));
   it("comps", () => expectAllMethodsRejectAnon("@/app/api/admin/comps/route"));
   it("debug-log", () =>
     expectAllMethodsRejectAnon("@/app/api/admin/debug-log/route"));
@@ -237,6 +254,9 @@ describe("meta: protected-route coverage", () => {
       ...findRouteFilesUnder(teamRoot),
     ]
       .map((p) => p.slice(projectRoot.length + 1)) // make relative
+      // Intentionally-public routes (e.g. /api/admin/status) aren't gated and
+      // are exempt from the protected-route coverage check.
+      .filter((p) => !PUBLIC_ADMIN_ROUTES.includes(p))
       .sort();
 
     const inManifest = [...PROTECTED_ROUTES].sort();


### PR DESCRIPTION
## Summary
Moves Team org provisioning in-app so any Drawbackwards platform admin can onboard a client without Clerk dashboard access. Closes the upstream half of the Team onboarding flow that the HQ docs previously left as a manual Clerk-dashboard step. Implements #190.

- **Manage Clients page** (`/admin/clients`): provision a Team org + invite the Team Lead as `org:admin`; list Team orgs and Pro subscribers (Pro is read-only).
- **Org lifecycle** (`/api/admin/clients/[orgId]`): suspend / reactivate, mark-internal, and delete (type-the-org-name to confirm).
- **Internal-org protection**: the Drawbackwards org (flagged via `publicMetadata.internal`, with a name fallback) can never be suspended or deleted; labeled "Internal" in the UI.
- **Account menu**: admin-only "Manage Clients" item, gated by a new `/api/admin/status` endpoint so `ADMIN_EMAILS` stays server-side.
- **Self-serve org creation disabled** on `/dashboard/team`; suspended orgs show a paused notice and are blocked at the team data API.
- **/hq lockstep**: `journeys`, `features`, `decisions` updated; frontmatter bumped to PR #199.

## Decisions baked in (per planning with Chester)
- Team Lead = Clerk `org:admin`. The acting admin is `createdBy` and stays as a co-admin for now (Clerk requires an existing creator).
- Suspend blocks the dashboard only; member tier is left intact. **Revoking Team comp on suspend is deferred pending Ward's input.**
- Pro clients included as a read-only list.

## Known blocker (not in this PR)
- The Team Lead **accepting** the invite end-to-end is still blocked by the Clerk dashboard Home URL fix (#181 — prod runs on a `pk_test_` dev Clerk instance). Provisioning and the pending `org:admin` invite are verifiable now; the accept→dashboard redirect verifies once Clerk dashboard access lands.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified locally)
- [ ] Unauthenticated: `/api/admin/status` → `{admin:false}`; `/api/admin/clients` GET/POST and `[orgId]` PATCH/DELETE → 403 (verified locally)
- [ ] Signed-in admin (set `ADMIN_EMAILS` to include your email): "Manage Clients" appears in Account menu; non-admins don't see it
- [ ] Provision a client → Clerk org created + pending `org:admin` invite for the Lead; org appears in the Team list
- [ ] `/dashboard/team` with no org shows "provisioned by Drawbackwards" (no Create Organization)
- [ ] Suspend a test org → members see paused notice + team API returns 403; reactivate restores
- [ ] Mark an org internal → suspend/delete controls disappear and are rejected by the API
- [ ] Delete a test org with name-typing confirmation; confirm the internal/Drawbackwards org cannot be deleted
- [ ] Pro list shows users with `tier: pro`

Note: built off `main`, which doesn't yet include PR #198. Both PRs edit the same `/hq` MDX files, so a minor conflict resolution will be needed whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)