### PR TITLE
Settings: photo-upload label reflects whether a photo exists yet

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -137,7 +137,11 @@ function ProfileCard() {
           )}
         </span>
         <label className="cursor-pointer text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors">
-          {uploading ? "Uploading…" : "Change photo"}
+          {uploading
+            ? "Uploading…"
+            : user.hasImage
+              ? "Change photo"
+              : "Upload photo"}
           <input
             type="file"
             accept="image/png,image/jpeg,image/webp"


### PR DESCRIPTION
## Summary
Small copy fix on `/settings`. The Profile card always rendered "CHANGE PHOTO" as the upload-trigger label, even for users who hadn't uploaded one (where only the initial fallback was showing). It read as if there was a photo to change.

Now:
- `user.hasImage === false` → "Upload photo"
- `user.hasImage === true` → "Change photo"
- mid-upload → "Uploading…" (unchanged)

## Notes
- Related to a real situation surfaced today: when a Google-OAuth user disconnects Google via the Google card, Clerk drops the Google-sourced avatar, leaving `hasImage` false. The label then mislabeled the upload affordance.
- No /hq consequence (label copy isn't documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)