### PR TITLE
Kill dashboard banner flashes (plan strip + team setup)

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -13,11 +13,18 @@ export async function GET() {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  // Read the user's org memberships once: used both for the self-healing
-  // comp fallback below and to decide whether this is an internal
-  // Drawbackwards member (who shouldn't see the "Complimentary Team" strip —
-  // we built the product; the comp framing doesn't apply to us).
+  // Read the user's org memberships once, then derive two dashboard signals
+  // server-side so the client can gate on a single fetch (no client-hook
+  // timing flashes):
+  //   - `internal`: member of the internal Drawbackwards org (hides the
+  //     "Complimentary Team" strip — we built the product).
+  //   - `needsTeamSetup`: the user is a Team Lead (org:admin) whose team is
+  //     still empty (no pending invites, no joined designer), so they should
+  //     see the "Set up your team" prompt. The hidden provisioning service
+  //     account and the Lead are both org:admin, so neither counts as an
+  //     invited designer.
   let internal = false;
+  let needsTeamSetup = false;
   try {
     const client = await clerkClient();
     const memberships = await client.users.getOrganizationMembershipList({
@@ -26,6 +33,30 @@ export async function GET() {
     internal = memberships.data.some((m) =>
       m.organization ? isInternalOrg(m.organization) : false,
     );
+
+    // For each org the user administers, the team is "set up" once a designer
+    // has been invited (pending invite) or joined (org:member). If any admin
+    // org is still empty, the Lead needs the setup prompt.
+    const adminOrgIds = memberships.data
+      .filter((m) => m.role === "org:admin" && m.organization?.id)
+      .map((m) => m.organization!.id);
+    for (const orgId of adminOrgIds) {
+      const [invs, mems] = await Promise.all([
+        client.organizations.getOrganizationInvitationList({
+          organizationId: orgId,
+        }),
+        client.organizations.getOrganizationMembershipList({
+          organizationId: orgId,
+          limit: 100,
+        }),
+      ]);
+      const hasPendingInvite = invs.data.some((i) => i.status === "pending");
+      const hasDesigner = mems.data.some((m) => m.role === "org:member");
+      if (!hasPendingInvite && !hasDesigner) {
+        needsTeamSetup = true;
+        break;
+      }
+    }
 
     // Self-healing fallback: if the user belongs to any Clerk organization
     // but doesn't yet have a team-tier comp (the webhook missed, the user
@@ -79,6 +110,7 @@ export async function GET() {
     tier: sub.tier,
     paid: isPaidTier(sub.tier),
     internal,
+    needsTeamSetup,
     comp: sub.comp
       ? {
           reason: sub.comp.reason,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth, useUser, useOrganization, RedirectToSignIn } from "@clerk/nextjs";
+import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
@@ -110,6 +110,8 @@ type DashboardData = {
   paid: boolean;
   /** Member of the internal Drawbackwards org — suppresses the comp strip. */
   internal?: boolean;
+  /** Team Lead with an empty team — show the "Set up your team" prompt. */
+  needsTeamSetup?: boolean;
   comp: CompMeta | null;
 };
 
@@ -413,34 +415,12 @@ export default function DashboardPage() {
   const [deleting, setDeleting] = useState<string | null>(null);
 
   // Make sure the user's org is the session's active org (invite-based
-  // provisioning doesn't auto-activate the way self-serve creation did), then
-  // read its membership + pending-invite state to decide team-setup status.
+  // provisioning doesn't auto-activate the way self-serve creation did) so the
+  // team card and team page render. The "Set up your team" decision itself is
+  // computed server-side (`needsTeamSetup` from /api/dashboard) and gated on
+  // the dashboard fetch below, so it never flashes on the staged resolution of
+  // client org hooks.
   useEnsureActiveOrg();
-  const { organization, membership, memberships, invitations } = useOrganization({
-    memberships: { infinite: true },
-    invitations: { status: ["pending"], infinite: true },
-  });
-
-  // The Team Lead's first-run prompt shows only while their team is empty:
-  // they're the org admin, no designer has been invited (no pending invites)
-  // and none has joined (no org:member). It disappears once they invite their
-  // first member. The hidden provisioning service account and the Lead are
-  // both org:admin, so neither counts as an invited designer.
-  //
-  // Gate on the org AND its roster/invite lists being fully loaded. Without
-  // this, there's a flash on refresh: the org activates a tick before its
-  // memberships/invitations resolve, so `hasInvitedMember` is briefly false
-  // and the banner shows for an instant on teams that are actually set up.
-  const teamStateLoaded =
-    !!organization &&
-    memberships?.isLoading === false &&
-    invitations?.isLoading === false;
-  const isOrgManager = membership?.role === "org:admin";
-  const hasInvitedMember =
-    (invitations?.data?.length ?? 0) > 0 ||
-    !!memberships?.data?.some((m) => m.role === "org:member");
-  const needsTeamSetup =
-    teamStateLoaded && isOrgManager && !hasInvitedMember;
 
   useEffect(() => {
     if (!isSignedIn) return;
@@ -498,11 +478,17 @@ export default function DashboardPage() {
   const tier = data?.tier ?? "free";
   const comp = data?.comp ?? null;
   const internal = data?.internal ?? false;
+  const needsTeamSetup = data?.needsTeamSetup ?? false;
   const firstName = user?.firstName || null;
 
   return (
     <div className="pt-20 font-mono">
-      <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} internal={internal} />
+      {/* Both the plan strip and the team-setup banner are gated on the
+          dashboard fetch (`data`) so they never flash a wrong default
+          (e.g. the free strip for an internal/team user) on first paint. */}
+      {data && (
+        <UpgradeStrip usage={usage} paid={paid} tier={tier} comp={comp} internal={internal} />
+      )}
       <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="mb-8">
           <h1 className="text-xl text-foreground font-sans">
@@ -510,7 +496,7 @@ export default function DashboardPage() {
           </h1>
         </div>
 
-        {needsTeamSetup && <TeamSetupBanner />}
+        {data && needsTeamSetup && <TeamSetupBanner />}
 
         {(tier === "team" || tier === "pulse") && <RequestReviewCTA />}
 
@@ -634,8 +620,9 @@ export default function DashboardPage() {
           <aside className="space-y-4">
             <UsageMeter />
             {/* While the empty-team setup banner is showing, don't also show
-                the team card — they'd be redundant for a Lead with no team. */}
-            {!needsTeamSetup && <TeamCard />}
+                the team card — they'd be redundant for a Lead with no team.
+                Gated on `data` so it doesn't flash before team state is known. */}
+            {data && !needsTeamSetup && <TeamCard />}
             <FigmaPluginCard />
             <SkillTokenCard />
           </aside>

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 219
+lastPr: 223
 ---
 
 ## How to read this page
@@ -59,7 +59,7 @@ After provisioning, the Team Lead (manager) gets the `org:admin` invite. From th
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
 
-**First-run setup banner:** on `/dashboard`, a Team Lead sees the green "Set up your team" prompt only while their team is still empty — they're the org admin and no designer has been invited yet (no pending invites, no `org:member`). It disappears once they invite their first member, and the team card takes over. The hidden provisioning service account and the Lead are both `org:admin`, so neither counts as an invited designer.
+**First-run setup banner:** on `/dashboard`, a Team Lead sees the green "Set up your team" prompt only while their team is still empty — they're the org admin and no designer has been invited yet (no pending invites, no `org:member`). It disappears once they invite their first member, and the team card takes over. The hidden provisioning service account and the Lead are both `org:admin`, so neither counts as an invited designer. This decision (`needsTeamSetup`) is computed server-side in `/api/dashboard` and the banner — like the plan strip — is gated on that fetch, so neither flashes a wrong default before the client knows the answer.
 
 **Internal members:** members of the internal **Drawbackwards** org don't see the "Complimentary Team" plan strip on `/dashboard` — we built the product, so the comp framing doesn't apply to us. `/api/dashboard` flags the membership (`internal`, via `isInternalOrg`) and the dashboard suppresses the strip. Other team clients still see it.
 


### PR DESCRIPTION
## Summary
Two banners flashed on every dashboard load, on local and prod:
1. The **"free scores left" plan strip** — rendered with `tier:free / internal:false` defaults before `/api/dashboard` resolved, so internal/team users saw it flash then vanish. It wasn't gated on load at all.
2. The green **"Set up your team" banner** — keyed off Clerk client hooks that resolve in stages; the earlier `isLoading` gate still flashed.

**Fix:** compute the team-setup decision **server-side** in `/api/dashboard` (`needsTeamSetup`: the user is an `org:admin` whose team has no pending invite and no `org:member`), reusing the membership read already done for `internal`. Then gate **both** banners (and the team card) on the single `/api/dashboard` fetch having resolved, so neither renders a wrong default before the answer is known. Removes the client-side `useOrganization` team-state logic from the dashboard.

## Notes
- `useEnsureActiveOrg` stays (the team card / team page still need an active org).
- Behavior unchanged: new Team Lead with an empty team sees the banner; it disappears after the first invite.
- /hq journeys updated in lockstep (lastPr 223).

## Test plan
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] `next build` compiles (verified)
- [ ] Internal/team user: no plan-strip flash, no green-banner flash on refresh
- [ ] Free user: plan strip appears (after load, no flash)
- [ ] New Team Lead (empty team): setup banner shows; after inviting, it's gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)