### PR TITLE
Fix team setup banner flash on dashboard refresh

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -426,12 +426,21 @@ export default function DashboardPage() {
   // and none has joined (no org:member). It disappears once they invite their
   // first member. The hidden provisioning service account and the Lead are
   // both org:admin, so neither counts as an invited designer.
+  //
+  // Gate on the org AND its roster/invite lists being fully loaded. Without
+  // this, there's a flash on refresh: the org activates a tick before its
+  // memberships/invitations resolve, so `hasInvitedMember` is briefly false
+  // and the banner shows for an instant on teams that are actually set up.
+  const teamStateLoaded =
+    !!organization &&
+    memberships?.isLoading === false &&
+    invitations?.isLoading === false;
   const isOrgManager = membership?.role === "org:admin";
   const hasInvitedMember =
     (invitations?.data?.length ?? 0) > 0 ||
     !!memberships?.data?.some((m) => m.role === "org:member");
   const needsTeamSetup =
-    !!organization && isOrgManager && !hasInvitedMember;
+    teamStateLoaded && isOrgManager && !hasInvitedMember;
 
   useEffect(() => {
     if (!isSignedIn) return;


### PR DESCRIPTION
## Summary
The team setup banner flash fix (originally committed on the #219 branch as 2ec0053) did not make it into main — #219 merged from an earlier commit, so the deployed dashboard still flashes the green "Set up your team" banner for an instant on refresh. This re-applies the fix.

The banner is gated on the org's roster/invite state, but the org activates a tick before its memberships/invitations resolve. In that window `hasInvitedMember` is briefly false, so the banner flashes on refresh for teams that are actually set up. Gate `needsTeamSetup` on the paginated memberships/invitations having finished loading (`isLoading === false`) so the banner only renders once team state is known.

## Notes
- No /hq consequence (the journeys note from #219 already describes the banner lifecycle).

## Test plan
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] `next build` compiles (verified)
- [ ] On dashboard refresh as a set-up team manager, the green banner no longer flashes
- [ ] Empty-team manager still sees the banner (after load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)