### PR TITLE
Dedicated /settings account page, replacing the Clerk modal (#203)

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -175,7 +175,7 @@ function ProfileCard() {
         <p className="text-sm text-foreground font-sans">
           {user.primaryEmailAddress?.emailAddress ?? "—"}
         </p>
-        <p className="text-[10px] text-muted font-sans mt-1">
+        <p className="text-xs text-muted font-sans mt-1">
           This is your sign-in email. We send your sign-in code here.
         </p>
       </div>
@@ -203,14 +203,28 @@ function GoogleCard() {
 
   if (!user) return null;
 
-  const google = user.externalAccounts.find((a) =>
-    (a.provider ?? "").includes("google"),
+  // Only a *verified* Google link counts as connected. createExternalAccount
+  // adds the record in an unverified state before the OAuth round-trip, so a
+  // cancelled attempt would otherwise show as "Connected".
+  const isGoogle = (a: { provider?: string }) =>
+    (a.provider ?? "").includes("google");
+  const google = user.externalAccounts.find(
+    (a) => isGoogle(a) && a.verification?.status === "verified",
   );
 
   async function connect() {
     setBusy(true);
     setError(null);
     try {
+      // Clear any stale unverified Google link left by a cancelled attempt so
+      // re-connecting doesn't collide.
+      const stale = user!.externalAccounts.find(
+        (a) => isGoogle(a) && a.verification?.status !== "verified",
+      );
+      if (stale) {
+        await stale.destroy();
+        await user!.reload();
+      }
       const ext = await user!.createExternalAccount({
         strategy: "oauth_google",
         redirectUrl: `${window.location.origin}/settings`,
@@ -253,7 +267,7 @@ function GoogleCard() {
               <span className="text-muted"> · {google.emailAddress}</span>
             ) : null}
           </p>
-          <p className="text-[10px] text-muted font-sans mt-1">
+          <p className="text-xs text-muted font-sans mt-1">
             You can sign in with Google. Disconnecting still leaves email
             sign-in, so you won&apos;t be locked out.
           </p>
@@ -269,7 +283,7 @@ function GoogleCard() {
       ) : (
         <>
           <p className="mt-4 text-sm text-foreground font-sans">Not connected</p>
-          <p className="text-[10px] text-muted font-sans mt-1">
+          <p className="text-xs text-muted font-sans mt-1">
             Connect Google to sign in with one click instead of an email code.
           </p>
           {error && (
@@ -318,7 +332,7 @@ function DangerCard() {
 
   return (
     <>
-      <div className="border border-ladder-red/30 bg-ladder-red/5 p-6">
+      <div className={CARD}>
         <span className="text-[9px] text-ladder-red uppercase tracking-widest font-semibold">
           Delete account
         </span>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,389 @@
+"use client";
+
+import { useState } from "react";
+import { useUser, useClerk, RedirectToSignIn } from "@clerk/nextjs";
+
+/**
+ * Dedicated account settings page (#203), replacing Clerk's `openUserProfile()`
+ * modal. A single page (no tabs) of stacked cards in the app's "Lego box"
+ * style, so it reads consistently with the rest of the product instead of
+ * Clerk's one-off modal chrome. Reached only from the Account menu, so there's
+ * no back link — just a "Settings" title like Team / Manage Clients.
+ *
+ * Built on Clerk hooks rather than the `<UserProfile />` component on purpose:
+ * styling that component to match our dark/tool aesthetic is a rabbit hole, and
+ * a passwordless app only needs a thin surface (profile, the Google link, and
+ * account deletion).
+ */
+
+const CARD = "border border-[#333] bg-[#1e1e1e] p-6";
+const LABEL =
+  "text-[9px] text-ladder-green uppercase tracking-widest font-semibold";
+const INPUT =
+  "w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans";
+const BTN_PRIMARY =
+  "text-xs font-semibold bg-ladder-green text-[#1a1a1a] uppercase tracking-widest px-5 py-2.5 hover:bg-ladder-green/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed";
+const BTN_GHOST =
+  "text-xs font-semibold text-foreground uppercase tracking-widest border border-[#333] px-5 py-2.5 hover:border-muted transition-colors disabled:opacity-40 disabled:cursor-not-allowed";
+
+export default function SettingsPage() {
+  const { isLoaded, isSignedIn } = useUser();
+
+  if (!isLoaded) return null;
+  if (!isSignedIn) return <RedirectToSignIn />;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-2xl mx-auto px-6 py-10">
+        <div className="mb-8">
+          <h1 className="text-xl text-foreground font-sans">Settings</h1>
+          <p className="text-xs text-muted font-sans mt-1">
+            Your account and sign-in.
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          <ProfileCard />
+          <GoogleCard />
+          <DangerCard />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ProfileCard() {
+  const { user } = useUser();
+  const [firstName, setFirstName] = useState(user?.firstName ?? "");
+  const [lastName, setLastName] = useState(user?.lastName ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!user) return null;
+
+  const dirty =
+    firstName.trim() !== (user.firstName ?? "") ||
+    lastName.trim() !== (user.lastName ?? "");
+
+  async function save() {
+    setSaving(true);
+    setError(null);
+    try {
+      await user!.update({
+        firstName: firstName.trim(),
+        lastName: lastName.trim(),
+      });
+      setSaved(true);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't save your profile.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function onPickImage(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    setError(null);
+    try {
+      await user!.setProfileImage({ file });
+      await user!.reload();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Couldn't update your photo.",
+      );
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  }
+
+  const initial = (
+    user.firstName?.[0] ||
+    user.lastName?.[0] ||
+    user.primaryEmailAddress?.emailAddress?.[0] ||
+    "?"
+  ).toUpperCase();
+
+  return (
+    <div className={CARD}>
+      <span className={LABEL}>Profile</span>
+
+      <div className="mt-4 flex items-center gap-4">
+        <span className="relative block w-14 h-14 rounded-full overflow-hidden bg-[#111] flex-shrink-0">
+          {user.hasImage ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={user.imageUrl}
+              alt=""
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <span className="absolute inset-0 flex items-center justify-center bg-ladder-green text-[#1a1a1a] text-lg font-semibold uppercase">
+              {initial}
+            </span>
+          )}
+        </span>
+        <label className="cursor-pointer text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors">
+          {uploading ? "Uploading…" : "Change photo"}
+          <input
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={onPickImage}
+            disabled={uploading}
+            className="hidden"
+          />
+        </label>
+      </div>
+
+      <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-[10px] text-muted uppercase tracking-widest mb-1.5">
+            First name
+          </label>
+          <input
+            value={firstName}
+            onChange={(e) => {
+              setFirstName(e.target.value);
+              setSaved(false);
+            }}
+            className={INPUT}
+          />
+        </div>
+        <div>
+          <label className="block text-[10px] text-muted uppercase tracking-widest mb-1.5">
+            Last name
+          </label>
+          <input
+            value={lastName}
+            onChange={(e) => {
+              setLastName(e.target.value);
+              setSaved(false);
+            }}
+            className={INPUT}
+          />
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <label className="block text-[10px] text-muted uppercase tracking-widest mb-1.5">
+          Email
+        </label>
+        <p className="text-sm text-foreground font-sans">
+          {user.primaryEmailAddress?.emailAddress ?? "—"}
+        </p>
+        <p className="text-[10px] text-muted font-sans mt-1">
+          This is your sign-in email. We send your sign-in code here.
+        </p>
+      </div>
+
+      {error && <p className="mt-4 text-xs text-ladder-red font-sans">{error}</p>}
+
+      <div className="mt-5 flex items-center gap-4">
+        <button onClick={save} disabled={!dirty || saving} className={BTN_PRIMARY}>
+          {saving ? "Saving…" : "Save"}
+        </button>
+        {saved && !dirty && (
+          <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+            Saved
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GoogleCard() {
+  const { user } = useUser();
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!user) return null;
+
+  const google = user.externalAccounts.find((a) =>
+    (a.provider ?? "").includes("google"),
+  );
+
+  async function connect() {
+    setBusy(true);
+    setError(null);
+    try {
+      const ext = await user!.createExternalAccount({
+        strategy: "oauth_google",
+        redirectUrl: `${window.location.origin}/settings`,
+      });
+      const url = ext.verification?.externalVerificationRedirectURL;
+      if (url) {
+        window.location.href = url.toString();
+      } else {
+        setError("Couldn't start the Google connection.");
+        setBusy(false);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't connect Google.");
+      setBusy(false);
+    }
+  }
+
+  async function disconnect() {
+    if (!google) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await google.destroy();
+      await user!.reload();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't disconnect Google.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className={CARD}>
+      <span className={LABEL}>Google</span>
+      {google ? (
+        <>
+          <p className="mt-4 text-sm text-foreground font-sans">
+            Connected
+            {google.emailAddress ? (
+              <span className="text-muted"> · {google.emailAddress}</span>
+            ) : null}
+          </p>
+          <p className="text-[10px] text-muted font-sans mt-1">
+            You can sign in with Google. Disconnecting still leaves email
+            sign-in, so you won&apos;t be locked out.
+          </p>
+          {error && (
+            <p className="mt-4 text-xs text-ladder-red font-sans">{error}</p>
+          )}
+          <div className="mt-5">
+            <button onClick={disconnect} disabled={busy} className={BTN_GHOST}>
+              {busy ? "Working…" : "Disconnect Google"}
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="mt-4 text-sm text-foreground font-sans">Not connected</p>
+          <p className="text-[10px] text-muted font-sans mt-1">
+            Connect Google to sign in with one click instead of an email code.
+          </p>
+          {error && (
+            <p className="mt-4 text-xs text-ladder-red font-sans">{error}</p>
+          )}
+          <div className="mt-5">
+            <button onClick={connect} disabled={busy} className={BTN_PRIMARY}>
+              {busy ? "Connecting…" : "Connect Google"}
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function DangerCard() {
+  const { user } = useUser();
+  const { signOut } = useClerk();
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const PHRASE = "Delete my account";
+
+  if (!user) return null;
+
+  async function confirmDelete() {
+    setBusy(true);
+    setError(null);
+    try {
+      await user!.delete();
+      await signOut({ redirectUrl: "/" });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Couldn't delete account.");
+      setBusy(false);
+    }
+  }
+
+  function close() {
+    if (busy) return;
+    setOpen(false);
+    setConfirmText("");
+    setError(null);
+  }
+
+  return (
+    <>
+      <div className="border border-ladder-red/30 bg-ladder-red/5 p-6">
+        <span className="text-[9px] text-ladder-red uppercase tracking-widest font-semibold">
+          Delete account
+        </span>
+        <p className="mt-4 text-xs text-muted font-sans leading-relaxed">
+          Permanently delete your account, your scores, and your team
+          membership. This cannot be undone.
+        </p>
+        <div className="mt-5">
+          <button
+            onClick={() => setOpen(true)}
+            className="text-xs font-semibold bg-ladder-red text-white uppercase tracking-widest px-5 py-2.5 hover:bg-ladder-red/90 transition-colors"
+          >
+            Delete account
+          </button>
+        </div>
+      </div>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/70 px-6"
+          onClick={close}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div
+            className="w-full max-w-md border border-[#2a2a2a] bg-[#161616] p-5 shadow-2xl shadow-black/50 font-mono"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-lg font-sans font-semibold text-foreground mb-2">
+              Delete your account
+            </h2>
+            <p className="text-xs text-muted font-sans mb-4 leading-relaxed">
+              This permanently deletes your Ladder account, all of your scores,
+              and removes you from any team. It cannot be undone. Type{" "}
+              <span className="text-foreground">{PHRASE}</span> to confirm.
+            </p>
+            <input
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              placeholder={PHRASE}
+              autoFocus
+              className={INPUT}
+            />
+            {error && (
+              <p className="mt-3 text-xs text-ladder-red font-sans">{error}</p>
+            )}
+            <div className="mt-5 flex items-center justify-end gap-4">
+              <button
+                onClick={close}
+                disabled={busy}
+                className="text-xs font-semibold text-muted hover:text-foreground transition-colors px-4 py-1.5 uppercase tracking-widest"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmDelete}
+                disabled={busy || confirmText.trim() !== PHRASE}
+                className="text-xs font-semibold bg-ladder-red text-white px-4 py-1.5 hover:bg-ladder-red/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed uppercase tracking-widest"
+              >
+                {busy ? "Deleting…" : "Delete account"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,7 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { useUser, useClerk, RedirectToSignIn } from "@clerk/nextjs";
+import {
+  useUser,
+  useClerk,
+  useReverification,
+  RedirectToSignIn,
+} from "@clerk/nextjs";
 
 /**
  * Dedicated account settings page (#203), replacing Clerk's `openUserProfile()`
@@ -20,7 +25,11 @@ const CARD = "border border-[#333] bg-[#1e1e1e] p-6";
 const LABEL =
   "text-[9px] text-ladder-green uppercase tracking-widest font-semibold";
 const INPUT =
-  "w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-2 focus:outline-none focus:border-muted placeholder:text-[#555] font-sans";
+  "w-full bg-[#111] border border-[#333] text-sm text-foreground px-2.5 py-2 focus:outline-none focus:border-ladder-green placeholder:text-[#555] font-sans";
+
+/** True for a Google external account, whatever exact provider string Clerk uses. */
+const isGoogleAccount = (a: { provider?: string }) =>
+  (a.provider ?? "").includes("google");
 const BTN_PRIMARY =
   "text-xs font-semibold bg-ladder-green text-[#1a1a1a] uppercase tracking-widest px-5 py-2.5 hover:bg-ladder-green/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed";
 const BTN_GHOST =
@@ -201,35 +210,50 @@ function GoogleCard() {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Linking/unlinking an external account is a sensitive operation that Clerk
+  // gates behind step-up reverification. useReverification prompts the user to
+  // re-verify (an email code, since we're passwordless) and retries on success.
+  const doConnect = useReverification(async () => {
+    // Clear any stale unverified Google link left by a cancelled attempt so
+    // re-connecting doesn't collide.
+    const stale = user!.externalAccounts.find(
+      (a) => isGoogleAccount(a) && a.verification?.status !== "verified",
+    );
+    if (stale) {
+      await stale.destroy();
+      await user!.reload();
+    }
+    return user!.createExternalAccount({
+      strategy: "oauth_google",
+      redirectUrl: `${window.location.origin}/settings`,
+    });
+  });
+
+  const doDisconnect = useReverification(async () => {
+    const g = user!.externalAccounts.find(
+      (a) => isGoogleAccount(a) && a.verification?.status === "verified",
+    );
+    if (g) {
+      await g.destroy();
+      await user!.reload();
+    }
+  });
+
   if (!user) return null;
 
   // Only a *verified* Google link counts as connected. createExternalAccount
   // adds the record in an unverified state before the OAuth round-trip, so a
   // cancelled attempt would otherwise show as "Connected".
-  const isGoogle = (a: { provider?: string }) =>
-    (a.provider ?? "").includes("google");
   const google = user.externalAccounts.find(
-    (a) => isGoogle(a) && a.verification?.status === "verified",
+    (a) => isGoogleAccount(a) && a.verification?.status === "verified",
   );
 
   async function connect() {
     setBusy(true);
     setError(null);
     try {
-      // Clear any stale unverified Google link left by a cancelled attempt so
-      // re-connecting doesn't collide.
-      const stale = user!.externalAccounts.find(
-        (a) => isGoogle(a) && a.verification?.status !== "verified",
-      );
-      if (stale) {
-        await stale.destroy();
-        await user!.reload();
-      }
-      const ext = await user!.createExternalAccount({
-        strategy: "oauth_google",
-        redirectUrl: `${window.location.origin}/settings`,
-      });
-      const url = ext.verification?.externalVerificationRedirectURL;
+      const ext = await doConnect();
+      const url = ext?.verification?.externalVerificationRedirectURL;
       if (url) {
         window.location.href = url.toString();
       } else {
@@ -243,12 +267,10 @@ function GoogleCard() {
   }
 
   async function disconnect() {
-    if (!google) return;
     setBusy(true);
     setError(null);
     try {
-      await google.destroy();
-      await user!.reload();
+      await doDisconnect();
     } catch (e) {
       setError(e instanceof Error ? e.message : "Couldn't disconnect Google.");
     } finally {
@@ -309,13 +331,18 @@ function DangerCard() {
   const [error, setError] = useState<string | null>(null);
   const PHRASE = "Delete my account";
 
+  // Account deletion is reverification-gated by Clerk, same as account linking.
+  const doDelete = useReverification(async () => {
+    await user!.delete();
+  });
+
   if (!user) return null;
 
   async function confirmDelete() {
     setBusy(true);
     setError(null);
     try {
-      await user!.delete();
+      await doDelete();
       await signOut({ redirectUrl: "/" });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Couldn't delete account.");

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -122,7 +122,7 @@ function ProfileCard() {
       <span className={LABEL}>Profile</span>
 
       <div className="mt-4 flex items-center gap-4">
-        <span className="relative block w-14 h-14 rounded-full overflow-hidden bg-[#111] flex-shrink-0">
+        <span className="relative block w-28 h-28 rounded-full overflow-hidden bg-[#111] flex-shrink-0">
           {user.hasImage ? (
             // eslint-disable-next-line @next/next/no-img-element
             <img
@@ -131,7 +131,7 @@ function ProfileCard() {
               className="w-full h-full object-cover"
             />
           ) : (
-            <span className="absolute inset-0 flex items-center justify-center bg-ladder-green text-[#1a1a1a] text-lg font-semibold uppercase">
+            <span className="absolute inset-0 flex items-center justify-center bg-ladder-green text-[#1a1a1a] text-3xl font-semibold uppercase">
               {initial}
             </span>
           )}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -15,6 +15,7 @@ export function Nav() {
   const inProduct =
     pathname?.startsWith("/dashboard") ||
     pathname?.startsWith("/score") ||
+    pathname?.startsWith("/settings") ||
     pathname?.startsWith("/hq") ||
     pathname?.startsWith("/admin") ||
     false;

--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -136,7 +136,7 @@ function MenuRow({
 
 export function UserMenu() {
   const { user, isLoaded } = useUser();
-  const { signOut, openUserProfile } = useClerk();
+  const { signOut } = useClerk();
   const { organization } = useOrganization();
   const [open, setOpen] = useState(false);
   const [portalLoading, setPortalLoading] = useState(false);
@@ -340,10 +340,8 @@ export function UserMenu() {
             <MenuRow
               icon={ICON.settings}
               label="Settings"
-              onClick={() => {
-                setOpen(false);
-                openUserProfile();
-              }}
+              href="/settings"
+              onClick={() => setOpen(false)}
             />
           </div>
 

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -1,8 +1,8 @@
 ---
 title: API Protocols
-updatedAt: 2026-05-19
+updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 179
+lastPr: 225
 ---
 
 ## Two surfaces, one to come
@@ -67,7 +67,7 @@ Detailed request/response shape lives in the route file. When the public API shi
 | Public API key | **Roadmap** | Bearer `ldr_live_...` | UI doesn't exist yet (issuance is roadmap) |
 | MCP | **Roadmap** | Bearer in MCP config | n/a |
 
-There is **no `/dashboard/settings` route today**. Plugin and Skill tokens are issued via API calls from in-product flows. The settings UI that issues these tokens is roadmap.
+The account settings page lives at **`/settings`** (#203: profile, Google connection, account deletion). It does **not** yet issue API keys or Plugin/Skill tokens — those are still issued via API calls from in-product flows, and the key-issuance section of `/settings` is roadmap.
 
 ## Versioning
 
@@ -118,4 +118,4 @@ Until that ships, anything you read in this page about "v1/score" paths, MCP too
 
 ## Key rotation (target state)
 
-Once API key issuance UI ships, keys rotate from `/dashboard/settings`. Old tokens valid for 24 hours after rotation. Today, Plugin and Skill tokens rotate by re-issuing via the API. Admin allowlists rotate via `ADMIN_EMAILS` env vars; `SUPER_ADMIN_EMAILS` rotates only via PR + deploy + Ward's passphrase.
+Once API key issuance UI ships, keys rotate from `/settings`. Old tokens valid for 24 hours after rotation. Today, Plugin and Skill tokens rotate by re-issuing via the API. Admin allowlists rotate via `ADMIN_EMAILS` env vars; `SUPER_ADMIN_EMAILS` rotates only via PR + deploy + Ward's passphrase.

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -2,7 +2,7 @@
 title: API Protocols
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 225
+lastPr: 229
 ---
 
 ## Two surfaces, one to come

--- a/src/content/hq/diagrams.ts
+++ b/src/content/hq/diagrams.ts
@@ -155,7 +155,7 @@ flowchart LR
 flowchart LR
   SignUp["Sign up on runladder.com"]
   Upgrade["Upgrade to Pro or Teams"]
-  Settings["/dashboard/settings"]
+  Settings["/settings"]
   Key["Generate API key"]
   Call["POST /v1/score"]
   Response["Score + X-Ladder-API-Version header"]

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 225
+lastPr: 229
 ---
 
 ## How to read this page
@@ -44,7 +44,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Public profile (`/[username]`) | All signed-in | Roadmap | No route yet |
 | Ladder Lift CTA on sub-3.0 scores | Free | Roadmap | No code yet |
 | Teardowns (`/teardowns`) | Public | Roadmap | No route yet |
-| Account settings (`/settings`): profile, Google connect/disconnect, delete account | All signed-in | Live (PR #225) | `src/app/settings/page.tsx` (#203). Replaces Clerk's `openUserProfile()` modal. Billing + API-key sections still roadmap. |
+| Account settings (`/settings`): profile, Google connect/disconnect, delete account | All signed-in | Live (PR #229) | `src/app/settings/page.tsx` (#203). Replaces Clerk's `openUserProfile()` modal. Billing + API-key sections still roadmap. |
 
 ## Figma plugin: `drawbackwards/ai-design-assistant` + runladder backend
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-05-26
+updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 200
+lastPr: 225
 ---
 
 ## How to read this page
@@ -44,7 +44,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Public profile (`/[username]`) | All signed-in | Roadmap | No route yet |
 | Ladder Lift CTA on sub-3.0 scores | Free | Roadmap | No code yet |
 | Teardowns (`/teardowns`) | Public | Roadmap | No route yet |
-| `/dashboard/settings` (account, billing, API keys) | All signed-in | Roadmap | No route yet |
+| Account settings (`/settings`): profile, Google connect/disconnect, delete account | All signed-in | Live (PR #225) | `src/app/settings/page.tsx` (#203). Replaces Clerk's `openUserProfile()` modal. Billing + API-key sections still roadmap. |
 
 ## Figma plugin: `drawbackwards/ai-design-assistant` + runladder backend
 
@@ -112,7 +112,7 @@ The dedicated public surface at `api.runladder.com` does not exist (domain doesn
 | `api.runladder.com` domain registered + configured | Roadmap | DNS returns NXDOMAIN today |
 | Public `POST /v1/score` with Bearer auth | Roadmap | No code yet |
 | Public `GET /v1/framework` | Roadmap | Internal `/api/framework` exists; public version pending |
-| API key issuance UI (`/dashboard/settings`) | Roadmap | No route yet |
+| API key issuance UI (`/settings`) | Roadmap | Account settings live at `/settings`; key-issuance section pending |
 | Rate-limit response (429 + `Retry-After`) | Roadmap | Today returns 401/403 with tier-specific messages |
 | MCP server with `ladder.score`, `ladder.framework`, `ladder.account` tools | Roadmap | No code yet |
 | OpenAPI spec | Roadmap | No spec written |

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 223
+lastPr: 225
 ---
 
 ## How to read this page
@@ -77,7 +77,7 @@ The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend e
 
 Key beats:
 
-- Plugin token is issued via `POST /api/plugin/issue-token` (Clerk session required), then pasted into the Figma plugin. There is **no `/dashboard/settings` UI for this yet**; issuance happens via in-plugin auth flow.
+- Plugin token is issued via `POST /api/plugin/issue-token` (Clerk session required), then pasted into the Figma plugin. The account page at `/settings` (#203) does **not** issue these tokens yet; issuance happens via the in-plugin auth flow.
 - Token is server-issued, single-user, scoped to plugin requests. Verified via `POST /api/plugin/verify-token`.
 - Score requests hit `/api/plugin/analyze`. Same scoring engine as the web app. Persisted via `POST /api/plugin/persist-score`.
 - Free users hit the 5-lifetime cap inside the plugin same as on web.
@@ -132,7 +132,7 @@ This is the future-target surface. Today, the same scoring is callable via `/api
 When the public API ships:
 
 - Sign up on runladder.com, upgrade to Pro or Teams.
-- Generate an API key from the Pro settings page (`/dashboard/settings`, also roadmap).
+- Generate an API key from the settings page (`/settings`; the account section is live per #203, the API-key section is roadmap).
 - Call `POST /api/score` (or the future `api.runladder.com/v1/score`) with Bearer auth.
 - Response includes `X-Ladder-API-Version` header.
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 225
+lastPr: 229
 ---
 
 ## How to read this page

--- a/src/content/hq/roadmap.mdx
+++ b/src/content/hq/roadmap.mdx
@@ -2,7 +2,7 @@
 title: Roadmap
 updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 225
+lastPr: 229
 ---
 
 ## How this page works

--- a/src/content/hq/roadmap.mdx
+++ b/src/content/hq/roadmap.mdx
@@ -1,8 +1,8 @@
 ---
 title: Roadmap
-updatedAt: 2026-05-19
+updatedAt: 2026-05-27
 updatedBy: Sara
-lastPr: 179
+lastPr: 225
 ---
 
 ## How this page works
@@ -52,7 +52,7 @@ Until all three flip, no paid acquisition push. Soft launches with the design co
 | Public profile (`/[username]`) | Web | After Top 100 ships |
 | Figma plugin relaunch + marketplace demo | Plugin | Re-review restarted 2026-04-18 |
 | Pro upsell flow polish (a11y + UX copywriting unlock) | Web | Conversion lever |
-| `/dashboard/settings` (account, billing, API keys) | Web | Required before public API ships (key issuance UI) |
+| `/settings` billing + API-key sections | Web | Account section shipped (`/settings`, #203); billing + key issuance still required before public API ships |
 | Engineering hire trigger evaluation | Team | See [Decisions Log → Engineering model](/hq/decisions#engineering-model-current-state) |
 
 ## Skill distribution roadmap
@@ -132,7 +132,7 @@ Owner: Ward + Sara.
 
 ### Phase 3: API key issuance UI (1 week)
 
-Build `/dashboard/settings`:
+Add an API-keys section to `/settings` (the account page shipped in #203):
 
 1. List existing API keys (masked).
 2. Generate new keys with a label.


### PR DESCRIPTION
## Summary
Closes #203. Replaces the Account menu's Clerk `openUserProfile()` modal (one-off nav/chrome, painful to restyle) with a dedicated `/settings` page built on Clerk hooks, in the app's own dark/tool aesthetic.

Single page titled "Settings" (matching Team / Manage Clients), no back link (only reachable from the Account menu), with stacked cards in the box style:

- **Profile** - edit first/last name and avatar; email shown read-only (passwordless login). Saves via `user.update()` / `user.setProfileImage()`.
- **Google** - Connect when unlinked (`createExternalAccount`), or show the connected Google email with a guarded Disconnect. Email sign-in always remains, so no lockout. Plain "Google" copy instead of the generic "Connected account".
- **Delete account** - danger card + dialog requiring the user to type `Delete my account` to confirm (mirrors the org-delete interaction in Manage Clients), then `user.delete()` and sign out to `/`.

Repoints the Account-menu "Settings" row to `/settings`.

## Route decision
Lives at `/settings` (top-level account area, since it isn't reached via dashboard nav). `/hq` previously designated `/dashboard/settings` as the future account/billing/API-keys home; this PR moves that documented home to `/settings` so future billing + API-key sections land in the same place (no split).

## Scope notes
- No tabs (single page of cards), no embedded Clerk `<UserProfile />`, no billing (separate Stripe surface), no multi-email, no sessions card. Each can be added later.

## /hq lockstep
features, roadmap, api, journeys, and the API-key-flow diagram updated; account settings marked Live at `/settings`. (The historical reference in decisions.mdx is left as-is.)

## Test plan
- [ ] `npx tsc --noEmit` clean (verified)
- [ ] `next build` compiles (verified)
- [ ] Edit name/avatar saves and persists
- [ ] Google: Connect launches OAuth; when linked, shows email + Disconnect works (and you can still sign in via email code)
- [ ] Delete account: confirm button stays disabled until `Delete my account` is typed; deletion signs out to `/`
- [ ] Account menu "Settings" navigates to `/settings` (no modal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)