### PR TITLE
Pro upgrade flow: sign-up modal + post-checkout confirmation + logo hide (part of #213)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import Link from "next/link";
@@ -483,6 +483,7 @@ export default function DashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState<string | null>(null);
+  const [upgradedToPro, setUpgradedToPro] = useState(false);
 
   // Make sure the user's org is the session's active org (invite-based
   // provisioning doesn't auto-activate the way self-serve creation did) so the
@@ -492,25 +493,35 @@ export default function DashboardPage() {
   // client org hooks.
   useEnsureActiveOrg();
 
+  const loadDashboard = useCallback(async () => {
+    try {
+      const res = await fetch("/api/dashboard");
+      if (res.ok) setData(await res.json());
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
   useEffect(() => {
     if (!isSignedIn) return;
+    loadDashboard();
+  }, [isSignedIn, loadDashboard]);
 
-    async function fetchData() {
-      try {
-        const res = await fetch("/api/dashboard");
-        if (res.ok) {
-          const json = await res.json();
-          setData(json);
-        }
-      } catch {
-        // Silently fail
-      } finally {
-        setLoading(false);
-      }
-    }
-
-    fetchData();
-  }, [isSignedIn]);
+  // Stripe checkout returns to /dashboard?upgraded=pro. Confirm the upgrade and
+  // re-fetch shortly after — the tier flips via the Stripe webhook (async), so
+  // the first load can still read "Free". Read from window (not useSearchParams)
+  // to avoid a Suspense boundary requirement. (#213)
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("upgraded") !== "pro") return;
+    setUpgradedToPro(true);
+    window.history.replaceState({}, "", "/dashboard");
+    const t = setTimeout(() => loadDashboard(), 2500);
+    return () => clearTimeout(t);
+  }, [loadDashboard]);
 
   async function deleteScore(scoreId: string) {
     setDeleting(scoreId);
@@ -559,6 +570,26 @@ export default function DashboardPage() {
 
   return (
     <div className="pt-20 font-mono">
+      {/* Post-checkout confirmation (#213). Dismissible; the tier catches up via
+          the Stripe webhook + the delayed re-fetch above. */}
+      {upgradedToPro && (
+        <div className="border-b border-ladder-green/30 bg-ladder-green/5">
+          <div className="max-w-6xl mx-auto px-6 py-5 flex items-center justify-center gap-4 flex-wrap">
+            <span className="text-[11px] text-muted font-sans">
+              <span className="text-ladder-green font-semibold uppercase tracking-widest text-[10px]">
+                Welcome to Pro
+              </span>{" "}
+              — 2,000 scores/month across every surface.
+            </span>
+            <button
+              onClick={() => setUpgradedToPro(false)}
+              className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
       {/* Both the plan strip and the team-setup banner are gated on the
           dashboard fetch (`data`) so they never flash a wrong default
           (e.g. the free strip for an internal/team user) on first paint. */}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -355,7 +355,8 @@ h1, h2, h3, h4, h5, h6 {
 .cl-alternativeMethodsBlockButton {
   background: #1a1a1a !important;
   border-color: #2a2a2a !important;
-  border-radius: 0 !important;
+  border-radius: 6px !important;
+  overflow: hidden !important;
   color: #e5e5e5 !important;
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -73,6 +73,15 @@ export default function RootLayout({
           colorDanger: "#ef4444",
           fontFamily: "var(--font-inter), Inter, sans-serif",
         },
+        elements: {
+          // Hide Clerk's app logo across every Clerk surface (the modal that
+          // pops from Subscribe, user-button popovers, etc.) — it's a dark
+          // wordmark that's invisible on our dark UI and duplicates our own
+          // branding. The /login and /sign-up pages hide it via authAppearance;
+          // this covers the modal + everywhere else.
+          logoBox: "!hidden",
+          logoImage: "!hidden",
+        },
       }}
       localization={{
         signIn: {

--- a/src/components/SubscribeButton.tsx
+++ b/src/components/SubscribeButton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useAuth, SignInButton } from "@clerk/nextjs";
+import { useAuth, SignUpButton } from "@clerk/nextjs";
 
 type Props = {
   plan: "pro";
@@ -11,9 +11,11 @@ type Props = {
 
 /**
  * Triggers Stripe Checkout for a given plan.
- * Unauthed users get Clerk's modal sign-in overlaid on the page so they
- * don't lose their place — after signing in they're still on /pricing
- * and the next click goes straight to Stripe Checkout.
+ * Signed-out users get Clerk's modal **sign-up** overlaid on the page (most
+ * people clicking Subscribe are new customers; the sign-up modal still offers
+ * "Sign in" + Google for returning users). They don't lose their place — after
+ * auth they're back on /pricing and the next click goes to Stripe Checkout.
+ * (Auto-resuming into checkout after auth is tracked in #316.)
  */
 export function SubscribeButton({ plan, className, children }: Props) {
   const { isSignedIn, isLoaded } = useAuth();
@@ -50,15 +52,15 @@ export function SubscribeButton({ plan, className, children }: Props) {
 
   if (!isSignedIn) {
     return (
-      <SignInButton
+      <SignUpButton
         mode="modal"
         forceRedirectUrl="/pricing"
-        signUpForceRedirectUrl="/pricing"
+        signInForceRedirectUrl="/pricing"
       >
         <button type="button" className={className}>
           {children}
         </button>
-      </SignInButton>
+      </SignUpButton>
     );
   }
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-06-03
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 275
+lastPr: 321
 ---
 
 ## How to read this page

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -36,7 +36,7 @@ Triggers for the upgrade conversation:
 - User clicks a Pro-only tab (a11y audit, UX copywriting) on a score result.
 - User hits the Pricing page directly.
 
-The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). On success the user lands on `/dashboard?welcome=pro` and Pro features unlock immediately. Free users can also start the same checkout straight from the account menu's **Upgrade to Pro** row (#275); until Stripe is configured (#213) that row surfaces a "Billing not set up yet" message instead of navigating.
+The Stripe checkout is self-serve at the Pro price on `/pricing` ($1,000/mo today, via `POST /api/stripe/checkout`). A **signed-out** visitor who clicks Subscribe gets Clerk's **sign-up** modal (so a new customer can create an account; returning users use its "Sign in" link / Google), then returns to `/pricing` to continue — auto-resume into checkout is tracked in #316. On success the user lands on `/dashboard?upgraded=pro`, which shows a dismissible "Welcome to Pro" confirmation and re-fetches so the tier reflects Pro once the webhook lands. Free users can also start the same checkout from the account menu's **Upgrade to Pro** row (#275). Stripe config + go-live is tracked in #213; webhook `→ /api/stripe/webhooks` maps the price to `tier: pro`.
 
 ### Team provisioning (Live, admin-side — v0.5.5, PR #200)
 


### PR DESCRIPTION
## Summary
The Pro upgrade-path code, **verified end-to-end in Stripe test mode** (checkout + webhook tier-flip + customer portal — all `200`s on the listener).

- **SubscribeButton → sign-up modal.** Signed-out Subscribe opened a *sign-in* modal, so a new customer hit "Couldn't find your account" with no way to create one. Now it opens Clerk's **sign-up** modal (returning users still get "Sign in" + Google). Auto-resume into checkout after auth tracked in **#316**.
- **Post-checkout confirmation.** `/dashboard?upgraded=pro` now shows a dismissible "Welcome to Pro" banner + a delayed re-fetch so the tier reflects Pro once the async webhook lands. Banner padded (`py-5`) to match the sidebar cards.
- **Clerk logo hidden globally** (modal + user-button popovers), matching `/login` + `/sign-up`.
- **Clerk styling:** rounded the alternative-methods block button (radius 6px + overflow hidden).

## Not closing #213
This is the **code** half. #213 closes after the **live** Stripe config (Production env + live product/price/key + a dashboard webhook at `runladder.com`) and a live smoke test.

## /hq
`journeys.mdx` updated: sign-up entry for Subscribe + the `?upgraded=pro` confirmation.

## Verification
`tsc` + lint clean. End-to-end test-mode checkout confirmed (webhook events 200, tier flipped, banner shown).

Part of #213. Related UX: #316, #317, #318, #319, #320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)