### PR TITLE
Free upgrade via Stripe in account menu; distinct Team fixtures; fake team names

### DIFF
--- a/src/components/UserMenu.tsx
+++ b/src/components/UserMenu.tsx
@@ -213,19 +213,19 @@ export function UserMenu() {
     email[0] ||
     "?"
   ).toUpperCase();
-  async function handleManageBilling() {
+  // Shared Stripe entry point. Pro uses the customer portal; Free upgrade uses
+  // checkout. Both behave the same: navigate to the returned URL, or surface a
+  // message instead of silently doing nothing. Real config is tracked in #213.
+  async function startBilling(endpoint: string) {
     setPortalLoading(true);
     setPortalMsg(null);
     try {
-      const res = await fetch("/api/stripe/portal", { method: "POST" });
+      const res = await fetch(endpoint, { method: "POST" });
       const data = (await res.json().catch(() => ({}))) as { url?: string };
       if (data.url) {
         window.location.href = data.url;
         return; // navigating away — keep the loading state until unload
       }
-      // No URL: the Stripe portal isn't usable yet (not configured, or this
-      // account has no Stripe customer). Surface that instead of silently
-      // doing nothing. Real config is tracked in #213.
       setPortalMsg(
         res.status === 404 ? "No active subscription" : "Billing not set up yet",
       );
@@ -234,6 +234,19 @@ export function UserMenu() {
     }
     setPortalLoading(false);
   }
+
+  // Right-aligned meta shared by the Free "Upgrade to Pro" and Pro
+  // "Subscription" rows: the green price normally, "Opening…" while a billing
+  // request is in flight, an amber message if it couldn't open.
+  const billingMeta = portalLoading ? (
+    <span className="text-muted text-[10px]">Opening…</span>
+  ) : portalMsg ? (
+    <span className="text-amber-400 text-[10px]">{portalMsg}</span>
+  ) : (
+    <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
+      $1,000/mo
+    </span>
+  );
 
   return (
     <div ref={wrapperRef} className="relative">
@@ -341,33 +354,17 @@ export function UserMenu() {
               <MenuRow
                 icon={ICON.billing}
                 label="Upgrade to Pro"
-                href="/pricing"
-                onClick={() => setOpen(false)}
-                meta={
-                  <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
-                    $1,000/mo
-                  </span>
-                }
+                onClick={() => startBilling("/api/stripe/checkout")}
+                disabled={portalLoading}
+                meta={billingMeta}
               />
             ) : isStripePro ? (
               <MenuRow
                 icon={ICON.billing}
                 label="Subscription"
-                onClick={() => handleManageBilling()}
+                onClick={() => startBilling("/api/stripe/portal")}
                 disabled={portalLoading}
-                meta={
-                  portalLoading ? (
-                    <span className="text-muted text-[10px]">Opening…</span>
-                  ) : portalMsg ? (
-                    <span className="text-amber-400 text-[10px]">
-                      {portalMsg}
-                    </span>
-                  ) : (
-                    <span className="text-ladder-green text-[10px] uppercase tracking-widest font-semibold">
-                      $1,000/mo
-                    </span>
-                  )
-                }
+                meta={billingMeta}
               />
             ) : null}
             <MenuRow

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-06-03
 updatedBy: Sara
-lastPr: 274
+lastPr: 275
 ---
 
 ## How to read this page
@@ -36,7 +36,7 @@ Triggers for the upgrade conversation:
 - User clicks a Pro-only tab (a11y audit, UX copywriting) on a score result.
 - User hits the Pricing page directly.
 
-The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately.
+The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately. Free users can also start the same checkout straight from the account menu's **Upgrade to Pro** row (#275); until Stripe is configured (#213) that row surfaces a "Billing not set up yet" message instead of navigating.
 
 ### Team provisioning (Live, admin-side — v0.5.5, PR #200)
 

--- a/src/lib/dev/dashboard-fixtures.ts
+++ b/src/lib/dev/dashboard-fixtures.ts
@@ -73,6 +73,21 @@ const SEMI_ACTIVE_SCORES = SEMI_ACTIVE_DAYS.map((d, i) => {
   return score(`fx-r${i}`, v, labelFor(v), `Screen ${i + 1}`, d);
 });
 
+// A separate, sparser cadence for the Team preview, so the Team designer's
+// design-rhythm heatmap (active days / sessions) reads differently from Pro's
+// rather than showing identical numbers.
+const TEAM_ACTIVE_DAYS = [
+  2, 3, 7, 7, 10, 14, 17, 21, 22, 28, 33, 35, 35, 40, 44, 47, 52, 56, 56, 61,
+  65, 70, 74, 74, 79, 84, 88,
+];
+
+const TEAM_ACTIVE_SCORES = TEAM_ACTIVE_DAYS.map((d, i) => {
+  const base = 4.0 - (d / 91) * 1.2;
+  const jitter = ((i % 4) - 1.5) * 0.15;
+  const v = Math.max(1.8, Math.min(4.7, Math.round((base + jitter) * 10) / 10));
+  return score(`fx-t${i}`, v, labelFor(v), `Screen ${i + 1}`, d);
+});
+
 /** Account-menu + plan-strip overrides the dashboard derives from Clerk/data. */
 export type ViewAsUserMeta = {
   firstName: string | null;
@@ -113,7 +128,7 @@ export function viewAsUserMeta(s: ViewAsState): ViewAsUserMeta {
   // previewed fixture, so fixtures are never admins.
   const orgName = CLIENT_ORG;
   return {
-    firstName: s.role === "designer" ? "Jordan" : "Chester",
+    firstName: s.role === "designer" ? "Jordan" : "Morgan",
     tier: "team",
     comp: { reason: `Member of ${orgName}`, expiresAt: null },
     internal: false, // banner logic is role-driven; refined later
@@ -165,10 +180,10 @@ export function viewAsDashboardData(s: ViewAsState): DashboardData {
   // Team plan — role drives empty vs populated.
   const isLeadEmpty = s.role === "lead-empty";
   return {
-    scores: isLeadEmpty ? [] : SEMI_ACTIVE_SCORES,
+    scores: isLeadEmpty ? [] : TEAM_ACTIVE_SCORES,
     stats: isLeadEmpty
       ? emptyStats
-      : { ...stats, totalScans: SEMI_ACTIVE_SCORES.length, bestScore: 4.8 },
+      : { ...stats, totalScans: TEAM_ACTIVE_SCORES.length, bestScore: 4.7 },
     usage: { used: isLeadEmpty ? 0 : 1280, limit: 25000 },
     tier: "team",
     paid: true,
@@ -234,7 +249,7 @@ export type ViewAsTeam = {
 
 /** Team Dashboard fixtures keyed on the Team-plan role. */
 export function viewAsTeamData(s: ViewAsState): ViewAsTeam {
-  const lead = teamMember("lead", "Chester", "Schendel", "org:admin", 3.6, 40);
+  const lead = teamMember("lead", "Morgan", "Ellis", "org:admin", 3.6, 40);
   const orgName = "Acme Co.";
 
   if (s.role === "lead-empty") {


### PR DESCRIPTION
## Summary

- **Account menu — Free upgrade:** the Free "Upgrade to Pro" row now starts Stripe checkout (`POST /api/stripe/checkout`), mirroring how the Pro "Subscription" row opens the customer portal. Both go through a shared `startBilling()` helper with shared meta. Until Stripe is configured (#213), the row keeps the menu open and shows the amber "Billing not set up yet" message instead of linking to `/pricing`.
- **Dev fixtures — Team heatmap:** the Team preview uses a separate, sparser cadence (`TEAM_ACTIVE_SCORES`) so the Team designer's design-rhythm heatmap reads differently from Pro instead of showing identical active-days/sessions numbers.
- **Dev fixtures — names:** renamed the example Team Lead to **Morgan Ellis** (and the lead greeting name to Morgan) so no Drawbackwards person appears. The full example roster — Morgan Ellis, Jordan Lee, Sam Rivera, Avery Chen — is now all non-Drawbackwards, to avoid confusion in demos.

## /hq lockstep
- `journeys.mdx`: note the account-menu "Upgrade to Pro" checkout path.

## Verification
- `tsc --noEmit` clean; lint clean.
- Dev fixtures are tree-shaken from prod/preview builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)