### PR TITLE
Onboarding & admin bug fixes (rest of the swoop, stranded by early #261 merge)

### DIFF
--- a/src/app/api/admin/clients/route.ts
+++ b/src/app/api/admin/clients/route.ts
@@ -54,12 +54,22 @@ export async function GET() {
     limit: 200,
     includeMembersCount: true,
   });
+  const provisioner = provisioningUserId();
   const teamClients: TeamClient[] = orgList.data.map((org) => {
     const meta = orgMeta(org);
+    // Exclude the hidden provisioning service account from the count. It's a
+    // member of every org it provisioned (it's the `createdBy` owner), so
+    // Clerk's raw membersCount is always +1 for provisioned orgs (#262). The
+    // `createdBy === provisioner` guard keeps legacy/non-provisioned orgs exact.
+    const rawCount = org.membersCount ?? 0;
+    const membersCount =
+      provisioner && org.createdBy === provisioner
+        ? Math.max(0, rawCount - 1)
+        : rawCount;
     return {
       id: org.id,
       name: org.name,
-      membersCount: org.membersCount ?? 0,
+      membersCount,
       status: orgStatus(org),
       internal: isInternalOrg(org),
       teamLead: meta.teamLead ?? null,

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -93,12 +93,30 @@ export async function POST(req: NextRequest) {
         });
         const meta = (org.publicMetadata ?? {}) as {
           status?: string;
-          teamLead?: { email?: string };
+          teamLead?: { email?: string; firstName?: string; lastName?: string };
         };
         if (meta.status === "pending" && meta.teamLead?.email) {
           const user = await client.users.getUser(userId);
           const email = user.primaryEmailAddress?.emailAddress?.toLowerCase();
           if (email && email === meta.teamLead.email.toLowerCase()) {
+            // Propagate the name captured at provisioning onto the new user's
+            // profile — Clerk org invitations don't carry it over, so without
+            // this the Team Lead lands nameless (greeting falls back, menu
+            // shows no name). Only set it if they haven't set one themselves.
+            if (
+              !user.firstName &&
+              !user.lastName &&
+              (meta.teamLead.firstName || meta.teamLead.lastName)
+            ) {
+              try {
+                await client.users.updateUser(userId, {
+                  firstName: meta.teamLead.firstName,
+                  lastName: meta.teamLead.lastName,
+                });
+              } catch (e) {
+                console.error("[clerk webhook] name propagation failed", e);
+              }
+            }
             await client.organizations.updateOrganization(orgId, {
               publicMetadata: { ...meta, status: "active" },
             });

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -161,7 +161,7 @@ function UpgradeStrip({
         <div className="max-w-6xl mx-auto px-6 py-2.5 flex items-center justify-center gap-4 flex-wrap">
           <span className="text-[11px] text-muted font-sans">
             <span className="text-ladder-green font-semibold uppercase tracking-widest text-[10px]">
-              Complimentary {tierLabel}
+              {tierLabel}
             </span>
             {comp.reason && <> — {comp.reason}.</>}
             {expiry && (
@@ -492,7 +492,7 @@ export default function DashboardPage() {
       <div className="max-w-6xl mx-auto px-6 py-10">
         <div className="mb-8">
           <h1 className="text-xl text-foreground font-sans">
-            {firstName ? `Hi, ${firstName}.` : "Welcome back."}
+            {firstName ? `Hi, ${firstName}.` : "Welcome."}
           </h1>
         </div>
 

--- a/src/app/dashboard/reviews/request/page.tsx
+++ b/src/app/dashboard/reviews/request/page.tsx
@@ -40,7 +40,7 @@ export default function RequestReviewPage() {
               Request sent.
             </p>
             <p className="text-sm text-muted font-sans leading-relaxed max-w-md mx-auto mb-6">
-              Your manager will see it on their team dashboard. You&apos;ll
+              Your Team Lead will see it on their team dashboard. You&apos;ll
               get a notification when they pick it up.
             </p>
             <Link
@@ -70,8 +70,8 @@ export default function RequestReviewPage() {
             Request a review
           </h1>
           <p className="text-sm text-muted font-sans leading-relaxed">
-            Ask your team manager for human eyes on a screen. Ladder will
-            score it. Your manager and the assigned reviewers will drop
+            Ask your Team Lead for human eyes on a screen. Ladder will
+            score it. Your Team Lead and the assigned reviewers will drop
             notes and weigh in with a Team Take.
           </p>
         </div>
@@ -97,7 +97,7 @@ export default function RequestReviewPage() {
             </label>
             <p className="text-[11px] text-muted font-sans mb-2">
               Optional. Pick an existing Review to attach this screen to, or
-              leave blank and let the manager decide.
+              leave blank and let your Team Lead decide.
             </p>
             <div className="flex flex-wrap gap-2">
               <button
@@ -109,7 +109,7 @@ export default function RequestReviewPage() {
                     : "border-[#3a3a3a] text-body hover:border-[#555] hover:text-foreground"
                 }`}
               >
-                Manager decides
+                Team Lead decides
               </button>
               {MOCK_REVIEWS.filter((r) => r.status === "active").map((r) => (
                 <button

--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -261,9 +261,9 @@ export default function TeamMemberDetailPage() {
   if (authorized === false) {
     return (
       <div className="pt-20 max-w-2xl mx-auto px-6 py-20 font-mono">
-        <h1 className="text-xl font-bold font-sans mb-3">Manager access required</h1>
+        <h1 className="text-xl font-bold font-sans mb-3">Team Lead access required</h1>
         <p className="text-sm text-muted font-sans">
-          Only team managers can see member detail. Head back to{" "}
+          Only Team Leads can see member detail. Head back to{" "}
           <Link href="/dashboard/team" className="text-ladder-green hover:underline">
             your team
           </Link>
@@ -343,7 +343,7 @@ export default function TeamMemberDetailPage() {
                 {member.role === "org:admin" && (
                   <>
                     <span className="text-[#444] mx-1.5">·</span>
-                    <span className="text-ladder-green">manager</span>
+                    <span className="text-ladder-green">Team Lead</span>
                   </>
                 )}
               </p>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -462,7 +462,7 @@ function MemberRow({
           </p>
           {member.role === "org:admin" && !isSelf && (
             <span className="text-[9px] text-ladder-green uppercase tracking-widest">
-              Manager
+              Team Lead
             </span>
           )}
         </div>
@@ -887,7 +887,7 @@ export default function TeamPage() {
               {isAdmin && (
                 <>
                   {" · "}
-                  <span className="text-ladder-green">manager</span>
+                  <span className="text-ladder-green">Team Lead</span>
                 </>
               )}
             </p>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -435,9 +435,13 @@ function MemberRow({
   const avg = stats?.avgScore ?? null;
   const totalScans = stats?.totalScans ?? 0;
   const lastAt = stats?.lastScoreAt ?? null;
-  const drillHref = member.userId
-    ? `/dashboard/team/members/${member.userId}`
-    : null;
+  // Only Team Leads (org:admin) can open member detail. Gate the row link on
+  // the viewer's role so designers don't click through to a 403 (#263) — the
+  // row renders as plain, non-clickable content for them.
+  const drillHref =
+    isAdmin && member.userId
+      ? `/dashboard/team/members/${member.userId}`
+      : null;
 
   const Body = (
     <div className="px-4 py-4 flex items-center gap-5">

--- a/src/components/TeamSetupBanner.tsx
+++ b/src/components/TeamSetupBanner.tsx
@@ -12,7 +12,7 @@ export function TeamSetupBanner() {
       <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-6 items-end">
         <div className="min-w-0">
           <p className="text-[10px] uppercase tracking-widest text-[#0a1a14]/70 font-semibold mb-3">
-            Team leader
+            Team Lead
           </p>
           {/* `!` important modifier: a global `h1–h6 { color: foreground }`
               rule in globals.css is unlayered, so it beats Tailwind's layered

--- a/src/content/hq/glossary.mdx
+++ b/src/content/hq/glossary.mdx
@@ -73,4 +73,3 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 | "The Ladder platform" | "Ladder" | Platform is a generic word |
 | "Tier" (for rungs) | "Rung" or "level" | "Tier" is the price tier |
 | "Manager" / "Team Leader" (the role) | "Team Lead" | One canonical term for the `org:admin` who leads a client team |
-| "Score it" (anonymous) | "Sign up to score" | No anonymous scoring |

--- a/src/content/hq/glossary.mdx
+++ b/src/content/hq/glossary.mdx
@@ -1,8 +1,8 @@
 ---
 title: Glossary
-updatedAt: 2026-05-19
+updatedAt: 2026-05-29
 updatedBy: Sara
-lastPr: 179
+lastPr: 261
 ---
 
 ## Why this exists
@@ -49,7 +49,7 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 | **Pro** | $1,000/mo self-serve on Stripe, individual, 2,000 scores/month, all surfaces. |
 | **Team** | Agency engagement via MSA + SOW (Beta on /pricing). Publicly Custom. Capital T. |
 | **Teams** | Plural noun ("Teams customers"), referring to multiple Team engagements collectively. |
-| **Team Member** / **Team Leader** | Roles within a Teams engagement. |
+| **Team Member** / **Team Lead** | Roles within a Teams engagement. **Team Lead** is the canonical term for the `org:admin` who leads a client team — not "Manager" or "Team Leader." |
 | **Pulse User** | Customer on a Pulse engagement. |
 | **Admin** | Internal Drawbackwards admin (Ward, Michael, Jordan). |
 | **Super Admin** | Ward only. |
@@ -72,4 +72,5 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 | "Team plan" | "Teams" or "Teams engagement" | Teams isn't a plan, it's an engagement |
 | "The Ladder platform" | "Ladder" | Platform is a generic word |
 | "Tier" (for rungs) | "Rung" or "level" | "Tier" is the price tier |
+| "Manager" / "Team Leader" (the role) | "Team Lead" | One canonical term for the `org:admin` who leads a client team |
 | "Score it" (anonymous) | "Sign up to score" | No anonymous scoring |

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-05-28
+updatedAt: 2026-05-29
 updatedBy: Sara
-lastPr: 232
+lastPr: 261
 ---
 
 ## How to read this page
@@ -47,21 +47,21 @@ Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a plat
 3. Self-serve org creation is disabled — clients can no longer spin up their own orgs.
 4. Lifecycle: admins can **suspend/reactivate** an org when a contract pauses/ends (suspended orgs see a "team access paused" notice; members keep their tier for now) and **delete** test orgs (type-the-name to confirm). The internal **Drawbackwards** org is protected from both.
 
-### Team manager flow (Live, post-engagement)
+### Team Lead flow (Live, post-engagement)
 
-After provisioning, the Team Lead (manager) gets the `org:admin` invite. From there:
+After provisioning, the Team Lead gets the `org:admin` invite. On accept, the first/last name captured at provisioning is applied to their Clerk profile (Clerk invitations don't carry it over), so they aren't greeted nameless (#259). From there:
 
 1. Land on `/dashboard/team` with an empty roster. The page **activates their org** (`setActive`) on first visit if no org is the session's active one — before #190, self-serve `CreateOrganization` set the org active automatically; the invite-based flow does not, so without this the page hung on "Loading your team…".
 2. Invite designers by email. Clerk Organization handles the invite.
 3. Accepted invitees auto-get a `tier: team` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
-4. Manager sees the team pool meter (25,000 monthly default, shipped v0.4.18), member roster with letter grades A-F, and the Reviews workflow.
-5. Reviews flow: designer requests review, manager accepts or declines, designer scores iterations in `/dashboard/reviews/[slug]`, manager and peers add Team Takes and pin annotations.
+4. The Team Lead sees the team pool meter (25,000 monthly default, shipped v0.4.18), member roster with letter grades A-F, and the Reviews workflow.
+5. Reviews flow: designer requests review, the Team Lead accepts or declines, designer scores iterations in `/dashboard/reviews/[slug]`, the Team Lead and peers add Team Takes and pin annotations.
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
 
 **First-run setup banner:** on `/dashboard`, a Team Lead sees the green "Set up your team" prompt only while their team is still empty — they're the org admin and no designer has been invited yet (no pending invites, no `org:member`). It disappears once they invite their first member, and the team card takes over. The hidden provisioning service account and the Lead are both `org:admin`, so neither counts as an invited designer. This decision (`needsTeamSetup`) is computed server-side in `/api/dashboard` and the banner — like the plan strip — is gated on that fetch, so neither flashes a wrong default before the client knows the answer.
 
-**Internal members:** members of the internal **Drawbackwards** org don't see the "Complimentary Team" plan strip on `/dashboard` — we built the product, so the comp framing doesn't apply to us. `/api/dashboard` flags the membership (`internal`, via `isInternalOrg`) and the dashboard suppresses the strip. Other team clients still see it.
+**Internal members:** members of the internal **Drawbackwards** org don't see the team plan strip on `/dashboard` — we built the product, so the comp framing doesn't apply to us. (The strip no longer shows the word "Complimentary" to paying clients — it renders the tier label, e.g. "Team — Member of {org}." See #258.) `/api/dashboard` flags the membership (`internal`, via `isInternalOrg`) and the dashboard suppresses the strip. Other team clients still see it.
 
 **Onboarding access note (v0.5.4, PR #198):** signed-in users, including invitees returning from Clerk's hosted portal with an active session, bypass the site password gate (`SITE_PASSWORD`), so the invite flow isn't blocked by the wall. Cold visitors still see it. See [Decisions → Site password gate bypasses signed-in users](/hq/decisions).
 


### PR DESCRIPTION
#261 was merged while it still contained only the banner fix, so these commits — pushed right after — never made it into main. Re-opening them here. **No banner change in this PR; that already shipped in #261.**

## Fixes
- **Member count** (#262): `/admin/clients` excludes the hidden provisioning service account (solo Team Lead reads "1" not "2").
- **"Complimentary" → tier label** (#258): paying-client plan strip no longer says "Complimentary."
- **Welcome copy** (#259): "Welcome." not "Welcome back." for first-time / nameless users.
- **Name propagation** (#259): Clerk webhook applies the provisioned first/last name to the new Team Lead's profile on accept.
- **Team Lead terminology** (#260): standardized in-app role copy to "Team Lead" (team dashboard, member detail, reviews, setup banner). Left "account manager" and marketing copy alone.
- **Designer row-gating** (#263): designers no longer click team members through to a Team-Lead-only 403; rows are non-clickable for them.
- **Glossary anon-scoring** : removed the stale "No anonymous scoring" entry (#187, confirmed with Ward).

## Excluded (logged, needs investigation)
- Post-accept landing destination (#259 / #8); Clerk handoff flash; Clerk Turnstile bot-challenge (config, #259).

## /hq lockstep
glossary + journeys updated; frontmatter bumped (lastPr references #261; will note #261/this PR).

## Verification
`npx tsc --noEmit` clean; no new lint issues in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)