### PR TITLE
Update Team Take language to Team Collaboration on /products (#246)

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -86,7 +86,7 @@ const SURFACES = [
       "Team leaderboard unified across all Ladder surfaces",
       "Design rhythm and activity heatmap per designer",
       "Design Reviews: score every iteration, track score lift across the sprint",
-      "Team Take: peer designers score alongside Ladder on every frame",
+      "Team Collaboration: designers can leave comments on how to improve a score on each other's designs and managers can see all commenting activity across the team",
       "Seat management: invite, archive, and remove team members",
       "25,000 pooled scores per month across web, Figma, and Claude",
     ],


### PR DESCRIPTION
## Summary

- Replaces the "Team Take: peer designers score alongside Ladder on every frame" bullet on `/products` with the Team Collaboration framing
- Language is consistent with the pricing page update from #243: "Designers can leave comments on how to improve a score on each other's designs and managers can see all commenting activity across the team"
- In-product UI (dashboard/reviews) is out of scope per ticket — requires a separate decision with Ward

Closes #246

## Test plan

- [ ] Visit `/products` and confirm the Team tier feature list shows the Team Collaboration bullet, no mention of "Team Take" or "peer scoring"

🤖 Generated with [Claude Code](https://claude.com/claude-code)