### PR TITLE
Update Teams CTA copy and clean up /contact page

### DIFF
--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -91,7 +91,7 @@ const SCREEN_SCORE_TIERS: ScreenTier[] = [
       "Access to customer sentiment and Ladder Pulse scoring data + insights, if subscribed (coming soon)",
       "Audit toolkit with redline annotations on every score (coming soon)",
     ],
-    cta: "Apply to be a beta tester",
+    cta: "Talk to us about Teams",
     href: "/contact?interest=teams-beta",
     solidCta: false,
   },


### PR DESCRIPTION
Closes #197
Closes #236

## Summary

**Teams CTA (#197)**
- Updated Teams tier CTA on `/pricing` from "Apply to be a beta tester" to "Talk to us about Teams", consistent with the Pulse CTA pattern. Routes to `/contact?interest=teams-beta` which already notifies `hello@drawbackwards.com` via Resend.

**Contact page cleanup (#236)**
- Remove `<br />` from H1 so headline wraps naturally
- Hero spans full width (removed `max-w-2xl` constraint)
- Hero body tightened to 2 sentences, removed "from design to the boardroom"
- "What changes when you have a score" bullets rewritten: shorter sentences, no buzzwords
- "Who we work with" card hidden (preserved in comments for potential reuse)
- Teams interest option updated to "Ladder for Teams (beta)"

## Test plan

- [ ] Teams CTA on `/pricing` reads "Talk to us about Teams"
- [ ] `/contact` H1 wraps naturally with no forced line break
- [ ] Hero body is 2 sentences, no corporate language
- [ ] "What changes" bullets are concise and pass brand voice check
- [ ] "Who we work with" card is not visible
- [ ] "Ladder for Teams (beta)" interest option pre-selects correctly from `/contact?interest=teams-beta`
- [ ] Pulse CTA still reads "Talk to us about Pulse" (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)