### PR TITLE
Team invite copy: drop "from Clerk" reference (#199)

### DIFF
--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -159,7 +159,7 @@ function InviteForm({
       </div>
       {err && <p className="mt-2 text-xs text-ladder-red font-sans">{err}</p>}
       <p className="mt-2 text-[10px] text-muted font-sans">
-        They&apos;ll get an email from Clerk with a sign-in link. On accept, they&apos;re comped to team tier automatically.
+        They&apos;ll get an email with a sign-in link. On accept, they&apos;re comped to team tier automatically.
       </p>
     </form>
   );


### PR DESCRIPTION
## Summary
Closes #199. The team invite form's helper text named Clerk as the email sender — an implementation detail users shouldn't see.

- `src/app/dashboard/team/page.tsx`: "They'll get an email **from Clerk** with a sign-in link…" → "They'll get an email with a sign-in link…"

## Notes
- One-line copy change. `tsc` clean.
- No `/hq` doc consequence — this micro-copy isn't quoted in the feature inventory.
- Branched off `main` independently of the in-flight provisioning PR (#200), so it can merge on its own.

## Test plan
- [ ] Visit `/dashboard/team` as an org admin; the invite form hint reads "They'll get an email with a sign-in link. On accept, they're comped to team tier automatically."

🤖 Generated with [Claude Code](https://claude.com/claude-code)