### PR TITLE
Onboarding & admin bug fixes (banner, member count, copy, name, Team Lead terminology)

### DIFF
--- a/src/components/TeamSetupBanner.tsx
+++ b/src/components/TeamSetupBanner.tsx
@@ -14,7 +14,13 @@ export function TeamSetupBanner() {
           <p className="text-[10px] uppercase tracking-widest text-[#0a1a14]/70 font-semibold mb-3">
             Team leader
           </p>
-          <h3 className="text-2xl text-[#1a1a1a] font-sans font-semibold mb-3 tracking-tight">
+          {/* `!` important modifier: a global `h1–h6 { color: foreground }`
+              rule in globals.css is unlayered, so it beats Tailwind's layered
+              text-color utility (Tailwind v4 cascade-layer precedence) and
+              forces this heading white on the green banner. The important
+              utility wins it back. Root fix (layer the global rule) tracked
+              in #259/#40. */}
+          <h3 className="text-2xl text-[#1a1a1a]! font-sans font-semibold mb-3 tracking-tight">
             Set up your team
           </h3>
           <p className="text-sm text-[#0a1a14]/80 font-sans leading-relaxed max-w-2xl">


### PR DESCRIPTION
Bundles the fixes from the 2026-05-29 prod onboarding test.

## Fixes
- **Banner heading rendered white** (#259/#40) — global unlayered `h1–h6 { color }` beat Tailwind's layered utility (v4 cascade layers); added `text-[#1a1a1a]!`. Root fix (layer the global rule) still tracked for the design-system cleanup.
- **Member count includes the service account** (#262) — `/admin/clients` showed "2" for a solo Team Lead. Now excludes the hidden provisioning account via a `createdBy === provisioner` guard (legacy orgs stay exact).
- **"Complimentary" shown to paying clients** (#258) — the dashboard plan strip now shows the tier label (e.g. "Team — Member of {org}"), not "Complimentary Team."
- **"Welcome back" on a first visit** (#259) — fallback greeting is now "Welcome." for first-time / nameless users.
- **Team Lead lands nameless** (#259) — the Clerk webhook now applies the provisioned first/last name to the new user's profile on accept (Clerk invitations don't carry it), if they haven't set one.
- **Role terminology** (#260) — standardized in-app copy to **"Team Lead"** (was a mix of "Manager"/"Team Leader") across the team dashboard, member detail, reviews, and setup banner. Left "account manager" (the Drawbackwards contact) and marketing buyer-persona copy alone, per Chester.

## Deliberately excluded
- **Post-accept landing destination** (#259 / task #8) — the Team Lead lands on home, not `/dashboard`. `signUpFallbackRedirectUrl` is already `/score`, yet the invite-accept still goes to home, so the lever is the invitation redirect / Clerk Account Portal, not the ClerkProvider fallbacks. Spans both the Team Lead and designer invite paths and needs a Clerk re-test — out of scope here.

## /hq lockstep
- `glossary.mdx`: "Team Lead" recorded as canonical; "Manager"/"Team Leader" deprecated for the role.
- `journeys.mdx`: terminology, name propagation, and comp-label updates.
- Frontmatter bumped on both (lastPr 261).

## Verification
- `npx tsc --noEmit` clean.
- Lint: no new issues in changed files (pre-existing warnings in dashboard.tsx unrelated).

## Test plan
- [ ] `/admin/clients`: a solo-Team-Lead org shows **1** member.
- [ ] Dashboard plan strip for a Team client reads "Team — …", no "Complimentary."
- [ ] New Team Lead (no name set) is greeted "Welcome." not "Welcome back."; after the webhook fix, a freshly-accepted Team Lead shows their provisioned name.
- [ ] Team dashboard / member detail / reviews say "Team Lead," never "Manager."
- [ ] Banner heading renders dark on the green banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)