### PR TITLE
Admin Free users list + reusable Skeleton system; fixture & tag fixes

### DIFF
--- a/src/app/admin/(tabbed)/clients/page.tsx
+++ b/src/app/admin/(tabbed)/clients/page.tsx
@@ -3,6 +3,30 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
+import { Skeleton } from "@/components/Skeleton";
+
+/**
+ * Skeleton rows that mirror the real table: one shimmer bar per column, in the
+ * same `<td>`s the data lands in, sized to match a one-line row. The table head
+ * and section chrome stay rendered, so real rows replace these in place with no
+ * layout shift (only the row count differs).
+ */
+function TableSkeleton({ cols, rows = 4 }: { cols: number; rows?: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <tr key={r} className="border-b border-[#222] last:border-0">
+          {Array.from({ length: cols }).map((_, c) => (
+            <td key={c} className="p-3">
+              {/* First column a touch wider (email), rest narrower. */}
+              <Skeleton className={`h-3.5 ${c === 0 ? "w-4/5" : "w-1/2"}`} />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
 
 type TeamClient = {
   id: string;
@@ -22,6 +46,14 @@ type ProClient = {
   since: number;
 };
 
+type FreeUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  since: number;
+  lastActiveAt: number | null;
+};
+
 function fmtDate(ms: number | null | undefined) {
   if (!ms) return "—";
   const d = new Date(ms);
@@ -37,6 +69,7 @@ export default function ManageClientsPage() {
   const { isSignedIn } = useAuth();
   const [teamClients, setTeamClients] = useState<TeamClient[]>([]);
   const [proClients, setProClients] = useState<ProClient[]>([]);
+  const [freeUsers, setFreeUsers] = useState<FreeUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [busyOrg, setBusyOrg] = useState<string | null>(null);
@@ -58,6 +91,7 @@ export default function ManageClientsPage() {
       const j = await res.json();
       setTeamClients(j.teamClients || []);
       setProClients(j.proClients || []);
+      setFreeUsers(j.freeUsers || []);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load");
     } finally {
@@ -132,7 +166,7 @@ export default function ManageClientsPage() {
     <>
       <div className="mb-6 flex items-baseline justify-between">
         <p className="text-xs text-muted font-sans">
-          Team orgs (provisioned) and Pro subscribers
+          Team orgs (provisioned), Pro subscribers, and Free users
         </p>
         <div className="flex items-center gap-4">
           <button
@@ -163,7 +197,13 @@ export default function ManageClientsPage() {
             <span className="text-[10px] text-muted uppercase tracking-widest">
               Team clients
             </span>
-            <span className="text-[10px] text-muted">{teamClients.length} total</span>
+            {loading ? (
+              <Skeleton className="h-3 w-12" />
+            ) : (
+              <span className="text-[10px] text-muted">
+                {teamClients.length} total
+              </span>
+            )}
           </div>
 
           <div className="border border-[#333] bg-[#1e1e1e]">
@@ -179,7 +219,9 @@ export default function ManageClientsPage() {
                 </tr>
               </thead>
               <tbody>
-                {teamClients.length === 0 ? (
+                {loading ? (
+                  <TableSkeleton cols={6} />
+                ) : teamClients.length === 0 ? (
                   <tr>
                     <td colSpan={6} className="p-6 text-center text-muted font-sans">
                       No Team clients yet.
@@ -257,12 +299,18 @@ export default function ManageClientsPage() {
         </section>
 
         {/* ── Pro clients (read-only) ───────────────────────────── */}
-        <section>
+        <section className="mb-12">
           <div className="flex items-center justify-between mb-4">
             <span className="text-[10px] text-muted uppercase tracking-widest">
               Pro clients
             </span>
-            <span className="text-[10px] text-muted">{proClients.length} total</span>
+            {loading ? (
+              <Skeleton className="h-3 w-12" />
+            ) : (
+              <span className="text-[10px] text-muted">
+                {proClients.length} total
+              </span>
+            )}
           </div>
 
           <div className="border border-[#333] bg-[#1e1e1e]">
@@ -276,7 +324,9 @@ export default function ManageClientsPage() {
                 </tr>
               </thead>
               <tbody>
-                {proClients.length === 0 ? (
+                {loading ? (
+                  <TableSkeleton cols={4} />
+                ) : proClients.length === 0 ? (
                   <tr>
                     <td colSpan={4} className="p-6 text-center text-muted font-sans">
                       No Pro clients yet.
@@ -294,6 +344,58 @@ export default function ManageClientsPage() {
                         {p.comp ? "Comp" : "Stripe"}
                       </td>
                       <td className="p-3 text-muted">{fmtDate(p.since)}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Free users (read-only) ────────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Free users
+            </span>
+            {loading ? (
+              <Skeleton className="h-3 w-12" />
+            ) : (
+              <span className="text-[10px] text-muted">
+                {freeUsers.length} total
+              </span>
+            )}
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs table-fixed">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3 w-1/4">Email</th>
+                  <th className="text-left p-3">Name</th>
+                  <th className="text-left p-3">Last active</th>
+                  <th className="text-left p-3">Joined</th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <TableSkeleton cols={4} />
+                ) : freeUsers.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="p-6 text-center text-muted font-sans">
+                      No free users yet.
+                    </td>
+                  </tr>
+                ) : (
+                  freeUsers.map((u) => (
+                    <tr
+                      key={u.id}
+                      className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                    >
+                      <td className="p-3 text-foreground truncate">{u.email}</td>
+                      <td className="p-3 text-muted">{u.name || "—"}</td>
+                      <td className="p-3 text-muted">{fmtDate(u.lastActiveAt)}</td>
+                      <td className="p-3 text-muted">{fmtDate(u.since)}</td>
                     </tr>
                   ))
                 )}

--- a/src/app/admin/(tabbed)/layout.tsx
+++ b/src/app/admin/(tabbed)/layout.tsx
@@ -13,13 +13,13 @@ import { TabButton } from "@/components/Tabs";
  * render their own back-link + heading.
  */
 
-const TABS = [
+const TABS: { label: string; href: string; badge?: string }[] = [
   { label: "Clients", href: "/admin/clients" },
-  { label: "Evaluations", href: "/admin/evaluations" },
+  { label: "Evaluations", href: "/admin/evaluations", badge: "Beta" },
   { label: "Feedback", href: "/admin/feedback" },
   { label: "Comps", href: "/admin/comps" },
   { label: "Beta Codes", href: "/admin/beta-codes" },
-] as const;
+];
 
 export default function AdminTabbedLayout({
   children,
@@ -40,6 +40,7 @@ export default function AdminTabbedLayout({
               key={t.href}
               label={t.label}
               href={t.href}
+              badge={t.badge}
               active={pathname.startsWith(t.href)}
             />
           ))}

--- a/src/app/api/admin/clients/route.ts
+++ b/src/app/api/admin/clients/route.ts
@@ -44,6 +44,14 @@ type ProClient = {
   since: number;
 };
 
+type FreeUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  since: number;
+  lastActiveAt: number | null;
+};
+
 export async function GET() {
   if (!(await getAdminEmail())) return unauthorized();
 
@@ -83,25 +91,42 @@ export async function GET() {
   // grows large, back this with a Redis index of pro user ids.
   const userList = await client.users.getUserList({ limit: 500 });
   const proClients: ProClient[] = [];
+  const freeUsers: FreeUser[] = [];
   for (const u of userList.data) {
+    // The hidden provisioning service account isn't a real user — skip it.
+    if (provisioner && u.id === provisioner) continue;
     const meta = u.publicMetadata as Record<string, unknown> | undefined;
-    if ((meta?.tier as Tier | undefined) !== "pro") continue;
-    proClients.push({
+    const tier = meta?.tier as Tier | undefined;
+    if (tier === "pro") {
+      proClients.push({
+        id: u.id,
+        email: u.primaryEmailAddress?.emailAddress ?? "",
+        name: u.fullName || u.firstName || null,
+        comp: meta?.comp === true,
+        since:
+          typeof meta?.compGrantedAt === "number"
+            ? (meta.compGrantedAt as number)
+            : u.createdAt,
+      });
+      continue;
+    }
+    // Team / Pulse members are surfaced via their org above; only Free and
+    // tier-less individual accounts land in the Free users list.
+    if (tier === "team" || tier === "pulse") continue;
+    freeUsers.push({
       id: u.id,
       email: u.primaryEmailAddress?.emailAddress ?? "",
       name: u.fullName || u.firstName || null,
-      comp: meta?.comp === true,
-      since:
-        typeof meta?.compGrantedAt === "number"
-          ? (meta.compGrantedAt as number)
-          : u.createdAt,
+      since: u.createdAt,
+      lastActiveAt: u.lastSignInAt ?? null,
     });
   }
 
   teamClients.sort((a, b) => b.createdAt - a.createdAt);
   proClients.sort((a, b) => b.since - a.since);
+  freeUsers.sort((a, b) => b.since - a.since);
 
-  return NextResponse.json({ teamClients, proClients });
+  return NextResponse.json({ teamClients, proClients, freeUsers });
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/reviews/ReviewsOverview";
 import { TabButton } from "@/components/Tabs";
 import { SectionLabel } from "@/components/SectionLabel";
+import { Skeleton } from "@/components/Skeleton";
 import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import { useViewAs } from "@/lib/dev/view-as";
 import { viewAsTeamData } from "@/lib/dev/dashboard-fixtures";
@@ -657,6 +658,82 @@ function ArchivedMemberRow({
   );
 }
 
+/**
+ * Structure-matching loading state for the members tab. Mirrors the real
+ * layout (Lead: stat row + pool/invite + members; designer: just members) so
+ * content fills into place when the team data arrives, with no reflow. The
+ * page header and tab bar stay rendered above this — only the data-shaped
+ * region is skeletoned.
+ */
+function TeamSkeleton({ isAdmin }: { isAdmin: boolean }) {
+  return (
+    <>
+      {isAdmin && (
+        <>
+          <section className="mb-6">
+            <SectionLabel className="mb-3">Team performance</SectionLabel>
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+              {Array.from({ length: 4 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="border border-[#2a2a2a] bg-[#1a1a1a] p-4"
+                >
+                  <Skeleton className="h-2 w-16 mb-3" />
+                  <Skeleton className="h-7 w-12" />
+                </div>
+              ))}
+            </div>
+          </section>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-10 items-start">
+            <section>
+              <SectionLabel className="mb-3">Team pool</SectionLabel>
+              <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+                <div className="flex items-baseline justify-between gap-3 mb-4">
+                  <Skeleton className="h-3 w-40" />
+                  <Skeleton className="h-3 w-16" />
+                </div>
+                <Skeleton className="h-1.5 w-full" />
+                <Skeleton className="h-2 w-24 mt-2" />
+              </div>
+            </section>
+            <section>
+              <SectionLabel className="mb-3">Invite a designer</SectionLabel>
+              <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-4">
+                <Skeleton className="h-9 w-full" />
+              </div>
+            </section>
+          </div>
+        </>
+      )}
+
+      <section className="mb-10">
+        <div className="flex items-baseline justify-between mb-3">
+          <SectionLabel>Members</SectionLabel>
+          <Skeleton className="h-3 w-44" />
+        </div>
+        <div className="border border-[#2a2a2a] bg-[#1a1a1a]">
+          <ul aria-hidden="true">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <li
+                key={i}
+                className="border-b border-[#222] last:border-0 p-4 flex items-center gap-4"
+              >
+                <div className="flex-1 min-w-0 space-y-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-56" />
+                </div>
+                <Skeleton className="h-8 w-10" />
+                <Skeleton className="h-8 w-10" />
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </>
+  );
+}
+
 export default function TeamPage() {
   const { isSignedIn, isLoaded } = useAuth();
   const { isLoaded: orgListLoaded, userMemberships } = useOrganizationList({
@@ -896,9 +973,15 @@ export default function TeamPage() {
               {orgName}
             </h1>
             <p className="text-xs text-muted font-sans mt-1">
-              {memberList.length} member{memberList.length !== 1 ? "s" : ""}
-              {inviteList.length > 0 &&
-                ` · ${inviteList.length} pending invite${inviteList.length !== 1 ? "s" : ""}`}
+              {teamLoadingEff && memberList.length === 0 ? (
+                <Skeleton className="h-3 w-32 inline-block align-middle" />
+              ) : (
+                <>
+                  {memberList.length} member{memberList.length !== 1 ? "s" : ""}
+                  {inviteList.length > 0 &&
+                    ` · ${inviteList.length} pending invite${inviteList.length !== 1 ? "s" : ""}`}
+                </>
+              )}
             </p>
           </div>
           <Link
@@ -952,8 +1035,11 @@ export default function TeamPage() {
           ))}
 
         {/* Members tab — default view for everyone. */}
-        {teamTab === "members" && (
-          <>
+        {teamTab === "members" &&
+          (teamLoadingEff && memberList.length === 0 ? (
+            <TeamSkeleton isAdmin={isAdmin} />
+          ) : (
+            <>
         {isAdmin && teamDataEff?.insights && (
           <InsightsPanel insights={teamDataEff.insights} />
         )}
@@ -1090,8 +1176,8 @@ export default function TeamPage() {
             </div>
           </section>
         )}
-          </>
-        )}
+            </>
+          ))}
       </div>
     </div>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -153,17 +153,30 @@ h1, h2, h3, h4, h5, h6 {
 .animate-fade-up-delay-3 { animation-delay: 0.3s; opacity: 0; }
 .animate-fade-up-delay-4 { animation-delay: 0.4s; opacity: 0; }
 
-/* Shimmer loading for skeleton cards */
+/* Skeleton loading effect — single control point for every `.shimmer` / <Skeleton>.
+   CURRENT: subtle opacity pulse (matches Tailwind's `animate-pulse`).
+   To revert to the directional gradient sweep, restore the commented block below. */
+@keyframes shimmer {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}
+
+.shimmer {
+  background: #222;
+  animation: shimmer 1.5s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+}
+
+/* Previous gradient sweep (kept for easy comparison):
 @keyframes shimmer {
   0% { background-position: 200% 0; }
   100% { background-position: -200% 0; }
 }
-
 .shimmer {
   background: linear-gradient(90deg, #222 25%, #2a2a2a 50%, #222 75%);
   background-size: 200% 100%;
   animation: shimmer 1.4s ease-in-out infinite;
 }
+*/
 
 /* ── Clerk auth component overrides ── */
 /* Clerk uses inline styles that require !important to override. */

--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,33 @@
+/**
+ * Reusable loading skeleton — a shimmering placeholder block.
+ *
+ * Pass Tailwind sizing/shape classes via `className` (e.g. "h-4 w-32"). The
+ * animation and base color come from the `.shimmer` utility in globals.css, so
+ * this component is the single place to evolve skeleton styling app-wide.
+ * Prefer this over hand-rolling `<div className="shimmer …" />`.
+ */
+export function Skeleton({ className = "" }: { className?: string }) {
+  return <div className={`shimmer ${className}`} aria-hidden="true" />;
+}
+
+/**
+ * N stacked skeleton lines, for list/card loading states. `rowClassName` sets
+ * each line's height/shape; `className` sets the wrapper (gap, etc.).
+ */
+export function SkeletonRows({
+  rows = 3,
+  rowClassName = "h-16",
+  className = "space-y-1.5",
+}: {
+  rows?: number;
+  rowClassName?: string;
+  className?: string;
+}) {
+  return (
+    <div className={className} aria-hidden="true">
+      {Array.from({ length: rows }).map((_, i) => (
+        <Skeleton key={i} className={rowClassName} />
+      ))}
+    </div>
+  );
+}

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-03
+updatedAt: 2026-06-04
 updatedBy: Sara
-lastPr: 273
+lastPr: 276
 ---
 
 ## How to read this page
@@ -134,7 +134,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Plugin backend proxy (`pluginFetch`) | Admin | Live | `src/lib/admin.ts` |
 | Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Live | `src/lib/admin.ts`, hardcoded, passphrase-gated |
 | Webhook handler for Clerk org join | Auto | Live (v0.3.0) | `src/app/api/webhooks/clerk/route.ts` |
-| Manage Clients page (Team orgs + Pro list) | Admin | Live (v0.5.5) | `src/app/admin/clients/page.tsx`, [#200](https://github.com/drawbackwards/runladder/pull/200) |
+| Manage Clients page (Team orgs + Pro list + Free users list) | Admin | Live (v0.5.5) | `src/app/admin/clients/page.tsx`, [#200](https://github.com/drawbackwards/runladder/pull/200), Free users list [#276](https://github.com/drawbackwards/runladder/pull/276) |
 | Provision Team org + invite Team Lead as `org:admin` | Admin | Live (v0.5.5) | `src/app/api/admin/clients/route.ts` |
 | Org lifecycle: suspend / reactivate / delete (type-to-confirm) | Admin | Live (v0.5.5) | `src/app/api/admin/clients/[orgId]/route.ts` |
 | Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |

--- a/src/lib/dev/dashboard-fixtures.ts
+++ b/src/lib/dev/dashboard-fixtures.ts
@@ -1,6 +1,7 @@
 import type { DashboardData } from "@/app/dashboard/page";
 import type { TeamData } from "@/app/dashboard/team/page";
 import type { UsageData } from "@/components/UsageMeter";
+import type { DailyActivity } from "@/components/ActivityHeatmap";
 import type { Tier } from "@/lib/plans";
 import type { ViewAsState } from "@/lib/dev/view-as";
 
@@ -128,7 +129,7 @@ export function viewAsUserMeta(s: ViewAsState): ViewAsUserMeta {
   // previewed fixture, so fixtures are never admins.
   const orgName = CLIENT_ORG;
   return {
-    firstName: s.role === "designer" ? "Jordan" : "Morgan",
+    firstName: s.role === "designer" ? "Priya" : "Morgan",
     tier: "team",
     comp: { reason: `Member of ${orgName}`, expiresAt: null },
     internal: false, // banner logic is role-driven; refined later
@@ -195,6 +196,34 @@ export function viewAsDashboardData(s: ViewAsState): DashboardData {
 
 /* ── Team Dashboard fixtures ─────────────────────────────────────────────── */
 
+// Deterministic per-member activity for the last 91 days, so the team member
+// rows render their design-rhythm heatmap in dev the way prod does (the real
+// API returns this; the fixtures previously left it empty, which hid the bar).
+function genActivity(seed: number): DailyActivity[] {
+  let s = (seed * 9301 + 49297) % 233280;
+  const rnd = () => {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  };
+  const today = new Date();
+  const todayUTC = Date.UTC(
+    today.getUTCFullYear(),
+    today.getUTCMonth(),
+    today.getUTCDate(),
+  );
+  const out: DailyActivity[] = [];
+  for (let i = 90; i >= 0; i--) {
+    const active = rnd() < 0.4;
+    const count = active ? 1 + Math.floor(rnd() * 3) : 0;
+    out.push({
+      date: new Date(todayUTC - i * DAY).toISOString().slice(0, 10),
+      count,
+      avgScore: count > 0 ? Math.round((3 + rnd() * 1.5) * 10) / 10 : null,
+    });
+  }
+  return out;
+}
+
 function teamMember(
   id: string,
   first: string,
@@ -221,7 +250,7 @@ function teamMember(
     },
     recentScans: Math.max(1, Math.round(scans / 3)),
     monthlyScans: scans,
-    activity: [],
+    activity: genActivity(scans),
     evaluationsInWindow: 2,
   };
 }
@@ -268,7 +297,7 @@ export function viewAsTeamData(s: ViewAsState): ViewAsTeam {
   }
 
   const designers = [
-    teamMember("d1", "Jordan", "Lee", "org:member", 3.2, 28),
+    teamMember("d1", "Priya", "Nair", "org:member", 3.2, 28),
     teamMember("d2", "Sam", "Rivera", "org:member", 2.9, 19),
     teamMember("d3", "Avery", "Chen", "org:member", 3.8, 33),
   ];


### PR DESCRIPTION
## Summary

Dashboard/admin polish ahead of Friday's internal review. All tsc/lint clean.

### Admin
- **Clients screen → new "Free users" section** (read-only): Email, Name, Last active, Joined (column order matches the Pro table). Sourced by extending `/api/admin/clients` with a `freeUsers` list — Free/tier-less Clerk users, excluding Team/Pulse members and the hidden provisioning account.
- **Evaluations tab** now carries a **Beta** tag (via `TabButton`'s new `badge` prop).

### Loading states / Skeleton system
- New reusable **`<Skeleton>` / `<SkeletonRows>`** primitive (`src/components/Skeleton.tsx`) — the single place to evolve skeleton styling.
- **Structure-matching skeletons** on the Clients tables and the Team members tab (`TeamSkeleton` mirrors the Lead layout): chrome stays rendered, only data-shaped slots shimmer, so content fills into place with no layout shift.
- Skeleton effect switched from a gradient sweep to a **subtle opacity pulse (1.5s)** — changed once in the `.shimmer` definition so every skeleton updates together (old gradient kept commented for easy revert).

### Dev fixtures (tree-shaken from prod)
- Team member rows generate per-member activity, so their heatmaps render in preview like prod (were empty → bar hidden).
- Renamed example designer to **Priya Nair** (Jordan is a Drawbackwards teammate); example roster is now fully non-DB.

## /hq lockstep
- `features.mdx`: Manage Clients row now notes the Free users list.

## Verification
- `tsc --noEmit` clean; lint clean (one pre-existing `react-hooks/purity` warning, untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)