### PR TITLE
Fix copy token flow and right rail polish (#279)

### DIFF
--- a/src/app/dashboard/claude/page.tsx
+++ b/src/app/dashboard/claude/page.tsx
@@ -318,16 +318,12 @@ export default function ClaudeDetailPage() {
                     </li>
                     <li>
                       <span className="text-foreground">3.</span>{" "}
-                      {copiedToken ? (
-                        <span className="text-ladder-green">Copied!</span>
-                      ) : (
-                        <span
-                          onClick={copyToken}
-                          className="cursor-pointer text-ladder-green hover:underline"
-                        >
-                          Copy your Ladder token
-                        </span>
-                      )}{" "}
+                      <span
+                        onClick={copyToken}
+                        className="cursor-pointer text-ladder-green hover:underline"
+                      >
+                        {skill.tokenCopyLabel}
+                      </span>{" "}
                       and save it in the project&apos;s Instructions section.
                     </li>
                     <li>

--- a/src/components/skill/useSkillInstall.ts
+++ b/src/components/skill/useSkillInstall.ts
@@ -102,12 +102,21 @@ export function useSkillInstall() {
     setTimeout(() => setCopied(false), 2000);
   }
 
-  function copyToken() {
-    if (!rawToken) return;
+  async function copyToken() {
+    if (!rawToken) {
+      await generate();
+      return;
+    }
     navigator.clipboard.writeText(`My Ladder token is ${rawToken}`);
     setCopiedToken(true);
     setTimeout(() => setCopiedToken(false), 2000);
   }
+
+  const tokenCopyLabel = copiedToken
+    ? "Copied!"
+    : rawToken
+      ? "Copy your Ladder token"
+      : "Generate and copy token";
 
   return {
     loading,
@@ -124,6 +133,7 @@ export function useSkillInstall() {
     copyCommand,
     copiedToken,
     copyToken,
+    tokenCopyLabel,
     downloadUrl: DOWNLOAD_URL,
     reset: generate,
     disconnect,

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -78,6 +78,7 @@ Bundle source and `CURRENT_SKILL_VERSION` in `src/lib/skill-version.ts` (current
 | Surface tracking on skill scores (`lastUsedSurface`) | Skill token | Live (#279) | `src/lib/skill-auth.ts`, `src/app/api/skill/score/route.ts`, `src/app/api/skill/token/route.ts` |
 | SKILL.md standalone download (`/api/skill/download`) | All signed-in | Live (#278) | `src/app/api/skill/download/route.ts` |
 | Claude.ai install path via Claude Project | All signed-in | Live (#278) | `skill/SKILL.md`, `src/app/dashboard/claude/page.tsx` |
+| Copy Ladder token — generates fresh token if null, then copies to clipboard | All signed-in | Live (#279) | `src/components/skill/useSkillInstall.ts`, `src/app/dashboard/claude/page.tsx` |
 | Public plugin marketplace (`marketplace.json` in `drawbackwards/runladder`) | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
 | Submission to `anthropics/skills` public marketplace | Public | Roadmap | See [Roadmap → Skill distribution](/hq/roadmap#skill-distribution-roadmap) |
 | Teams enterprise deployment (admin workspace deploy) | Teams | Roadmap | Shipped by Anthropic Dec 2025, we have not used it yet |


### PR DESCRIPTION
## What changed

Two fixes on top of the four-state right rail work:

1. **Copy token now works in connected state.** Previously, clicking "Copy 
your Ladder token" did nothing when the user was already connected because 
`rawToken` was null. The flow now generates a fresh token first if needed, 
then copies on the second click. Label updates through three states: 
"Generate and copy token" → "Copy your Ladder token" → "Copied!"

2. **Claude.ai card uses `tokenCopyLabel`** from the hook instead of 
inline ternary logic, keeping the display state handling in one place.

## Changes

- `src/components/skill/useSkillInstall.ts` — `copyToken` calls `generate()` 
  if `rawToken` is null; adds `tokenCopyLabel` helper for all three display states
- `src/app/dashboard/claude/page.tsx` — Claude.ai card uses `skill.tokenCopyLabel`

## HQ lockstep

`src/content/hq/features.mdx` updated with new row for copy token fix.

## Testing

After merge, verify on production:
1. Go to `/dashboard/claude` in connected state
2. Click "Copy your Ladder token" — should show "Generate and copy token" first click, "Copy your Ladder token" second, "Copied!" on copy
3. Paste into Claude Project instructions and run a score to flip Claude.ai card to connected