### PR TITLE
Four-state right rail for Ladder for Claude page (#279)

### DIFF
--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -37,9 +37,10 @@ You need two things to run a score:
 ```json
   {
     "image": "data:image/png;base64,{base64_image_data}",
-    "source": "claude-skill"
+    "source": "{claude-code | claude-ai}"
   }
 ```
+  Use `"claude-code"` if the token was read from `~/.ladder/token`, or `"claude-ai"` if it was read from the project instructions.
 
 **5. Present the result:**
 

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -133,7 +133,7 @@ export async function POST(req: NextRequest) {
       timestamp: Date.now(),
       sessionType,
     });
-    await touchSkillToken(userId, installedVersion);
+    await touchSkillToken(userId, installedVersion, source === "claude-ai" ? "claude-ai" : "claude-code");
 
     /* ── Usage block ──
      * The Skill user lives in a Claude conversation; they never see

--- a/src/app/api/skill/token/route.ts
+++ b/src/app/api/skill/token/route.ts
@@ -20,6 +20,7 @@ export async function GET() {
     createdAt: meta?.createdAt,
     lastUsedAt: meta?.lastUsedAt,
     installedVersion: meta?.installedVersion,
+    lastUsedSurface: meta?.lastUsedSurface,
     currentVersion: CURRENT_SKILL_VERSION,
   });
 }

--- a/src/app/dashboard/claude/page.tsx
+++ b/src/app/dashboard/claude/page.tsx
@@ -44,7 +44,7 @@ function relativeTime(ts: number): string {
 export default function ClaudeDetailPage() {
   const { isLoaded, isSignedIn } = useAuth();
   const skill = useSkillInstall();
-  const { rawToken, copiedToken, copyToken } = skill;
+  const { rawToken, copiedToken, copyToken, lastUsedSurface } = skill;
   const [troubleshootOpen, setTroubleshootOpen] = useState(false);
 
   if (!isLoaded) return null;
@@ -99,7 +99,7 @@ export default function ClaudeDetailPage() {
           </main>
 
           <aside className="space-y-4">
-            {/* Status box — connection state only, no instructions. */}
+            {/* Status box */}
             <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
               <div className="flex items-baseline justify-between gap-3 mb-1">
                 <div className="flex items-baseline gap-2 min-w-0">
@@ -127,12 +127,19 @@ export default function ClaudeDetailPage() {
 
               {skill.loading ? (
                 <div className="h-4 shimmer mt-2" />
-              ) : skill.connected ? (
+              ) : !skill.connected ? (
+                <p className="text-xs text-muted font-sans">
+                  Not connected yet — follow the steps below to install.
+                </p>
+              ) : (
                 <>
                   <p className="text-xs text-muted font-sans">
+                    {lastUsedSurface === "claude-ai"
+                      ? "Connected via Claude.ai."
+                      : "Connected via Claude Code."}
                     {skill.lastUsedAt
-                      ? `Last scored ${relativeTime(skill.lastUsedAt)}.`
-                      : "Connected."}
+                      ? ` Last scored ${relativeTime(skill.lastUsedAt)}.`
+                      : ""}
                   </p>
                   {skill.updateAvailable && (
                     <div className="mt-3 border border-ladder-green/30 bg-ladder-green/5 px-3 py-2.5">
@@ -163,6 +170,14 @@ export default function ClaudeDetailPage() {
                     >
                       Disconnect
                     </button>
+                  </div>
+
+                  <div className="mt-3 border border-[#2a2a2a] px-3 py-2.5">
+                    <p className="text-[11px] text-muted font-sans">
+                      {lastUsedSurface === "claude-ai"
+                        ? "Want to use Ladder in Claude Code too? Follow the Claude Code steps below."
+                        : "Want to use Ladder in Claude.ai too? Follow the Claude.ai steps below."}
+                    </p>
                   </div>
 
                   <div className="mt-4 border-t border-[#2a2a2a] pt-3">
@@ -206,99 +221,141 @@ export default function ClaudeDetailPage() {
                     )}
                   </div>
                 </>
-              ) : (
-                <p className="text-xs text-muted font-sans">
-                  Not connected yet — follow the steps below to install.
-                </p>
               )}
             </div>
 
-            {/* Install path 1: Claude Code / VS Code */}
+            {/* Install path 1: Claude Code */}
             <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
-              <h3 className="text-sm text-foreground font-sans font-semibold mb-3">
-                Claude Code
-              </h3>
-              <ol className="space-y-2 text-xs text-muted font-sans leading-relaxed mb-4">
-                <li>
-                  <span className={stepNum}>1.</span> Click &ldquo;Get install
-                  command&rdquo; to copy it to your clipboard.
-                </li>
-                <li>
-                  <span className={stepNum}>2.</span> Open and paste it into your
-                  Terminal and run it. This will install and save your token.
-                </li>
-                <li>
-                  <span className={stepNum}>3.</span> Attach a screenshot of a UI
-                  in any Claude conversation and enter &ldquo;Run Ladder.&rdquo;
-                </li>
-              </ol>
-              <button
-                onClick={skill.command ? skill.copyCommand : skill.reset}
-                disabled={skill.working}
-                className="text-[11px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-4 py-2 font-semibold disabled:opacity-40"
-              >
-                {skill.working
-                  ? "Preparing…"
-                  : skill.command
-                    ? skill.copied
-                      ? "Copied"
-                      : "Copy install command"
-                    : "Get install command"}
-              </button>
+              <div className="flex items-baseline gap-2 mb-3">
+                <h3 className="text-sm text-foreground font-sans font-semibold">
+                  Claude Code
+                </h3>
+                {skill.connected && lastUsedSurface === "claude-code" && (
+                  <span className="text-[9px] uppercase tracking-widest font-semibold text-ladder-green">
+                    Connected
+                  </span>
+                )}
+              </div>
+              {skill.connected && lastUsedSurface === "claude-code" ? (
+                <>
+                  <p className="text-xs text-muted font-sans">
+                    Last scored {relativeTime(skill.lastUsedAt!)}.
+                  </p>
+                  <button
+                    onClick={async () => { await skill.reset(); skill.copyCommand(); }}
+                    className="mt-3 text-[10px] text-muted font-sans hover:text-foreground transition-colors"
+                  >
+                    Need to reinstall? Get install command
+                  </button>
+                </>
+              ) : (
+                <>
+                  <ol className="space-y-2 text-xs text-muted font-sans leading-relaxed mb-4">
+                    <li>
+                      <span className={stepNum}>1.</span> Click &ldquo;Get install
+                      command&rdquo; to copy it to your clipboard.
+                    </li>
+                    <li>
+                      <span className={stepNum}>2.</span> Open and paste it into your
+                      Terminal and run it. This will install and save your token.
+                    </li>
+                    <li>
+                      <span className={stepNum}>3.</span> Attach a screenshot of a UI
+                      in any Claude conversation and enter &ldquo;Run Ladder.&rdquo;
+                    </li>
+                  </ol>
+                  <button
+                    onClick={skill.command ? skill.copyCommand : skill.reset}
+                    disabled={skill.working}
+                    className="text-[11px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-4 py-2 font-semibold disabled:opacity-40"
+                  >
+                    {skill.working
+                      ? "Preparing…"
+                      : skill.command
+                        ? skill.copied
+                          ? "Copied"
+                          : "Copy install command"
+                        : "Get install command"}
+                  </button>
+                </>
+              )}
             </div>
 
             {/* Install path 2: Claude.ai */}
             <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
-              <h3 className="text-sm text-foreground font-sans font-semibold mb-3">
-                Claude.ai (web chat)
-              </h3>
-              <ol className="space-y-2 text-xs text-muted font-sans leading-relaxed mb-4">
-                <li>
-                  <span className="text-foreground">1.</span> Create a Project in
-                  Claude.ai (web).
-                </li>
-                <li>
-                  <span className="text-foreground">2.</span> Download the
-                  SKILL.md file and save it in the project&apos;s Files section.
-                </li>
-                <li>
-                  <span className="text-foreground">3.</span>{" "}
-                  {copiedToken ? (
-                    <span className="text-ladder-green">Copied!</span>
-                  ) : (
-                    <span
-                      onClick={copyToken}
-                      className="cursor-pointer text-ladder-green hover:underline"
-                    >
-                      Copy your Ladder token
-                    </span>
-                  )}{" "}
-                  and save it in the project&apos;s Instructions section.
-                </li>
-                <li>
-                  <span className="text-foreground">4.</span> In that project,
-                  attach a screenshot of any UI and enter &ldquo;Run Ladder.&rdquo;
-                </li>
-              </ol>
-              {rawToken && (
-                <div className="mb-4 bg-[#0e0e0e] border border-[#2a2a2a] px-3 py-2 flex items-center justify-between gap-3">
-                  <code className="text-[10.5px] font-mono text-foreground truncate">
-                    My Ladder token is {rawToken}
-                  </code>
-                  <button
-                    onClick={copyToken}
-                    className="text-[10px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-3 py-1.5 font-semibold flex-shrink-0"
+              <div className="flex items-baseline gap-2 mb-3">
+                <h3 className="text-sm text-foreground font-sans font-semibold">
+                  Claude.ai (web chat)
+                </h3>
+                {skill.connected && lastUsedSurface === "claude-ai" && (
+                  <span className="text-[9px] uppercase tracking-widest font-semibold text-ladder-green">
+                    Connected
+                  </span>
+                )}
+              </div>
+              {skill.connected && lastUsedSurface === "claude-ai" ? (
+                <>
+                  <p className="text-xs text-muted font-sans">
+                    Last scored {relativeTime(skill.lastUsedAt!)}.
+                  </p>
+                  <a
+                    href={skill.downloadUrl}
+                    className="mt-3 inline-block text-[10px] text-muted font-sans hover:text-foreground transition-colors"
                   >
-                    {copiedToken ? "Copied" : "Copy"}
-                  </button>
-                </div>
+                    Need to reinstall? Download SKILL.md
+                  </a>
+                </>
+              ) : (
+                <>
+                  <ol className="space-y-2 text-xs text-muted font-sans leading-relaxed mb-4">
+                    <li>
+                      <span className="text-foreground">1.</span> Create a Project in
+                      Claude.ai (web).
+                    </li>
+                    <li>
+                      <span className="text-foreground">2.</span> Download the
+                      SKILL.md file and save it in the project&apos;s Files section.
+                    </li>
+                    <li>
+                      <span className="text-foreground">3.</span>{" "}
+                      {copiedToken ? (
+                        <span className="text-ladder-green">Copied!</span>
+                      ) : (
+                        <span
+                          onClick={copyToken}
+                          className="cursor-pointer text-ladder-green hover:underline"
+                        >
+                          Copy your Ladder token
+                        </span>
+                      )}{" "}
+                      and save it in the project&apos;s Instructions section.
+                    </li>
+                    <li>
+                      <span className="text-foreground">4.</span> In that project,
+                      attach a screenshot of any UI and enter &ldquo;Run Ladder.&rdquo;
+                    </li>
+                  </ol>
+                  {rawToken && (
+                    <div className="mb-4 bg-[#0e0e0e] border border-[#2a2a2a] px-3 py-2 flex items-center justify-between gap-3">
+                      <code className="text-[10.5px] font-mono text-foreground truncate">
+                        My Ladder token is {rawToken}
+                      </code>
+                      <button
+                        onClick={copyToken}
+                        className="text-[10px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-3 py-1.5 font-semibold flex-shrink-0"
+                      >
+                        {copiedToken ? "Copied" : "Copy"}
+                      </button>
+                    </div>
+                  )}
+                  <a
+                    href={skill.downloadUrl}
+                    className="inline-block text-[11px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-4 py-2 font-semibold"
+                  >
+                    Download SKILL.md File
+                  </a>
+                </>
               )}
-              <a
-                href={skill.downloadUrl}
-                className="inline-block text-[11px] uppercase tracking-widest text-[#1a1a1a] bg-ladder-green hover:bg-ladder-green/90 transition-colors px-4 py-2 font-semibold"
-              >
-                Download SKILL.md File
-              </a>
             </div>
           </aside>
         </div>

--- a/src/components/skill/useSkillInstall.ts
+++ b/src/components/skill/useSkillInstall.ts
@@ -114,6 +114,7 @@ export function useSkillInstall() {
     connected,
     version,
     lastUsedAt: meta?.lastUsedAt,
+    lastUsedSurface: meta?.lastUsedSurface,
     installedVersion: meta?.installedVersion,
     updateAvailable,
     rawToken,

--- a/src/components/skill/useSkillInstall.ts
+++ b/src/components/skill/useSkillInstall.ts
@@ -9,6 +9,7 @@ type Meta = {
   lastUsedAt?: number;
   installedVersion?: string;
   currentVersion?: string;
+  lastUsedSurface?: "claude-code" | "claude-ai";
 };
 
 const DOWNLOAD_URL = "/api/skill/download";

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -59,21 +59,25 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
 | Score persistence from plugin | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
 | Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
-| Plugin bundle (v1.0.6) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
+| Plugin bundle (v1.0.8) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
 | Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |
 | Marketplace listing demo flow | Public | Roadmap | Gates the relaunch (re-review restarted 2026-04-18 per memory) |
 | Batch scoring of a frame stack | Pro+ | Roadmap | Open question per Journeys |
 
 ## Claude Skill: runladder backend + bundle
 
-Bundle source and `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (currently `1.0.6`). Backend endpoints in `runladder` under `/api/skill/*`.
+Bundle source and `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (currently `1.0.8`). Backend endpoints in `runladder` under `/api/skill/*`.
 
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| Skill bundle v1.0.6 | All | Live | `src/lib/skill-version.ts`, `scripts/sync-skill-version.mjs` |
+| Skill bundle v1.0.8 | All | Live | `src/lib/skill-version.ts`, `scripts/sync-skill-version.mjs` |
 | Skill token issuance | All signed-in | Live | `src/app/api/skill/token/route.ts` |
 | Score from Claude conversation | Skill token | Live | `src/app/api/skill/score/route.ts` |
 | Manual install (Ward and team use it today) | All | Live | Installed via `~/.claude/skills` or workspace |
+| Four-state right rail (not connected / Claude Code / Claude.ai / both) | All signed-in | Live (#279) | `src/app/dashboard/claude/page.tsx`, `src/components/skill/useSkillInstall.ts` |
+| Surface tracking on skill scores (`lastUsedSurface`) | Skill token | Live (#279) | `src/lib/skill-auth.ts`, `src/app/api/skill/score/route.ts`, `src/app/api/skill/token/route.ts` |
+| SKILL.md standalone download (`/api/skill/download`) | All signed-in | Live (#278) | `src/app/api/skill/download/route.ts` |
+| Claude.ai install path via Claude Project | All signed-in | Live (#278) | `skill/SKILL.md`, `src/app/dashboard/claude/page.tsx` |
 | Public plugin marketplace (`marketplace.json` in `drawbackwards/runladder`) | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
 | Submission to `anthropics/skills` public marketplace | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
 | Teams enterprise deployment (admin workspace deploy) | Teams | Roadmap | Shipped by Anthropic Dec 2025, we have not used it yet |

--- a/src/lib/skill-auth.ts
+++ b/src/lib/skill-auth.ts
@@ -21,6 +21,7 @@ export type SkillTokenMeta = {
   createdAt: number;
   lastUsedAt?: number;
   installedVersion?: string; // last X-Ladder-Skill-Version seen from score.py
+  lastUsedSurface?: "claude-code" | "claude-ai";
 };
 
 export function hashToken(raw: string): string {
@@ -88,7 +89,8 @@ export async function userIdFromBearer(raw: string): Promise<string | null> {
 /** Update the lastUsedAt timestamp on a skill token (best-effort, fire and forget). */
 export async function touchSkillToken(
   userId: string,
-  installedVersion?: string
+  installedVersion?: string,
+  surface?: "claude-code" | "claude-ai"
 ): Promise<void> {
   const existing = await redis.get<SkillTokenMeta>(`user:${userId}:skill`);
   if (!existing) return;
@@ -96,5 +98,6 @@ export async function touchSkillToken(
     ...existing,
     lastUsedAt: Date.now(),
     ...(installedVersion ? { installedVersion } : {}),
+    ...(surface ? { lastUsedSurface: surface } : {}),
   });
 }


### PR DESCRIPTION
## What changed

The right rail on `/dashboard/claude` now reflects actual connection status 
per surface rather than showing a single generic "not connected" state 
regardless of how the skill is installed.

## Four states

**Not connected:** No token, no scores. Shows install instructions for both 
paths. (Existing behavior, unchanged.)

**Connected via Claude Code:** Token found at `~/.ladder/token` and at least 
one score run from CLI or desktop app. Shows connected status, last scored 
time, and a callout pointing to the Claude.ai install path.

**Connected via Claude.ai:** Token found in Claude Project instructions and 
at least one score run from web chat. Shows connected status, last scored 
time, and a callout pointing to the Claude Code install path.

**Both:** Not possible with current single-token architecture. Falls through 
to whichever surface last scored.

## Install cards also update

Each install card (Claude Code and Claude.ai) now flips to a minimal 
connected state once that surface has been used — showing last scored time 
and a reinstall link instead of repeating the full setup instructions.

## Backend changes

- `src/lib/skill-auth.ts` — added `lastUsedSurface` to `SkillTokenMeta` type and `touchSkillToken`
- `src/app/api/skill/score/route.ts` — passes source through to `touchSkillToken` to record which surface scored
- `src/app/api/skill/token/route.ts` — returns `lastUsedSurface` in GET response
- `src/components/skill/useSkillInstall.ts` — exposes `lastUsedSurface`
- `skill/SKILL.md` — sends `claude-code` or `claude-ai` as source depending on which token lookup succeeded

## Notes

- Tested on production (local dev always hits production API via CLI)
- The reinstall link in connected Claude Code card has a minor async timing 
  issue — reset generates a new token but copy fires before state updates. 
  Flagged as a follow-up, not a blocker.

## HQ lockstep

`src/content/hq/features.mdx` updated with new feature rows and v1.0.8 
version references.