### PR TITLE
Usage: show the pool only; hard cap is a silent grace backstop (#227)

### DIFF
--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -303,29 +303,17 @@ function InsightsPanel({ insights }: { insights: Insights }) {
 }
 
 /**
- * Team pool meter. Mirrors the dashboard Usage box — same data and bar style:
- * monthly scoring volume against the soft pool cap, a bar normalized to the
- * hard cap with a tick at the soft cap, and the "resets in N days" / hard-cap
- * copy. The section label sits above the box, consistent with the rest of the
- * page. Visible to the Team Lead only.
+ * Team pool meter. Mirrors the dashboard Usage box: monthly scoring volume
+ * against the pool the customer bought (soft cap), plus the "resets in N days"
+ * copy. The 2x hard cap is a silent server-side grace backstop — never shown as
+ * a number (#227). Section label above the box. Visible to the Team Lead only.
  */
 function TeamPoolMeter({ pool }: { pool: TeamPool }) {
-  const { used, limit, hardCap, daysUntilReset } = pool;
-  const pct = Math.min(100, (used / hardCap) * 100);
-  const softTickPct = (limit / hardCap) * 100;
-  const blocked = used >= hardCap;
-  const over = used > limit;
-  const warn = !over && used / limit >= 0.8;
-
-  // Bar color shifts at 80% of soft (amber) and >=100% of soft (red) — the
-  // same thresholds and palette as the dashboard Usage meter.
-  const barClass = blocked
-    ? "bg-red-500"
-    : over
-      ? "bg-red-400"
-      : warn
-        ? "bg-amber-400"
-        : "bg-ladder-green";
+  const { used, limit, daysUntilReset } = pool;
+  const pct = Math.min(100, (used / limit) * 100);
+  const atCap = used >= limit;
+  const showGraceNote = used / limit >= 0.5;
+  const barClass = atCap ? "bg-amber-400" : "bg-ladder-green";
 
   return (
     <section>
@@ -340,53 +328,26 @@ function TeamPoolMeter({ pool }: { pool: TeamPool }) {
             Resets in {daysUntilReset}d
           </span>
         </div>
-        <div className="relative h-1.5 bg-[#0e0e0e]">
+        <div className="h-1.5 bg-[#0e0e0e]">
           <div
             className={`h-full ${barClass} transition-all`}
             style={{ width: `${pct}%` }}
           />
-          <div
-            className="absolute top-[-2px] bottom-[-2px] w-px bg-[#555]"
-            style={{ left: `${softTickPct}%` }}
-            title={`Soft cap: ${limit.toLocaleString()}`}
-          />
         </div>
-        <p className="text-[10px] text-muted mt-1 font-mono">
-          Hard cap at {hardCap.toLocaleString()}
-        </p>
-        {blocked ? (
-          <p className="text-[11px] text-red-400 mt-3">
-            Team pool is maxed for the month.{" "}
+        {atCap ? (
+          <p className="text-[11px] text-muted mt-3">
+            Pool limit reached — you&apos;re in a grace period.{" "}
             <a
-              href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20hard-cap%20reached"
-              className="underline"
+              href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20more%20capacity"
+              className="text-ladder-green hover:underline"
             >
-              Email us to lift the ceiling
+              Reach out to add capacity
             </a>
             .
           </p>
-        ) : over ? (
-          <p className="text-[11px] text-muted mt-3">
-            Over your monthly pool. Still scoring through to{" "}
-            {hardCap.toLocaleString()} —{" "}
-            <a
-              href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20higher%20volume%20inquiry"
-              className="text-ladder-green hover:underline"
-            >
-              talk to us about higher volume
-            </a>
-            .
-          </p>
-        ) : warn ? (
-          <p className="text-[11px] text-muted mt-3">
-            Approaching your team pool cap.{" "}
-            <a
-              href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20higher%20volume%20inquiry"
-              className="text-ladder-green hover:underline"
-            >
-              Talk to us
-            </a>
-            .
+        ) : showGraceNote ? (
+          <p className="text-[10px] text-muted mt-2 font-mono">
+            Includes a short grace period past your pool.
           </p>
         ) : null}
       </div>

--- a/src/components/UsageMeter.tsx
+++ b/src/components/UsageMeter.tsx
@@ -109,29 +109,20 @@ export function UsageMeter() {
   // Pulse skips this meter (queries are tracked separately).
   if (data.tier === "pulse") return null;
 
-  // Pro / Team: monthly view
+  // Pro / Team: monthly view. We surface only the pool the customer bought
+  // (the soft cap). The 2x hard cap stays a silent server-side grace backstop
+  // and is never shown as a number — putting it on screen made the pool look
+  // fake and killed the upgrade trigger (#227).
   if (data.monthlyLimit === null) return null;
   const used = data.monthlyUsed;
   const limit = data.monthlyLimit;
-  const hardCap = data.monthlyHardCap ?? limit * 2;
-  // The bar's full width represents the hard cap (the wall), with a
-  // tick marker at the soft cap. That way the user can SEE the gap
-  // between "we should talk" (soft) and "we have to stop" (hard).
-  const pct = Math.min(100, (used / hardCap) * 100);
-  const softTickPct = (limit / hardCap) * 100; // typically 50% with 2x multiplier
-  const blocked = used >= hardCap;
-  const over = used > limit;
-  const warn = !over && used / limit >= 0.8;
+  const pct = Math.min(100, (used / limit) * 100);
+  const atCap = used >= limit;
+  // Disclose the grace period from the halfway mark — a quiet footnote, no
+  // numbers — so customers know going over won't hard-stop them mid-work.
+  const showGraceNote = used / limit >= 0.5;
   const tierLabel = data.tier === "pro" ? "Pro" : "Team pool";
-
-  // Bar color shifts at 80% of soft (amber) and ≥100% of soft (red).
-  const barClass = blocked
-    ? "bg-red-500"
-    : over
-      ? "bg-red-400"
-      : warn
-        ? "bg-amber-400"
-        : "bg-ladder-green";
+  const barClass = atCap ? "bg-amber-400" : "bg-ladder-green";
 
   return (
     <div className="border border-[#2a2a2a] bg-[#1a1a1a] p-5">
@@ -150,55 +141,26 @@ export function UsageMeter() {
           Resets in {data.daysUntilReset}d
         </span>
       </div>
-      {/* Bar normalized to the hard cap; the tick at softTickPct marks
-          the soft cap so the user can see where "talk to us" begins
-          and where "scoring stops" lives. */}
-      <div className="relative h-1.5 bg-[#0e0e0e]">
+      <div className="h-1.5 bg-[#0e0e0e]">
         <div
           className={`h-full ${barClass} transition-all`}
           style={{ width: `${pct}%` }}
         />
-        <div
-          className="absolute top-[-2px] bottom-[-2px] w-px bg-[#555]"
-          style={{ left: `${softTickPct}%` }}
-          title={`Soft cap: ${limit.toLocaleString()}`}
-        />
       </div>
-      <p className="text-[10px] text-muted mt-1 font-mono">
-        Hard cap at {hardCap.toLocaleString()}
-      </p>
-      {blocked ? (
-        <p className="text-[11px] text-red-400 mt-3">
-          Scoring paused — you&apos;re past 2x your monthly cap.{" "}
+      {atCap ? (
+        <p className="text-[11px] text-muted mt-3">
+          Pool limit reached — you&apos;re in a grace period.{" "}
           <a
-            href="mailto:hello@drawbackwards.com?subject=Ladder%20hard-cap%20reached"
-            className="underline"
+            href="mailto:hello@drawbackwards.com?subject=Ladder%20Team%20more%20capacity"
+            className="text-ladder-green hover:underline"
           >
-            Email us to lift the ceiling
+            Reach out to add capacity
           </a>
           .
         </p>
-      ) : over ? (
-        <p className="text-[11px] text-muted mt-3">
-          You&apos;ve passed your monthly cap. Still scoring through to {hardCap.toLocaleString()} —{" "}
-          <a
-            href="mailto:hello@drawbackwards.com?subject=Ladder%20higher%20volume%20inquiry"
-            className="text-ladder-green hover:underline"
-          >
-            talk to us about higher volume
-          </a>
-          .
-        </p>
-      ) : warn ? (
-        <p className="text-[11px] text-muted mt-3">
-          Approaching your monthly cap. If you regularly hit this,{" "}
-          <a
-            href="mailto:hello@drawbackwards.com?subject=Ladder%20higher%20volume%20inquiry"
-            className="text-ladder-green hover:underline"
-          >
-            we&apos;ll size you up
-          </a>
-          .
+      ) : showGraceNote ? (
+        <p className="text-[10px] text-muted mt-2 font-mono">
+          Includes a short grace period past your pool.
         </p>
       ) : null}
     </div>

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-06-05
 updatedBy: Sara
-lastPr: 285
+lastPr: 288
 ---
 
 ## How to use this page

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -186,6 +186,8 @@ Why: the Free to Pro gap was a leaky funnel when Free was generous. Lifetime cap
 
 How to apply: don't offer ad-hoc discounts on Pro. Don't offer self-serve Team. Internal price targets stay in memory per [/hq documents PUBLIC pricing only](#hq-documents-public-pricing-only).
 
+**Hard cap is not surfaced to customers (#227, 2026-06-05):** the 2x hard cap (e.g. 50K behind Team's 25K pool) is an internal grace backstop, not a number we show. Surfacing "Hard cap at 50,000" made the purchased pool look fake and killed the upgrade trigger ("why upgrade at 30K if 50K is allowed?"). The customer UI now shows only the pool they bought (soft cap); a quiet, no-numbers footnote discloses that a short grace period exists (shown from 50% usage), and a "pool limit reached — grace period — reach out to add capacity" message appears at 100%. Scoring still hard-stops server-side at 2x. Proactive outreach when a team nears its pool is tracked in #287 (emails) + #286 (admin Team Detail).
+
 ---
 
 ## Teams is an agency engagement, not self-serve SaaS


### PR DESCRIPTION
## Summary
"Hard cap at 50,000" next to the 25K pool read as "you actually get 50K," making the purchased pool look fake and removing the upgrade trigger. Fix: surface only the pool the customer bought; keep the 2x hard cap as a silent server-side grace backstop.

- **Show the pool only** — bar normalizes to the soft cap; dropped the hard-cap line and the soft-cap tick.
- **Grace disclosed, no numbers** — a quiet footnote from 50% usage: *"Includes a short grace period past your pool."*
- **At the pool** (used ≥ limit): *"Pool limit reached — you're in a grace period. Reach out to add capacity."*
- The 2x hard cap still hard-stops scoring server-side; it's just never shown.

Applies to the dashboard **Usage meter** and the team-page **Team Pool box**.

Follow-ups (filed): **#286** admin Team Detail screen, **#287** usage-threshold emails (Team Lead + Ward).

## /hq
`decisions.mdx` records the not-surfaced-hard-cap decision.

## Verification
`tsc` + lint clean. Note: these surfaces are auth-gated (signed-in dashboard / Team Lead), so I couldn't headlessly preview them — worth an eyeball on deploy. To see the grace/at-cap states in the dev view-as switcher, usage needs to be ≥50% / ≥100% of the pool (current fixtures sit ~5–17%).

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)