### PR TITLE
Account menu: upgrade/subscription/settings cleanup (#212, #201, #204)

### DIFF
--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -182,6 +182,15 @@ export function UserMenu() {
   const paid = isPaidTier(tier);
   const tierLabel = TIER_LABEL[tier];
 
+  // Only real Stripe-paying Pro users get the "Subscription" row (it opens the
+  // Stripe customer portal). Comped users — including all Team/Pulse members,
+  // who are comped via the Drawbackwards engagement — have no Stripe customer,
+  // so the portal would fail to load (#204). Comp lives in publicMetadata;
+  // Stripe IDs are server-only (privateMetadata), so this is the reliable
+  // client-side signal. Team/Pulse/comped-Pro see no billing row (#201, #204).
+  const comped = user.publicMetadata?.comp === true;
+  const isStripePro = tier === "pro" && !comped;
+
   const fullName = user.fullName || user.firstName || "Account";
   const email = user.primaryEmailAddress?.emailAddress ?? "";
   const initial = (
@@ -300,7 +309,19 @@ export function UserMenu() {
                 onClick={() => setOpen(false)}
               />
             )}
-            {paid ? (
+            {tier === "free" ? (
+              <MenuRow
+                icon={ICON.billing}
+                label="Upgrade to Pro"
+                href="/pricing"
+                onClick={() => setOpen(false)}
+                meta={
+                  <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
+                    $1,000/mo
+                  </span>
+                }
+              />
+            ) : isStripePro ? (
               <MenuRow
                 icon={ICON.billing}
                 label="Subscription"
@@ -315,19 +336,7 @@ export function UserMenu() {
                   </span>
                 }
               />
-            ) : (
-              <MenuRow
-                icon={ICON.billing}
-                label="Upgrade to Pro"
-                href="/pricing"
-                onClick={() => setOpen(false)}
-                meta={
-                  <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
-                    $1,000/mo
-                  </span>
-                }
-              />
-            )}
+            ) : null}
             <MenuRow
               icon={ICON.settings}
               label="Settings"

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -318,7 +318,7 @@ export function UserMenu() {
             ) : (
               <MenuRow
                 icon={ICON.billing}
-                label="Subscription"
+                label="Upgrade to Pro"
                 href="/pricing"
                 onClick={() => setOpen(false)}
                 meta={
@@ -330,7 +330,7 @@ export function UserMenu() {
             )}
             <MenuRow
               icon={ICON.settings}
-              label="Account"
+              label="Settings"
               onClick={() => {
                 setOpen(false);
                 openUserProfile();


### PR DESCRIPTION
## Summary
Consolidates three menu tickets into one coherent rule for the Account-menu billing row, plus a label rename.

Billing row by tier:
| Tier | Row |
|---|---|
| Free | **"Upgrade to Pro"** → `/pricing` ($1,000/mo) |
| Pro via Stripe (`tier === "pro" && !comp`) | **"Subscription"** → Stripe customer portal |
| Team / Pulse / comped-Pro | **hidden** |

Also renames the profile row **"Account" → "Settings"**.

Closes:
- **#212** — free accounts see "Upgrade to Pro" instead of "Subscription"; "Account" → "Settings".
- **#201** — "Manage Subscription" is Pro-only.
- **#204** — hide "Subscription" for Team users and fix the silent Stripe failure: comped users (all Team/Pulse + comped-Pro) have no Stripe customer, so the portal couldn't load. They no longer see the row. `comp` lives in publicMetadata; Stripe IDs are server-only (privateMetadata), so `tier === "pro" && !comp` is the reliable client-side signal for a real payer.

## Notes
- No /hq consequence: these menu labels / billing-row visibility aren't documented in /hq.

## Test plan
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] `next build` compiles (verified)
- [ ] Free account: row reads "Upgrade to Pro" → /pricing; profile row reads "Settings"
- [ ] Stripe-paying Pro: row reads "Subscription" → opens Stripe portal
- [ ] Team / Pulse / comped account: no billing row shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)