### PR TITLE
Exclude org-membership comps from the admin Comps list

### DIFF
--- a/src/app/api/admin/comps/route.ts
+++ b/src/app/api/admin/comps/route.ts
@@ -29,6 +29,23 @@ function unauthorized() {
 }
 
 /**
+ * Org-membership comps (auto-granted when a user joins any Team/internal org)
+ * are the team-tier mechanism, not real comps. They're excluded from the admin
+ * list, which is for manual grants only (partners, friends, customers in
+ * flight) — so internal Drawbackwards members, the provisioning service
+ * account, and client team members never appear here. New records carry
+ * `compSource`; legacy ones (granted before that field existed) are matched by
+ * the webhook's reason pattern ("Member of {org}" / "Team member").
+ */
+function isOrgComp(meta: Record<string, unknown> | undefined): boolean {
+  const source = meta?.compSource;
+  if (source === "org") return true;
+  if (source === "manual") return false;
+  const reason = typeof meta?.compReason === "string" ? meta.compReason : "";
+  return reason === "Team member" || reason.startsWith("Member of ");
+}
+
+/**
  * GET /api/admin/comps
  * Lists all comps:
  *  - Active: users with publicMetadata.comp === true
@@ -48,6 +65,8 @@ export async function GET() {
   for (const u of list.data) {
     const meta = u.publicMetadata as Record<string, unknown> | undefined;
     if (meta?.comp !== true) continue;
+    // Hide org-membership comps — this list is for manual grants only.
+    if (isOrgComp(meta)) continue;
     const tierRaw = meta.tier;
     const tier: Tier =
       tierRaw === "pro" || tierRaw === "team" || tierRaw === "pulse"

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -79,6 +79,9 @@ export async function POST(req: NextRequest) {
     await grantComp(userId, {
       tier: "team",
       reason: orgName ? `Member of ${orgName}` : "Team member",
+      // Org-membership comp (the team-tier mechanism), not a real comp — kept
+      // out of the admin comps list, which is for manual partner/friend grants.
+      source: "org",
     });
 
     // Flip a freshly provisioned org from "pending" to "active" once its

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -1,8 +1,8 @@
 ---
 title: Decisions Log
-updatedAt: 2026-05-27
+updatedAt: 2026-05-29
 updatedBy: Sara
-lastPr: 217
+lastPr: 265
 ---
 
 ## How to use this page
@@ -191,6 +191,7 @@ Decisions baked in:
 - **Drawbackwards is an internal Team org.** We dogfood Team like any client, but the Drawbackwards org is flagged internal (`publicMetadata.internal`, with a "Drawbackwards" name fallback) and can never be suspended or deleted via the tooling. The "mark internal" toggle sets the flag without Clerk dashboard access.
 - **Suspend = block dashboard only (for now).** Suspending an org (contract paused/ended) blocks `/dashboard/team` and the team API but leaves member tier intact. **Revoking Team comp on suspend is deferred pending Ward's input.**
 - **Delete is type-to-confirm**, available to any platform admin, for QA cleanup. Internal org is exempt.
+- **Org-membership comps are not "comps."** Joining any Team or internal org auto-grants `tier: team` through the comp mechanism, but that's an internal tier-grant detail, not a real comp. The admin Comps list (`/admin/comps`) shows **only manual grants** (partners, friends, customers in flight) — internal Drawbackwards members, the hidden provisioning service account, and client team members are filtered out (tagged `compSource: "org"`, with a legacy reason-pattern fallback for records granted before the tag existed). Keeps the list accurate so a teammate or paying client never appears as a "comp."
 
 Why: provisioning was a manual Clerk-dashboard step only Ward could do. Moving it in-app lets any platform admin onboard a client and unblocks selling Team without dashboard access.
 

--- a/src/lib/tier.ts
+++ b/src/lib/tier.ts
@@ -7,6 +7,14 @@ export type CompInfo = {
   comp: true;
   /** Why this comp was granted (e.g. "Lumin partner", "Friend of DB"). */
   reason: string;
+  /**
+   * How the comp was granted. "org" = auto-granted by org membership (the
+   * team-tier mechanism — internal Drawbackwards + client members); "manual" =
+   * granted via the admin Grant Comp form (partners, friends, customers in
+   * flight). The admin comps list shows only "manual"; "org" comps are an
+   * internal tier-grant detail, not a real comp.
+   */
+  source?: "org" | "manual";
   /** Optional ISO ms timestamp. After this point the comp is treated as expired. */
   expiresAt?: number;
   /** ISO ms when the comp was granted. */
@@ -27,7 +35,11 @@ function readComp(meta: Record<string, unknown> | undefined): CompInfo | undefin
     typeof meta.compExpiresAt === "number" ? meta.compExpiresAt : undefined;
   const grantedAt =
     typeof meta.compGrantedAt === "number" ? meta.compGrantedAt : Date.now();
-  return { comp: true, reason, expiresAt, grantedAt };
+  const source =
+    meta.compSource === "org" || meta.compSource === "manual"
+      ? meta.compSource
+      : undefined;
+  return { comp: true, reason, source, expiresAt, grantedAt };
 }
 
 function isExpired(comp: CompInfo | undefined): boolean {
@@ -143,7 +155,17 @@ export async function setUserSubscription(
 /** Grant a complimentary tier to a user. Idempotent — overwrites prior comp. */
 export async function grantComp(
   userId: string,
-  args: { tier: Exclude<Tier, "free">; reason: string; expiresAt?: number }
+  args: {
+    tier: Exclude<Tier, "free">;
+    reason: string;
+    expiresAt?: number;
+    /**
+     * "org" = auto-granted via org membership; "manual" = admin Grant Comp
+     * form. Defaults to "manual" so the admin comps list (which hides "org"
+     * comps) keeps surfacing every form-granted comp.
+     */
+    source?: "org" | "manual";
+  }
 ): Promise<void> {
   const client = await clerkClient();
   const existing = await client.users.getUser(userId);
@@ -153,6 +175,7 @@ export async function grantComp(
       tier: args.tier,
       comp: true,
       compReason: args.reason,
+      compSource: args.source ?? "manual",
       compGrantedAt: Date.now(),
       ...(args.expiresAt ? { compExpiresAt: args.expiresAt } : { compExpiresAt: undefined }),
     },
@@ -171,6 +194,7 @@ export async function revokeComp(userId: string): Promise<void> {
   next.tier = "free";
   delete next.comp;
   delete next.compReason;
+  delete next.compSource;
   delete next.compGrantedAt;
   delete next.compExpiresAt;
   await client.users.updateUser(userId, { publicMetadata: next });


### PR DESCRIPTION
## Problem
The admin **Comps** list (`/admin/comps`) showed every user with `comp: true` — which includes the `tier: team` comp **auto-granted when anyone joins a Team or internal org**. So internal Drawbackwards members, the **hidden provisioning service account**, and client team members all appeared as "comps." Confusing and inaccurate: a teammate or a paying client is not a comp, and the tab is explicitly for "partners, friends, customers in flight."

## Fix
- Tag comps with **`compSource`**: `"org"` (Clerk webhook, on org join) vs `"manual"` (Grant Comp form). `grantComp` defaults to `"manual"`.
- The comps list **hides org-sourced comps**, with a **legacy reason-pattern fallback** (`"Member of {org}"` / `"Team member"`) so existing records (your account, the service account, Prod Test Co members) drop off **immediately — no migration**.
- `revokeComp` clears the new field.

Result: the list shows **only manual grants** — internal members, the provisioning account, and clients never appear.

## /hq lockstep
`decisions.mdx` records the "org-membership comps are not comps" rule; frontmatter bumped.

## Verification
- `npx tsc --noEmit` clean; eslint clean on changed files.
- Manual check after deploy: `/admin/comps` should show **0 active** for the current data (only org comps exist so far); granting a comp via the form still appears.

## Note
This is a list-display fix. Internal/client members still get `tier: team` under the hood via the comp mechanism (unchanged) — they're just no longer surfaced as "comps." A deeper refactor (deriving team-tier from org membership instead of overloading comp) is a larger future change, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)