### PR TITLE
Standardize the org:admin role on "Team Lead" (#260)

### DIFF
--- a/src/app/api/dashboard/team/invitations/[id]/reinvite/route.ts
+++ b/src/app/api/dashboard/team/invitations/[id]/reinvite/route.ts
@@ -26,7 +26,7 @@ export async function POST(
   }
   if (orgRole !== "org:admin") {
     return NextResponse.json(
-      { error: "Manager access required" },
+      { error: "Team Lead access required" },
       { status: 403 },
     );
   }

--- a/src/app/api/dashboard/team/members/[userId]/archive/route.ts
+++ b/src/app/api/dashboard/team/members/[userId]/archive/route.ts
@@ -29,7 +29,7 @@ export async function POST(
   }
   if (orgRole !== "org:admin") {
     return NextResponse.json(
-      { error: "Manager access required" },
+      { error: "Team Lead access required" },
       { status: 403 },
     );
   }

--- a/src/app/api/dashboard/team/members/[userId]/delete/route.ts
+++ b/src/app/api/dashboard/team/members/[userId]/delete/route.ts
@@ -32,7 +32,7 @@ export async function POST(
   }
   if (orgRole !== "org:admin") {
     return NextResponse.json(
-      { error: "Manager access required" },
+      { error: "Team Lead access required" },
       { status: 403 },
     );
   }

--- a/src/app/api/dashboard/team/members/[userId]/route.ts
+++ b/src/app/api/dashboard/team/members/[userId]/route.ts
@@ -139,7 +139,7 @@ export async function GET(
   }
   if (orgRole !== "org:admin") {
     return NextResponse.json(
-      { error: "Manager access required" },
+      { error: "Team Lead access required" },
       { status: 403 },
     );
   }

--- a/src/components/TeamSetupBanner.tsx
+++ b/src/components/TeamSetupBanner.tsx
@@ -25,8 +25,8 @@ export function TeamSetupBanner() {
           </h3>
           <p className="text-sm text-[#0a1a14]/80 font-sans leading-relaxed max-w-2xl">
             You&apos;re set up to lead a team on Ladder. Create your team to invite
-            your designers, see their scores and letter grades, and unlock manager
-            insights. Designers you invite get team-tier access automatically.
+            your designers, see their scores and letter grades, and unlock Team
+            Lead insights. Designers you invite get team-tier access automatically.
           </p>
         </div>
         <Link

--- a/src/components/reviews/RequestReviewCTA.tsx
+++ b/src/components/reviews/RequestReviewCTA.tsx
@@ -33,7 +33,7 @@ export function RequestReviewCTA() {
             Ask your team for a review
           </p>
           <p className="text-[11px] text-muted font-sans mt-0.5">
-            Send a screen to your manager for human crit. They&apos;ll see it
+            Send a screen to your Team Lead for human crit. They&apos;ll see it
             on their team dashboard.
           </p>
         </div>

--- a/src/content/hq/_sections.ts
+++ b/src/content/hq/_sections.ts
@@ -33,7 +33,7 @@ export const HQ_SECTIONS: HqSection[] = [
   {
     slug: "roles",
     title: "Roles",
-    intent: "Free, Pro, Team Leader, Team Member, Admin, Super Admin. What each can do.",
+    intent: "Free, Pro, Team Lead, Team Member, Admin, Super Admin. What each can do.",
   },
   {
     slug: "features",

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -177,7 +177,7 @@ Public limits (visible on `/pricing` and enforced in `src/lib/plans.ts`):
 | --- | --- | --- |
 | Free | 5 lifetime scores | Web + Skill + Figma |
 | Pro | 2,000 scores/mo (soft cap, hard cap 2x) | All surfaces + API keys (when public API ships) |
-| Team | 25,000 pooled scores/mo (Beta) | All Pro features + manager workflow |
+| Team | 25,000 pooled scores/mo (Beta) | All Pro features + Team Lead workflow |
 | Pulse | Custom (set per engagement) | All Team features + Pulse data ingest in `ladder-beta` |
 
 Pro went from $250/mo to $1,000/mo in v0.4.8 ([PR #166](https://github.com/drawbackwards/runladder/pull/166)) on 2026-04-28. Subscribe button is live via Stripe.

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -1,8 +1,8 @@
 ---
 title: Decisions Log
-updatedAt: 2026-06-04
-updatedBy: Chester
-lastPr: 277
+updatedAt: 2026-06-05
+updatedBy: Sara
+lastPr: 285
 ---
 
 ## How to use this page

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-04
+updatedAt: 2026-06-05
 updatedBy: Sara
-lastPr: 276
+lastPr: 285
 ---
 
 ## How to read this page

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -36,7 +36,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Reviews on dashboard | Pro+ | Live (v0.4.15) | [#173](https://github.com/drawbackwards/runladder/pull/173) |
 | Active Reviews on team dashboard | Team Members + Leaders | Live (v0.4.16) | [#174](https://github.com/drawbackwards/runladder/pull/174) |
 | Reviews: request flow, pins, scoring integration | Pro+ | Live (v0.4.17) | [#175](https://github.com/drawbackwards/runladder/pull/175) |
-| Team pool meter (25K cap rendered prominently) | Team Leaders | Live (v0.4.18) | [#176](https://github.com/drawbackwards/runladder/pull/176) |
+| Team pool meter (25K cap rendered prominently) | Team Leads | Live (v0.4.18) | [#176](https://github.com/drawbackwards/runladder/pull/176) |
 | Ladder HQ internal team hub (`/hq`) | Admin + Team | Live (v0.5.0) | [#177](https://github.com/drawbackwards/runladder/pull/177) |
 | HQ content + PR-stamp protocol | Admin + Team | Live (v0.5.1) | [#178](https://github.com/drawbackwards/runladder/pull/178) |
 | Blog (`/blog`) | Public | Live | `src/app/blog/`, content ongoing |
@@ -176,10 +176,10 @@ Pulled out so the Pro upgrade case is easy to articulate. See [Decisions Log →
 
 Built on top of Pro. Sold as a Drawbackwards engagement (MSA + SOW), not self-serve.
 
-- Team dashboard at `/dashboard/team` with manager view
+- Team dashboard at `/dashboard/team` with Team Lead view
 - Letter-grade scoring per member (A-F based on 30-day Comfortable+ rate)
 - Team performance insights (avg score, strongest/weakest rung)
 - Reviews + interactive pins + Team Take aggregate scoring
 - 25,000-query monthly pool
-- Manager-controlled seat invites via Clerk Organizations
+- Team-Lead-controlled seat invites via Clerk Organizations
 - Admin-provisioned orgs (self-serve org creation disabled in v0.5.5); suspend on contract end

--- a/src/content/hq/roles.mdx
+++ b/src/content/hq/roles.mdx
@@ -1,8 +1,8 @@
 ---
 title: Roles
-updatedAt: 2026-05-19
+updatedAt: 2026-06-05
 updatedBy: Sara
-lastPr: 179
+lastPr: 285
 ---
 
 ## End-user roles

--- a/src/content/hq/roles.mdx
+++ b/src/content/hq/roles.mdx
@@ -14,8 +14,8 @@ These are the tiers a customer can hold. Drives every gated feature on every sur
 | **Anonymous** | - | Marketing pages only. No scoring. Sign-up required to score. |
 | **Free** | Sign-up | 5 lifetime scores. Base score only. No a11y or UX copywriting tabs. |
 | **Pro** | Stripe self-serve, $1,000/mo (public) | 2,000 scores/mo, all surfaces, a11y and UX copywriting unlocked, enhanced dashboard. Hard cap at 4,000 scores/mo (2x soft cap). |
-| **Team Member** | Invited by Team Leader | Shares the team pool (25,000 pooled scores/mo). All Pro features. Sees team leaderboard. |
-| **Team Leader** | Drawbackwards engagement (Beta) | Manages seats, invites Team Members, sees team dashboard, controls billing. Comes via MSA + SOW. Public price: Custom. |
+| **Team Member** | Invited by Team Lead | Shares the team pool (25,000 pooled scores/mo). All Pro features. Sees team leaderboard. |
+| **Team Lead** | Drawbackwards engagement (Beta) | Manages seats, invites Team Members, sees team dashboard, controls billing. Comes via MSA + SOW. Public price: Custom. |
 | **Pulse User** | Pulse engagement | All Team features + Pulse data ingest and customer-feedback dashboard (lives in `ladder-beta`). Public price: Custom. |
 
 See [Decisions Log -- Public pricing](/hq/decisions#public-pricing-free-5-lifetime-pro-1000mo-self-serve-team-and-pulse-custom) for the rationale.
@@ -32,7 +32,7 @@ These gate access to platform internals. Email-based allowlist defined in `src/l
 
 ## Capability matrix
 
-| Capability | Free | Pro | Team Member | Team Leader | Pulse | Admin | Super Admin |
+| Capability | Free | Pro | Team Member | Team Lead | Pulse | Admin | Super Admin |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Score a screen | 5 lifetime | 2K/mo (4K hard cap) | Pool | Pool | Pool | Yes | Yes |
 | A11y audit | - | Yes | Yes | Yes | Yes | Yes | Yes |


### PR DESCRIPTION
## Summary
The same role (Clerk `org:admin`, the person who leads a client team) was called **Manager / Team Lead / Team Leader** across the UI. Standardize on **"Team Lead"** (the term in the customer-facing provisioning flow; recorded as canonical in `/hq/glossary`).

### Changed
- **UI copy:** `TeamSetupBanner` ("Team Lead insights"), `RequestReviewCTA` ("Send a screen to your Team Lead").
- **API error strings:** "Manager access required" → "Team Lead access required" (team member detail / archive / delete / reinvite routes).
- **`/hq` docs:** `roles.mdx` (incl. capability-matrix column), `_sections.ts` roles intent, `features.mdx`, `decisions.mdx`. Glossary already had the canonical entry.

### Left as-is (per the issue)
Marketing/persona language (home, products, pricing, teams), the **"Drawbackwards account manager"** relationship contact, the "Product Manager" job title, and internal code identifiers (`isManager`, the `"manager"` avatar-ring value) — flagged lower-priority maintainability, not user-facing.

## Verification
`tsc --noEmit` clean; lint clean.

Closes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)