### PR TITLE
Activate invited Team Lead's org + fix team setup banner

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -4,6 +4,7 @@ import { redis, lifetimeScansKey } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription, grantComp } from "@/lib/tier";
 import { getUserStats } from "@/lib/scores";
+import { isInternalOrg } from "@/lib/orgs";
 
 export async function GET() {
   const { userId } = await auth();
@@ -12,17 +13,26 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Self-healing fallback: if the user belongs to any Clerk organization
-  // but doesn't yet have a team-tier comp (the webhook missed, the user
-  // pre-dates the webhook, or the secret is unconfigured), grant the comp
-  // here so the dashboard banner doesn't lie to them. Idempotent.
+  // Read the user's org memberships once: used both for the self-healing
+  // comp fallback below and to decide whether this is an internal
+  // Drawbackwards member (who shouldn't see the "Complimentary Team" strip —
+  // we built the product; the comp framing doesn't apply to us).
+  let internal = false;
   try {
     const client = await clerkClient();
+    const memberships = await client.users.getOrganizationMembershipList({
+      userId,
+    });
+    internal = memberships.data.some((m) =>
+      m.organization ? isInternalOrg(m.organization) : false,
+    );
+
+    // Self-healing fallback: if the user belongs to any Clerk organization
+    // but doesn't yet have a team-tier comp (the webhook missed, the user
+    // pre-dates the webhook, or the secret is unconfigured), grant the comp
+    // here so the dashboard banner doesn't lie to them. Idempotent.
     const sub = await getUserSubscription(userId);
     if (sub.tier === "free" || (sub.tier !== "team" && !sub.comp)) {
-      const memberships = await client.users.getOrganizationMembershipList({
-        userId,
-      });
       const firstOrg = memberships.data[0];
       if (firstOrg) {
         await grantComp(userId, {
@@ -68,6 +78,7 @@ export async function GET() {
     stats,
     tier: sub.tier,
     paid: isPaidTier(sub.tier),
+    internal,
     comp: sub.comp
       ? {
           reason: sub.comp.reason,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -107,6 +107,8 @@ type DashboardData = {
   usage: UsageInfo;
   tier: "free" | "pro" | "team" | "pulse";
   paid: boolean;
+  /** Member of the internal Drawbackwards org — suppresses the comp strip. */
+  internal?: boolean;
   comp: CompMeta | null;
 };
 
@@ -128,13 +130,19 @@ function UpgradeStrip({
   paid,
   tier,
   comp,
+  internal,
 }: {
   usage: UsageInfo;
   paid: boolean;
   tier: "free" | "pro" | "team" | "pulse";
   comp: CompMeta | null;
+  internal?: boolean;
 }) {
   const tierLabel = tier === "pro" ? "Pro" : tier === "team" ? "Team" : tier === "pulse" ? "Pulse" : "Free";
+
+  // Internal Drawbackwards members don't see any plan/comp strip — we built
+  // Ladder; the "Complimentary Team" framing doesn't apply to us.
+  if (internal) return null;
 
   if (paid && comp) {
     const expiry =
@@ -458,11 +466,12 @@ export default function DashboardPage() {
   const paid = data?.paid ?? false;
   const tier = data?.tier ?? "free";
   const comp = data?.comp ?? null;
+  const internal = data?.internal ?? false;
   const firstName = user?.firstName || null;
 
   return (
     <div className="pt-20 font-mono">
-      <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} />
+      <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} internal={internal} />
       <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="mb-8">
           <h1 className="text-xl text-foreground font-sans">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
+import { useAuth, useUser, useOrganization, RedirectToSignIn } from "@clerk/nextjs";
+import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
 import { SkillTokenCard } from "@/components/SkillTokenCard";
@@ -411,6 +412,27 @@ export default function DashboardPage() {
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState<string | null>(null);
 
+  // Make sure the user's org is the session's active org (invite-based
+  // provisioning doesn't auto-activate the way self-serve creation did), then
+  // read its membership + pending-invite state to decide team-setup status.
+  useEnsureActiveOrg();
+  const { organization, membership, memberships, invitations } = useOrganization({
+    memberships: { infinite: true },
+    invitations: { status: ["pending"], infinite: true },
+  });
+
+  // The Team Lead's first-run prompt shows only while their team is empty:
+  // they're the org admin, no designer has been invited (no pending invites)
+  // and none has joined (no org:member). It disappears once they invite their
+  // first member. The hidden provisioning service account and the Lead are
+  // both org:admin, so neither counts as an invited designer.
+  const isOrgManager = membership?.role === "org:admin";
+  const hasInvitedMember =
+    (invitations?.data?.length ?? 0) > 0 ||
+    !!memberships?.data?.some((m) => m.role === "org:member");
+  const needsTeamSetup =
+    !!organization && isOrgManager && !hasInvitedMember;
+
   useEffect(() => {
     if (!isSignedIn) return;
 
@@ -479,7 +501,7 @@ export default function DashboardPage() {
           </h1>
         </div>
 
-        <TeamSetupBanner tier={tier} />
+        {needsTeamSetup && <TeamSetupBanner />}
 
         {(tier === "team" || tier === "pulse") && <RequestReviewCTA />}
 
@@ -602,7 +624,9 @@ export default function DashboardPage() {
 
           <aside className="space-y-4">
             <UsageMeter />
-            <TeamCard />
+            {/* While the empty-team setup banner is showing, don't also show
+                the team card — they'd be redundant for a Lead with no team. */}
+            {!needsTeamSetup && <TeamCard />}
             <FigmaPluginCard />
             <SkillTokenCard />
           </aside>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
+import { FormEvent, useCallback, useEffect, useState } from "react";
 import {
   useAuth,
   useOrganization,
@@ -16,6 +16,7 @@ import {
 import { Avatar } from "@/components/Avatar";
 import { ActiveReviewsCard } from "@/components/reviews/ActiveReviewsCard";
 import { ReviewRequestsPanel } from "@/components/reviews/ReviewRequestsPanel";
+import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 
 type MemberStats = {
   totalScans: number;
@@ -673,13 +674,13 @@ function ArchivedMemberRow({
 
 export default function TeamPage() {
   const { isSignedIn, isLoaded } = useAuth();
-  const {
-    isLoaded: orgListLoaded,
-    userMemberships,
-    setActive,
-  } = useOrganizationList({
+  const { isLoaded: orgListLoaded, userMemberships } = useOrganizationList({
     userMemberships: { infinite: true },
   });
+
+  // Activate the user's org if none is active (invite-based provisioning
+  // doesn't auto-activate the way self-serve creation did — see the hook).
+  useEnsureActiveOrg();
   const {
     organization,
     membership,
@@ -717,26 +718,6 @@ export default function TeamPage() {
       refreshTeamData();
     }
   }, [organization?.id, refreshTeamData]);
-
-  // Activate the user's org when they're a member of one but no org is the
-  // session's *active* org. Before #190, a Team Lead got their org via
-  // self-serve `CreateOrganization`, which auto-sets it active. #190 switched
-  // to admin provisioning via invitation, and accepting an invite makes you a
-  // member without setting the org active — so `useOrganization()` returned
-  // null and this page hung on "Loading your team…". Restoring the activation
-  // lets an invited Lead land in their team and invite designers.
-  const activatingRef = useRef(false);
-  useEffect(() => {
-    if (!orgListLoaded || !setActive) return;
-    if (organization) return;
-    const first = userMemberships?.data?.[0];
-    if (!first || activatingRef.current) return;
-    activatingRef.current = true;
-    setActive({ organization: first.organization.id }).catch(() => {
-      // Activation is best-effort; if it fails, allow a retry on next render.
-      activatingRef.current = false;
-    });
-  }, [orgListLoaded, setActive, organization, userMemberships?.data]);
 
   if (!isLoaded) return null;
   if (!isSignedIn) return <RedirectToSignIn />;

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FormEvent, useCallback, useEffect, useState } from "react";
+import { FormEvent, useCallback, useEffect, useRef, useState } from "react";
 import {
   useAuth,
   useOrganization,
@@ -673,7 +673,11 @@ function ArchivedMemberRow({
 
 export default function TeamPage() {
   const { isSignedIn, isLoaded } = useAuth();
-  const { isLoaded: orgListLoaded, userMemberships } = useOrganizationList({
+  const {
+    isLoaded: orgListLoaded,
+    userMemberships,
+    setActive,
+  } = useOrganizationList({
     userMemberships: { infinite: true },
   });
   const {
@@ -713,6 +717,26 @@ export default function TeamPage() {
       refreshTeamData();
     }
   }, [organization?.id, refreshTeamData]);
+
+  // Activate the user's org when they're a member of one but no org is the
+  // session's *active* org. Before #190, a Team Lead got their org via
+  // self-serve `CreateOrganization`, which auto-sets it active. #190 switched
+  // to admin provisioning via invitation, and accepting an invite makes you a
+  // member without setting the org active — so `useOrganization()` returned
+  // null and this page hung on "Loading your team…". Restoring the activation
+  // lets an invited Lead land in their team and invite designers.
+  const activatingRef = useRef(false);
+  useEffect(() => {
+    if (!orgListLoaded || !setActive) return;
+    if (organization) return;
+    const first = userMemberships?.data?.[0];
+    if (!first || activatingRef.current) return;
+    activatingRef.current = true;
+    setActive({ organization: first.organization.id }).catch(() => {
+      // Activation is best-effort; if it fails, allow a retry on next render.
+      activatingRef.current = false;
+    });
+  }, [orgListLoaded, setActive, organization, userMemberships?.data]);
 
   if (!isLoaded) return null;
   if (!isSignedIn) return <RedirectToSignIn />;

--- a/src/components/TeamSetupBanner.tsx
+++ b/src/components/TeamSetupBanner.tsx
@@ -1,31 +1,20 @@
-"use client";
-
 import Link from "next/link";
-import { useOrganization } from "@clerk/nextjs";
-import type { Tier } from "@/lib/plans";
 
 /**
- * First-time team setup prompt on the main dashboard. Shown when a user
- * is on the team or pulse tier but hasn't created or joined a Clerk Org
- * yet — i.e. they were comped or otherwise marked as a team customer
- * but never built the actual team. Hidden once they have an active org
- * (the dashboard's TeamCard takes over from there).
+ * First-time team setup prompt on the main dashboard. Presentational only —
+ * the dashboard decides when to render it: shown to a Team Lead (org:admin)
+ * whose team is still empty (no designers invited yet), and hidden once they
+ * invite their first member. See `src/app/dashboard/page.tsx`.
  */
-export function TeamSetupBanner({ tier }: { tier: Tier }) {
-  const { organization, isLoaded } = useOrganization();
-
-  if (!isLoaded) return null;
-  if (organization) return null;
-  if (tier !== "team" && tier !== "pulse") return null;
-
+export function TeamSetupBanner() {
   return (
     <div className="bg-ladder-green p-8 mb-8">
-      <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 items-center">
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 items-end">
         <div className="min-w-0">
           <p className="text-[10px] uppercase tracking-widest text-[#0a1a14]/70 font-semibold mb-3">
             Team leader
           </p>
-          <h3 className="text-2xl text-[#0a1a14] font-sans font-semibold mb-3 tracking-tight">
+          <h3 className="text-2xl text-[#1a1a1a] font-sans font-semibold mb-3 tracking-tight">
             Set up your team
           </h3>
           <p className="text-sm text-[#0a1a14]/80 font-sans leading-relaxed max-w-2xl">
@@ -36,7 +25,7 @@ export function TeamSetupBanner({ tier }: { tier: Tier }) {
         </div>
         <Link
           href="/dashboard/team"
-          className="text-sm font-semibold bg-white text-[#0a1a14] px-6 py-3.5 hover:bg-white/90 transition-colors flex-shrink-0 whitespace-nowrap justify-self-start md:justify-self-end"
+          className="bg-[#1a1a1a] text-white text-xs font-semibold uppercase tracking-widest px-8 py-3 hover:bg-[#1a1a1a]/90 transition-colors flex-shrink-0 whitespace-nowrap justify-self-start md:justify-self-end"
         >
           Create your team →
         </Link>

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -59,6 +59,8 @@ After provisioning, the Team Lead (manager) gets the `org:admin` invite. From th
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
 
+**First-run setup banner:** on `/dashboard`, a Team Lead sees the green "Set up your team" prompt only while their team is still empty — they're the org admin and no designer has been invited yet (no pending invites, no `org:member`). It disappears once they invite their first member, and the team card takes over. The hidden provisioning service account and the Lead are both `org:admin`, so neither counts as an invited designer.
+
 **Internal members:** members of the internal **Drawbackwards** org don't see the "Complimentary Team" plan strip on `/dashboard` — we built the product, so the comp framing doesn't apply to us. `/api/dashboard` flags the membership (`internal`, via `isInternalOrg`) and the dashboard suppresses the strip. Other team clients still see it.
 
 **Onboarding access note (v0.5.4, PR #198):** signed-in users, including invitees returning from Clerk's hosted portal with an active session, bypass the site password gate (`SITE_PASSWORD`), so the invite flow isn't blocked by the wall. Cold visitors still see it. See [Decisions → Site password gate bypasses signed-in users](/hq/decisions).

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 217
+lastPr: 219
 ---
 
 ## How to read this page
@@ -51,13 +51,15 @@ Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a plat
 
 After provisioning, the Team Lead (manager) gets the `org:admin` invite. From there:
 
-1. Land on `/dashboard/team` with an empty roster.
+1. Land on `/dashboard/team` with an empty roster. The page **activates their org** (`setActive`) on first visit if no org is the session's active one — before #190, self-serve `CreateOrganization` set the org active automatically; the invite-based flow does not, so without this the page hung on "Loading your team…".
 2. Invite designers by email. Clerk Organization handles the invite.
 3. Accepted invitees auto-get a `tier: team` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
 4. Manager sees the team pool meter (25,000 monthly default, shipped v0.4.18), member roster with letter grades A-F, and the Reviews workflow.
 5. Reviews flow: designer requests review, manager accepts or declines, designer scores iterations in `/dashboard/reviews/[slug]`, manager and peers add Team Takes and pin annotations.
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
+
+**Internal members:** members of the internal **Drawbackwards** org don't see the "Complimentary Team" plan strip on `/dashboard` — we built the product, so the comp framing doesn't apply to us. `/api/dashboard` flags the membership (`internal`, via `isInternalOrg`) and the dashboard suppresses the strip. Other team clients still see it.
 
 **Onboarding access note (v0.5.4, PR #198):** signed-in users, including invitees returning from Clerk's hosted portal with an active session, bypass the site password gate (`SITE_PASSWORD`), so the invite flow isn't blocked by the wall. Cold visitors still see it. See [Decisions → Site password gate bypasses signed-in users](/hq/decisions).
 

--- a/src/hooks/use-ensure-active-org.ts
+++ b/src/hooks/use-ensure-active-org.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useOrganization, useOrganizationList } from "@clerk/nextjs";
+
+/**
+ * Activate the user's organization when they're a member of one but no org is
+ * the session's *active* org.
+ *
+ * Before #190, a Team Lead got their org via self-serve `CreateOrganization`,
+ * which sets the new org active in the session. #190 switched to admin
+ * provisioning via invitation; accepting an invite makes you a member but does
+ * NOT set the org active, so `useOrganization()` returns null and the team
+ * surfaces can't resolve which team to show. This restores activation for the
+ * invite-based flow so the dashboard and team page render the user's team.
+ *
+ * Activates the first membership — clients only ever belong to one org. (Only
+ * internal Drawbackwards staff belong to several; a switcher is a later add.)
+ */
+export function useEnsureActiveOrg() {
+  const { organization } = useOrganization();
+  const {
+    isLoaded: listLoaded,
+    userMemberships,
+    setActive,
+  } = useOrganizationList({ userMemberships: { infinite: true } });
+
+  const activating = useRef(false);
+
+  useEffect(() => {
+    if (!listLoaded || !setActive) return;
+    if (organization) return;
+    const first = userMemberships?.data?.[0];
+    if (!first || activating.current) return;
+    activating.current = true;
+    setActive({ organization: first.organization.id }).catch(() => {
+      // Best-effort; allow a retry on a later render if activation failed.
+      activating.current = false;
+    });
+  }, [listLoaded, setActive, organization, userMemberships?.data]);
+}


### PR DESCRIPTION
## Summary
Two team-dashboard issues surfaced while testing #190's invite-based provisioning, plus a banner restyle.

**1. Active-org regression (the core bug).** Before #190, a Team Lead got their org via self-serve `CreateOrganization`, which sets the org active in the session. #190 switched to admin provisioning via invitation; accepting an invite makes you a member but does **not** set the org active, so `useOrganization()` returned null — `/dashboard/team` hung on "Loading your team…" and the dashboard couldn't resolve the team. New `useEnsureActiveOrg` hook (shared by the dashboard and team page) activates the user's org when none is active, restoring the pre-#190 behavior for the invite flow.

**2. "Set up your team" banner re-keyed to real team state.** It was shown to any team-tier user without an active org. Now it shows only to a Team Lead (org:admin) whose team is still empty, and disappears once they invite their first member (a pending invite or an `org:member` joining). The team card takes over; the two are mutually exclusive. The hidden provisioning service account and the Lead are both `org:admin`, so neither counts as an invited designer.

**3. Internal members** (Drawbackwards org) no longer see the "Complimentary Team" plan strip — we built the product, the comp framing doesn't apply to us. `/api/dashboard` flags it via `isInternalOrg`.

**4. Banner restyle:** dark `#1a1a1a` heading + button background, white button text, square all-caps button matching the recent button refresh, bottom-aligned.

## Notes
- Banner hides on the *first pending invite* (immediate feedback), not on first accepted member — matches "after a team lead invites a member."
- End-to-end invite-accept QA is still blocked by #181 (Clerk hosted-portal dead-end).

## Test plan
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] `next build` compiles (verified)
- [ ] Team Lead with empty team sees the styled banner; team card hidden
- [ ] After inviting a designer, banner disappears and team card shows
- [ ] Internal Drawbackwards member sees no "Complimentary Team" strip
- [ ] `/dashboard/team` no longer hangs on "Loading your team…" for an invited Lead

🤖 Generated with [Claude Code](https://claude.com/claude-code)