### PR TITLE
Structure-matching loading skeletons (dashboard + sidebar + member detail) + full-width member heatmap

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -8,12 +8,13 @@ import { getScoreColor } from "@/lib/ladder";
 import { FigmaPromoCard } from "@/components/promos/FigmaPromoCard";
 import { ClaudePromoCard } from "@/components/promos/ClaudePromoCard";
 import { UsageMeter } from "@/components/UsageMeter";
-import { TeamCard } from "@/components/TeamCard";
+import { TeamCard, TeamCardSkeleton } from "@/components/TeamCard";
 import { TeamSetupBanner } from "@/components/TeamSetupBanner";
 import { ManageSubscriptionButton } from "@/components/ManageSubscriptionButton";
 import { ActivityHeatmap, type DailyActivity } from "@/components/ActivityHeatmap";
 import { FREE_LIFETIME_LIMIT } from "@/lib/plans";
 import { SectionLabel } from "@/components/SectionLabel";
+import { Skeleton } from "@/components/Skeleton";
 import { useViewAs } from "@/lib/dev/view-as";
 import {
   viewAsDashboardData,
@@ -438,6 +439,43 @@ function DesignRhythmCard({ scores }: { scores: ScoreEntry[] }) {
   );
 }
 
+/**
+ * Loading placeholder for the Design rhythm card. Same eyebrow + box + 3-column
+ * layout (Active days / Sessions / chart) and the same chart height (7 rows ×
+ * 10px + 6 gaps × 3px = 88px) so the real card fills in without a jump.
+ */
+function DesignRhythmSkeleton() {
+  return (
+    <div className="mb-6">
+      <div className="flex items-baseline justify-between mb-3 gap-3 flex-wrap">
+        <SectionLabel>Design rhythm</SectionLabel>
+        <span className="text-[10px] text-muted">
+          Design sessions, last {RHYTHM_WINDOW_DAYS} days
+        </span>
+      </div>
+      <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+        <div className="grid grid-cols-[1fr_1fr_8fr] gap-4 items-center">
+          <div>
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Active days
+            </p>
+            <Skeleton className="h-7 w-10" />
+          </div>
+          <div>
+            <p className="text-[9px] text-muted uppercase tracking-widest mb-2">
+              Sessions
+            </p>
+            <Skeleton className="h-7 w-10" />
+          </div>
+          <div className="min-w-0">
+            <Skeleton className="h-[88px] w-full" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { isSignedIn, isLoaded } = useAuth();
   const { user } = useUser();
@@ -541,19 +579,40 @@ export default function DashboardPage() {
             <RequestReviewCTA /> here (gated on tier team/pulse) once Reviews
             ships. */}
 
-        <DesignRhythmCard scores={scores} />
+        {showLoading ? (
+          <DesignRhythmSkeleton />
+        ) : (
+          <DesignRhythmCard scores={scores} />
+        )}
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-8 items-start">
           <main>
             {showLoading ? (
-              <div className="space-y-1.5">
-                {[...Array(3)].map((_, i) => (
-                  <div
-                    key={i}
-                    className="border border-[#2a2a2a] bg-[#1a1a1a] shimmer h-16"
-                  />
-                ))}
-              </div>
+              // Mirror the loaded layout (CTA + Score history rows) so content
+              // fills into place without a jump. The score-a-screen CTA is a
+              // static link, so it renders for real.
+              <>
+                <ScoreCTACard />
+                <div className="mt-6 mb-3 flex items-center justify-between">
+                  <SectionLabel>Score history</SectionLabel>
+                  <Skeleton className="h-3 w-12" />
+                </div>
+                <div className="space-y-1.5">
+                  {Array.from({ length: 4 }).map((_, i) => (
+                    <div
+                      key={i}
+                      className="border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-3 flex items-center gap-4"
+                    >
+                      <Skeleton className="w-12 h-12 flex-shrink-0" />
+                      <Skeleton className="w-10 h-6 flex-shrink-0" />
+                      <div className="flex-1 min-w-0 space-y-2">
+                        <Skeleton className="h-4 w-40" />
+                        <Skeleton className="h-3 w-28" />
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
             ) : scores.length === 0 ? (
               <EmptyHero />
             ) : (
@@ -655,7 +714,16 @@ export default function DashboardPage() {
             {/* While the empty-team setup banner is showing, don't also show
                 the team card — they'd be redundant for a Lead with no team.
                 Gated on `data` so it doesn't flash before team state is known. */}
-            {effectiveData && tier === "team" && !needsTeamSetup && <TeamCard />}
+            {/* While the dashboard data loads, reserve the Team card's space
+                for team-tier users (read from Clerk metadata, which is known
+                before the /api/dashboard fetch) so the promos below don't get
+                shoved when it appears. */}
+            {showLoading
+              ? (user?.publicMetadata as { tier?: string } | undefined)?.tier ===
+                  "team" && <TeamCardSkeleton />
+              : effectiveData &&
+                tier === "team" &&
+                !needsTeamSetup && <TeamCard />}
             <FigmaPromoCard />
             <ClaudePromoCard />
           </aside>

--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ActivityHeatmap";
 import { Avatar } from "@/components/Avatar";
 import { TabButton } from "@/components/Tabs";
+import { Skeleton } from "@/components/Skeleton";
 
 type ScoreEntry = {
   id: string;
@@ -274,10 +275,75 @@ export default function TeamMemberDetailPage() {
   }
 
   if (loading) {
+    // Structure-matching skeleton: header, tabs, stat pills, Activity box, and
+    // score rows mirror the loaded layout so content fills in without a jump.
     return (
       <div className="pt-20 font-mono">
         <div className="max-w-6xl mx-auto px-6 py-10">
-          <p className="text-sm text-muted font-sans">Loading member…</p>
+          <div className="mb-8">
+            <Link
+              href="/dashboard/team"
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              ← Team
+            </Link>
+            <div className="mt-4 flex items-center gap-5">
+              <Skeleton className="w-16 h-16 rounded-full flex-shrink-0" />
+              <div className="min-w-0 space-y-2">
+                <Skeleton className="h-5 w-44" />
+                <Skeleton className="h-3 w-56" />
+              </div>
+            </div>
+          </div>
+
+          <div className="border-b border-[#2a2a2a] flex items-end gap-4 mb-6 pb-3">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-2 mb-8">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="border border-[#2a2a2a] bg-[#1a1a1a] p-4"
+              >
+                <Skeleton className="h-2 w-16 mb-3" />
+                <Skeleton className="h-7 w-12" />
+              </div>
+            ))}
+          </div>
+
+          <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5 mb-8">
+            <div className="flex items-baseline justify-between mb-4">
+              <span className="text-[10px] text-muted uppercase tracking-widest">
+                Activity
+              </span>
+              <Skeleton className="h-3 w-20" />
+            </div>
+            <Skeleton className="h-16 w-full" />
+          </div>
+
+          <div className="mb-3 flex items-baseline justify-between">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Score history
+            </span>
+            <Skeleton className="h-3 w-12" />
+          </div>
+          <div className="space-y-1.5">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div
+                key={i}
+                className="border border-[#2a2a2a] bg-[#1a1a1a] px-4 py-3 flex items-center gap-4"
+              >
+                <Skeleton className="w-12 h-12 flex-shrink-0" />
+                <Skeleton className="w-12 h-6 flex-shrink-0" />
+                <div className="flex-1 min-w-0 space-y-2">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-28" />
+                </div>
+              </div>
+            ))}
+          </div>
         </div>
       </div>
     );
@@ -423,10 +489,10 @@ export default function TeamMemberDetailPage() {
           </div>
           <ActivityHeatmap
             activity={bucket.activity}
-            cellWidth={18}
-            cellHeight={7}
-            cellGap={2}
+            cellHeight={10}
+            cellGap={3}
             emptyClassName="bg-[#222]"
+            fill
           />
         </div>
 

--- a/src/components/TeamCard.tsx
+++ b/src/components/TeamCard.tsx
@@ -5,6 +5,25 @@ import { useEffect, useState } from "react";
 import { useOrganization } from "@clerk/nextjs";
 import { useViewAs } from "@/lib/dev/view-as";
 import { viewAsTeamData } from "@/lib/dev/dashboard-fixtures";
+import { Skeleton } from "@/components/Skeleton";
+
+/**
+ * Loading placeholder for TeamCard — same box, eyebrow, and row layout so the
+ * card fills into place without shifting the sidebar. Shown while the dashboard
+ * data loads for team-tier users.
+ */
+export function TeamCardSkeleton() {
+  return (
+    <div className="border border-[#333] bg-[#1e1e1e] p-5">
+      <span className="block text-[9px] text-ladder-green uppercase tracking-widest font-semibold leading-none mb-3">
+        Team
+      </span>
+      <Skeleton className="h-4 w-32 mb-2" />
+      <Skeleton className="h-3 w-40 mb-5" />
+      <Skeleton className="h-8 w-28" />
+    </div>
+  );
+}
 
 /**
  * Dashboard sidebar entry point for the team view. Hidden when the user has no

--- a/src/components/UsageMeter.tsx
+++ b/src/components/UsageMeter.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useViewAs } from "@/lib/dev/view-as";
 import { viewAsUsageData } from "@/lib/dev/dashboard-fixtures";
+import { Skeleton } from "@/components/Skeleton";
 
 /**
  * Score usage meter for /dashboard/settings (and anywhere else we
@@ -52,7 +53,25 @@ export function UsageMeter() {
   }, [viewAs]);
 
   if (loading) {
-    return <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5 shimmer h-28" />;
+    // Mirror the loaded box (header + usage line + bar + footer line) so its
+    // height matches and the sidebar doesn't shift when data arrives. The
+    // "Usage" heading is the same across tiers, so keep it real.
+    return (
+      <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+        <div className="flex items-baseline justify-between gap-3 mb-1">
+          <h3 className="text-sm text-foreground font-sans font-semibold">
+            Usage
+          </h3>
+          <Skeleton className="h-2.5 w-12" />
+        </div>
+        <div className="flex items-baseline justify-between gap-3 mb-4">
+          <Skeleton className="h-3 w-40" />
+          <Skeleton className="h-2.5 w-14" />
+        </div>
+        <Skeleton className="h-1.5 w-full" />
+        <Skeleton className="h-2.5 w-24 mt-2" />
+      </div>
+    );
   }
   if (!data) return null;
 

--- a/src/components/promos/ClaudePromoCard.tsx
+++ b/src/components/promos/ClaudePromoCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Skeleton } from "@/components/Skeleton";
 
 type Meta = {
   hasToken?: boolean;
@@ -32,7 +33,19 @@ export function ClaudePromoCard() {
   }, []);
 
   if (loading) {
-    return <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5 shimmer h-24" />;
+    // Mirror the loaded card's structure so its height matches and the card
+    // below isn't shoved when real content arrives.
+    return (
+      <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+        <div className="flex items-baseline justify-between gap-3 mb-1">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-2.5 w-10" />
+        </div>
+        <Skeleton className="h-3 w-full mb-1.5" />
+        <Skeleton className="h-3 w-3/4 mb-3" />
+        <Skeleton className="h-2.5 w-20" />
+      </div>
+    );
   }
 
   const connected = !!meta?.hasToken && !!meta?.lastUsedAt;

--- a/src/components/promos/FigmaPromoCard.tsx
+++ b/src/components/promos/FigmaPromoCard.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { Skeleton } from "@/components/Skeleton";
 
 type Meta = {
   hasUsed?: boolean;
@@ -29,7 +30,19 @@ export function FigmaPromoCard() {
   }, []);
 
   if (loading) {
-    return <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5 shimmer h-24" />;
+    // Mirror the loaded card's structure so its height matches and the card
+    // below isn't shoved when real content arrives.
+    return (
+      <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
+        <div className="flex items-baseline justify-between gap-3 mb-1">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-2.5 w-10" />
+        </div>
+        <Skeleton className="h-3 w-full mb-1.5" />
+        <Skeleton className="h-3 w-3/4 mb-3" />
+        <Skeleton className="h-2.5 w-20" />
+      </div>
+    );
   }
 
   const connected = !!meta?.hasUsed;


### PR DESCRIPTION
## Summary
Replace jumpy/pop-in loading states with skeletons that mirror the loaded layout — chrome stays rendered, only data-shaped slots shimmer — so content fills into place without reflow. `tsc` + lint clean.

### Dashboard
- Main column: real "Score a screen" CTA + "Score history" eyebrow + score-row skeletons (thumbnail / score / name / meta).
- **Design rhythm**: matching skeleton (eyebrow + 3-column box at the exact 88px chart height) — no more pop-in after the data fetch.

### Sidebar (no more shoving)
- **Usage meter**, **Team card**, and both **promo cards** now load at their real heights instead of short shimmer blocks that grew and pushed the column.
- New exported `TeamCardSkeleton`, reserved for team-tier users via Clerk `publicMetadata.tier` (known before `/api/dashboard` resolves), so the slot is held from first paint.

### Member / designer detail page
- Activity heatmap now spans full width (`ActivityHeatmap` `fill` mode).
- Full-page structure-matching loading skeleton (header, tabs, stat pills, Activity box, score rows) replacing the "Loading member…" text.

## /hq
No consequence — loading-state / layout polish only (no feature, flow, API, role, pricing, glossary, or brand change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)