### PR TITLE
Private/Internal scoring (paid), scoring-engine version, team hover fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.7 / api 1.0.0 (2026-06-08)
+
+**Private scoring as a paid feature, scoring-engine versioning, and dashboard polish.**
+
+- **Private / Internal scoring (#290 + #301).** The scan-screen public/private toggle is now tier-aware. Free accounts can't score privately — the toggle is disabled, locked to public, with an "Upgrade to keep your scores private" prompt. Pro/Team/Pulse default to **private**, and turning it off shows an inline warning that the score will be public. The label is tier-aware everywhere a non-public score appears (dashboard list, score detail, designer detail): single users (Free/Pro) see "Private," team-context users (Team/Pulse) see "Internal." Enforced client-side and server-side (`/api/score` + `/api/score/stream` force `isPublic` for free users so the gate can't be bypassed via the API). New shared helper `src/lib/score-scope.ts`.
+- **Scoring-engine version (#309).** New `CURRENT_ENGINE_VERSION` constant (started at `1.2`) tracks the scoring algorithm independently of the app/API versions. Footer now reads "Scoring Engine v1.2 · App v0.5.7."
+- **Team dashboard hover fix (#303).** On a member row, the Archive/Delete actions now fade in as the score stats + drill arrow fade out, so the actions no longer overlap the numbers.
+- Versions 0.5.5 and 0.5.6 were skipped — they're reserved by the client-provisioning work (#200 / #217) that labeled ahead of the source of truth.
+- `/hq` updated: Architecture (Versioning), Decisions Log (private-scoring entry + engine version), Glossary (Score visibility), Features (private-scoring row).
+
+---
+
 ## app 0.5.4 / api 1.0.0 (2026-05-26)
 
 **Auth + onboarding fixes ahead of the Ladder Team sale.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.4",
+  "version": "0.5.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/plans";
 import { getMonthlyScans } from "@/lib/usage";
 import { getUserTier } from "@/lib/tier";
+import { canScorePrivately as tierCanScorePrivately } from "@/lib/score-scope";
 import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
 import {
   ANON_COOKIE,
@@ -68,8 +69,8 @@ export async function POST(req: NextRequest) {
     }
 
     /* ── Rate limiting (signed-in tiers) ── */
-    if (userId) {
-      const tier = await getUserTier(userId);
+    const tier = userId ? await getUserTier(userId) : null;
+    if (userId && tier) {
       if (!isPaidTier(tier)) {
         const usedKey = lifetimeScansKey(userId);
         const used = (await redis.get<number>(usedKey)) ?? 0;
@@ -147,7 +148,13 @@ export async function POST(req: NextRequest) {
       source: source || "upload",
       thumbnail,
       // Anonymous scores are always private; only signed-in users opt in.
-      isPublic: userId ? !!isPublic : false,
+      // Anonymous scores are always private. Free signed-in users can't score
+      // privately (paid feature, #290) — force public; paid tiers honored.
+      isPublic: userId
+        ? tierCanScorePrivately(tier)
+          ? !!isPublic
+          : true
+        : false,
       timestamp: Date.now(),
       sessionType,
     };

--- a/src/app/api/score/stream/route.ts
+++ b/src/app/api/score/stream/route.ts
@@ -14,6 +14,7 @@ import {
 } from "@/lib/plans";
 import { getMonthlyScans } from "@/lib/usage";
 import { getUserTier } from "@/lib/tier";
+import { canScorePrivately as tierCanScorePrivately } from "@/lib/score-scope";
 import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
 import {
   ANON_COOKIE,
@@ -78,8 +79,8 @@ export async function POST(req: NextRequest) {
   }
 
   /* ── Rate limiting (signed-in tiers; matches /api/score) ── */
-  if (userId) {
-    const tier = await getUserTier(userId);
+  const tier = userId ? await getUserTier(userId) : null;
+  if (userId && tier) {
     if (!isPaidTier(tier)) {
       const usedKey = lifetimeScansKey(userId);
       const used = (await redis.get<number>(usedKey)) ?? 0;
@@ -167,8 +168,15 @@ export async function POST(req: NextRequest) {
                 rungs: result.rungs,
                 source: source || "upload",
                 thumbnail,
-                // Anonymous scores are always private.
-                isPublic: userId ? !!isPublic : false,
+                // Anonymous scores are always private. Free signed-in users
+                // can't score privately (paid feature, #290), so their scores
+                // are forced public regardless of the posted flag; paid tiers
+                // are honored.
+                isPublic: userId
+                  ? tierCanScorePrivately(tier)
+                    ? !!isPublic
+                    : true
+                  : false,
                 timestamp: Date.now(),
                 sessionType,
               };

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,6 +5,7 @@ import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
+import { privateScopeLabel, isTeamScope } from "@/lib/score-scope";
 import { FigmaPromoCard } from "@/components/promos/FigmaPromoCard";
 import { ClaudePromoCard } from "@/components/promos/ClaudePromoCard";
 import { UsageMeter } from "@/components/UsageMeter";
@@ -268,20 +269,24 @@ function surfaceParts(label: string): { name: string; surface: string | null } {
 const META_BADGE =
   "text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5 flex-shrink-0";
 
-/** Score row title: cleaned name + optional surface badge (Figma/Skill/…) + Private badge. */
+/** Score row title: cleaned name + optional surface badge (Figma/Skill/…) + scope badge. */
 function ScoreRowTitle({
   label,
   isPublic,
+  isTeam,
 }: {
   label: string;
   isPublic?: boolean;
+  isTeam: boolean;
 }) {
   const { name, surface } = surfaceParts(label);
   return (
     <div className="flex items-center gap-2">
       <p className="text-sm text-foreground font-sans truncate">{name}</p>
       {surface && <span className={META_BADGE}>{surface}</span>}
-      {isPublic === false && <span className={META_BADGE}>Private</span>}
+      {isPublic === false && (
+        <span className={META_BADGE}>{privateScopeLabel(isTeam)}</span>
+      )}
     </div>
   );
 }
@@ -698,6 +703,7 @@ export default function DashboardPage() {
                             <ScoreRowTitle
                               label={entry.screenName || entry.source}
                               isPublic={entry.isPublic}
+                              isTeam={isTeamScope(tier)}
                             />
                             <p className="text-[10px] text-muted font-sans truncate mt-0.5">
                               <span style={{ color: getScoreColor(entry.score) }}>

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
+import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
+import { privateScopeLabel, isTeamScope } from "@/lib/score-scope";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
 import { ScoreBar } from "@/components/ScoreBar";
@@ -79,6 +80,12 @@ type RecentScore = {
 
 export default function ScoreDetailPage() {
   const { isSignedIn, isLoaded } = useAuth();
+  const { user } = useUser();
+  // Team-context accounts (team / pulse) label a non-public score "Internal"
+  // rather than "Private" — it's still visible to the team (#301).
+  const isTeam = isTeamScope(
+    (user?.publicMetadata as { tier?: string } | undefined)?.tier,
+  );
   const params = useParams();
   const [data, setData] = useState<ScoreDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -169,7 +176,7 @@ export default function ScoreDetailPage() {
                 ? "text-ladder-green border-ladder-green/30"
                 : "text-muted border-[#333]"
             }`}>
-              {data.isPublic ? "Public" : "Private"}
+              {data.isPublic ? "Public" : privateScopeLabel(isTeam)}
             </span>
             <span className="text-[10px] text-[#444]">{timeAgo(data.timestamp)}</span>
           </div>

--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -179,8 +179,10 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
               </span>
             )}
             {entry.isPublic === false && (
+              // This is the designer-detail page inside a team, so a non-public
+              // score is "Internal" (visible to the team), never "Private" (#301).
               <span className="text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5 flex-shrink-0">
-                Private
+                Internal
               </span>
             )}
           </div>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -386,6 +386,15 @@ function MemberRow({
       ? `/dashboard/team/members/${member.userId}`
       : null;
 
+  // Team Leads get Archive/Delete actions on every row but their own. Those
+  // fade in on hover; the score stats + drill arrow fade out in lockstep so
+  // the actions never overlap the numbers (#303). Rows without actions keep
+  // their stats visible on hover.
+  const showActions = isAdmin && !isSelf && !!member.userId;
+  const fadeOnHover = showActions
+    ? "group-hover:opacity-0 transition-opacity"
+    : "";
+
   const Body = (
     <div className="px-4 py-4 flex items-center gap-5">
       <Avatar
@@ -451,7 +460,7 @@ function MemberRow({
         </div>
       )}
 
-      <div className="flex items-start gap-5 flex-shrink-0">
+      <div className={`flex items-start gap-5 flex-shrink-0 ${fadeOnHover}`}>
         <div className="text-right min-w-[48px]">
           <p
             className="text-xl font-bold tabular-nums leading-none"
@@ -474,7 +483,7 @@ function MemberRow({
       </div>
 
       {drillHref && (
-        <span className="text-muted group-hover:text-foreground transition-colors text-base flex-shrink-0">
+        <span className={`text-muted group-hover:text-foreground transition-colors text-base flex-shrink-0 ${fadeOnHover}`}>
           →
         </span>
       )}
@@ -494,7 +503,7 @@ function MemberRow({
         Body
       )}
       {isAdmin && !isSelf && member.userId && (
-        <div className="absolute top-4 right-12 flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="absolute top-4 right-12 z-10 flex items-center gap-3 opacity-0 group-hover:opacity-100 transition-opacity">
           <button
             onClick={(e) => {
               e.preventDefault();

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useRef, useEffect, Suspense } from "react";
 import { useRouter } from "next/navigation";
-import { useAuth, useOrganization, SignUpButton } from "@clerk/nextjs";
+import { useAuth, useUser, useOrganization, SignUpButton } from "@clerk/nextjs";
+import { canScorePrivately as tierCanScorePrivately, isTeamScope } from "@/lib/score-scope";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
@@ -300,6 +301,13 @@ function AnonSignupPrompt({
 export default function ScorePage() {
   const router = useRouter();
   const { isSignedIn, isLoaded } = useAuth();
+  const { user, isLoaded: userLoaded } = useUser();
+  // Tier drives private-scoring access + labeling (#290 / #301). Free can't
+  // score privately; paid tiers default to private; team/pulse label it
+  // "Internal" rather than "Private".
+  const tier = (user?.publicMetadata as { tier?: string } | undefined)?.tier;
+  const canScorePrivately = tierCanScorePrivately(tier);
+  const internalScope = isTeamScope(tier);
   // Active Clerk organization = the user is currently scoring in a team
   // context. Only team members ever see the design/evaluation session
   // prompt — for free/Pro users the bucketing has no surface to show up
@@ -342,6 +350,18 @@ export default function ScorePage() {
   const fileRef = useRef<HTMLInputElement>(null);
   // Guards the one-shot claim of a pending anonymous score after sign-up.
   const claimedRef = useRef(false);
+  // Guards the one-shot tier-based privacy default so it doesn't clobber a
+  // manual toggle on later re-renders (#290).
+  const privacyDefaultApplied = useRef(false);
+
+  // Paid tiers (pro/team/pulse) default to a private score; free users stay
+  // public and can't change it. Applied once, after the Clerk user (and thus
+  // tier) has loaded, so it doesn't override a manual toggle.
+  useEffect(() => {
+    if (!userLoaded || !user || privacyDefaultApplied.current) return;
+    privacyDefaultApplied.current = true;
+    if (canScorePrivately) setIsPublic(false);
+  }, [userLoaded, user, canScorePrivately]);
 
   // Recent-scores list source:
   //  - Signed-in users: the account's backend-persisted scores (/api/dashboard),
@@ -765,38 +785,74 @@ export default function ScorePage() {
 
             {/* Informational callouts — above the drop zone (Ward feedback).
                 Public/private toggle for signed-in users, terms note for anon. */}
-            {isLoaded && isSignedIn ? (
-              <div className="mb-4 flex items-center justify-center gap-3">
-                <button
-                  type="button"
-                  onClick={() => setIsPublic(!isPublic)}
-                  className={`relative w-8 h-[18px] rounded-full transition-colors cursor-pointer ${
-                    isPublic ? "bg-ladder-green" : "bg-[#333]"
-                  }`}
-                  aria-label="Toggle public score"
-                >
-                  <span
-                    className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${
-                      isPublic ? "left-[16px]" : "left-[2px]"
+            {!isLoaded || !isSignedIn ? (
+              isLoaded ? (
+                <p className="mb-4 text-[11px] text-muted leading-relaxed text-center max-w-md mx-auto">
+                  By scoring, you agree to our{" "}
+                  <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Terms</a>{" "}
+                  and{" "}
+                  <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Privacy Policy</a>.
+                  Free scores may be published on runladder.com.{" "}
+                  <a href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Sign in</a>{" "}
+                  for private scoring.
+                </p>
+              ) : null
+            ) : !userLoaded ? (
+              // Tier still resolving — render nothing rather than flash the
+              // wrong toggle state (free vs paid) for a frame.
+              <div className="mb-4 h-[18px]" />
+            ) : canScorePrivately ? (
+              <div className="mb-4 flex flex-col items-center gap-1.5">
+                <div className="flex items-center justify-center gap-3">
+                  <button
+                    type="button"
+                    onClick={() => setIsPublic(!isPublic)}
+                    className={`relative w-8 h-[18px] rounded-full transition-colors cursor-pointer ${
+                      isPublic ? "bg-ladder-green" : "bg-[#333]"
                     }`}
-                  />
-                </button>
-                <span className="text-[11px] text-muted">
-                  {isPublic
-                    ? "Public score — saved to your dashboard and visible on runladder.com"
-                    : "Private score — saved to your dashboard, only you can see it"}
-                </span>
+                    aria-label="Toggle public score"
+                  >
+                    <span
+                      className={`absolute top-[2px] w-[14px] h-[14px] rounded-full bg-white transition-transform ${
+                        isPublic ? "left-[16px]" : "left-[2px]"
+                      }`}
+                    />
+                  </button>
+                  <span className="text-[11px] text-muted">
+                    {isPublic
+                      ? "Public score — saved to your dashboard and visible on runladder.com"
+                      : internalScope
+                        ? "Internal score — saved to your dashboard, visible to your team"
+                        : "Private score — saved to your dashboard, only you can see it"}
+                  </span>
+                </div>
+                {isPublic && (
+                  <p className="text-[11px] text-ladder-orange leading-relaxed text-center max-w-md mx-auto">
+                    Heads up — this score will be publicly visible on runladder.com.
+                  </p>
+                )}
               </div>
             ) : (
-              <p className="mb-4 text-[11px] text-muted leading-relaxed text-center max-w-md mx-auto">
-                By scoring, you agree to our{" "}
-                <a href="/terms" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Terms</a>{" "}
-                and{" "}
-                <a href="/privacy" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Privacy Policy</a>.
-                Free scores may be published on runladder.com.{" "}
-                <a href="/login" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Sign in</a>{" "}
-                for private scoring.
-              </p>
+              // Free tier: private scoring is a paid feature (#290). Lock the
+              // toggle to public and nudge an upgrade.
+              <div className="mb-4 flex flex-col items-center gap-1.5">
+                <div className="flex items-center justify-center gap-3 opacity-60">
+                  <span
+                    className="relative w-8 h-[18px] rounded-full bg-ladder-green cursor-not-allowed"
+                    aria-label="Public score. Private scoring requires a paid plan."
+                    title="Private scoring is available on paid plans"
+                  >
+                    <span className="absolute top-[2px] left-[16px] w-[14px] h-[14px] rounded-full bg-white" />
+                  </span>
+                  <span className="text-[11px] text-muted">
+                    Public score — saved to your dashboard and visible on runladder.com
+                  </span>
+                </div>
+                <p className="text-[11px] text-muted leading-relaxed text-center max-w-md mx-auto">
+                  <a href="/pricing" className="text-ladder-green hover:text-ladder-green/80 transition-colors cursor-pointer">Upgrade</a>{" "}
+                  to keep your scores private.
+                </p>
+              </div>
             )}
 
             {/* Drop zone */}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import { LadderLogo } from "./LadderLogo";
-import { CURRENT_APP_VERSION } from "@/lib/app-version";
+import { CURRENT_APP_VERSION, CURRENT_ENGINE_VERSION } from "@/lib/app-version";
 
 export function Footer() {
   return (
@@ -57,7 +57,9 @@ export function Footer() {
               Made with love by <a href="https://drawbackwards.com" className="text-body hover:text-foreground transition-colors">Drawbackwards</a> since 2003
             </span>
             <span className="text-[10px] text-muted tabular-nums ml-auto">
-              v{CURRENT_APP_VERSION}
+              Scoring Engine v{CURRENT_ENGINE_VERSION}
+              <span className="text-[#444] mx-1.5">·</span>
+              App v{CURRENT_APP_VERSION}
             </span>
           </div>
           {/* Single muted copyright line — the canonical licensing

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -1,8 +1,8 @@
 ---
 title: Architecture
-updatedAt: 2026-06-04
-updatedBy: Chester
-lastPr: 277
+updatedAt: 2026-06-08
+updatedBy: Sara
+lastPr: 322
 ---
 
 ## One scoring framework, three codebases (today)
@@ -57,7 +57,7 @@ Every surface ships its own version and shows it to users. See [API Protocols](/
 
 **Source of truth — the version constants under `src/lib`:**
 
-- `src/lib/app-version.ts`: runladder web app (`CURRENT_APP_VERSION`, rendered in the footer) and API (`CURRENT_API_VERSION`, sent on the `X-Ladder-API-Version` response header)
+- `src/lib/app-version.ts`: runladder web app (`CURRENT_APP_VERSION`, rendered in the footer), API (`CURRENT_API_VERSION`, sent on the `X-Ladder-API-Version` response header), and the **scoring engine** (`CURRENT_ENGINE_VERSION` — the prompt + rubric + model behaviour that turns a screen into a score, also rendered in the footer as "Scoring Engine vX.Y"). The engine versions independently of the app: it can be retuned without an app release, and every shipped score should be attributable to an engine version. Started at `1.2` ([#309](https://github.com/drawbackwards/runladder/issues/309)).
 - `src/lib/skill-version.ts`: Skill bundle (`CURRENT_SKILL_VERSION`, synced into the zip by `scripts/sync-skill-version.mjs`)
 - `src/lib/plugin-version.ts`: Figma plugin bundle
 
@@ -65,7 +65,7 @@ These constants are what runtime code reads. **`package.json`'s `version` field 
 
 **Bump procedure, per user-visible PR:**
 
-1. Bump the relevant constant in `src/lib/*-version.ts` (app and/or api and/or skill — they bump independently).
+1. Bump the relevant constant in `src/lib/*-version.ts` (app and/or api and/or scoring engine and/or skill — they bump independently).
 2. Mirror the new `CURRENT_APP_VERSION` into `package.json`'s `version`.
 3. Add a matching `CHANGELOG.md` entry (`## app X.Y.Z / api A.B.C (date)`).
 4. The same `X.Y.Z` is the version label you put in the Features inventory row and any Decisions/Journeys reference, so a reader can trace a feature → version → changelog → PR in one hop.

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -1,8 +1,8 @@
 ---
 title: Decisions Log
-updatedAt: 2026-06-05
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 288
+lastPr: 322
 ---
 
 ## How to use this page
@@ -12,6 +12,12 @@ The why behind big choices. Read this before you push back on a feature, a price
 If you want to challenge a decision, file an issue in GitHub with the proposed change and link the entry. We update entries when the world changes, never silently.
 
 ---
+
+## Private scoring is a paid feature; paid scores default to private (2026-06-08)
+
+**Rule:** Free accounts cannot save a score privately — their scores are always public on runladder.com. Every paid/team tier (Pro, Team, Pulse) can score privately, and the private toggle **defaults on** so a paid user is never surprised by a public-by-default score. Turning it off shows an inline warning. The label is tier-aware: single users (Free/Pro) see "Private," team-context users (Team/Pulse) see "Internal" (still team-visible). See [Glossary → Score visibility](/hq/glossary#score-visibility).
+
+Why: public free scores feed the Top 100 and the top-of-funnel demo, so "free = public" is a deliberate growth lever, not just a gate. Privacy is part of what paid buys. Defaulting paid users to private respects that they're paying for confidentiality; the off-warning prevents accidental publication. Enforced on the client (toggle gating) **and** the server (`/api/score` + `/api/score/stream` force `isPublic` for free users), so the gate can't be bypassed via the API. Shipped with [#290](https://github.com/drawbackwards/runladder/issues/290) + [#301](https://github.com/drawbackwards/runladder/issues/301).
 
 ## Versioning source of truth (2026-06-04)
 
@@ -24,6 +30,7 @@ How to apply:
 - Treat `src/lib/app-version.ts` as the single source of truth for the web app version. Bump it on every user-visible PR.
 - In the same PR, mirror the new `CURRENT_APP_VERSION` into `package.json`'s `version`, and add a matching `CHANGELOG.md` entry. Use that same `X.Y.Z` as the version label in the Features inventory row.
 - Never read `package.json` `version` at runtime. If you need the app version in code, import `CURRENT_APP_VERSION`.
+- The **scoring engine** now versions independently too: `CURRENT_ENGINE_VERSION` in the same file, surfaced in the footer as "Scoring Engine vX.Y," started at `1.2` ([#309](https://github.com/drawbackwards/runladder/issues/309)). Bump it when scoring behaviour (prompt/rubric/model) changes, separate from the app version.
 - The full bump procedure is in [Architecture → Versioning](/hq/architecture). Reconciled in [PR #277](https://github.com/drawbackwards/runladder/pull/277).
 
 Known follow-up (not resolved here): `features.mdx` and this log reference `v0.5.5` (#200) and `v0.5.6` for client-provisioning work, but those versions have no `CHANGELOG.md` entry and no constant bump — they were labeled ahead of the source of truth. Reconcile by either backfilling changelog entries or relabeling those rows to PR numbers; tracked separately so this PR stays scoped to the version system.

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-05
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 285
+lastPr: 322
 ---
 
 ## How to read this page
@@ -28,6 +28,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
 | Public scoring tool (`/score`) | All signed-in | Live | `src/app/score/` |
+| Private / Internal scoring (paid feature; toggle defaults on for paid, free locked to public, off-warning, tier-aware "Private"/"Internal" label) | Pro / Team / Pulse (free = public only) | Live (v0.5.7, [#290](https://github.com/drawbackwards/runladder/issues/290) / [#301](https://github.com/drawbackwards/runladder/issues/301)) | `src/app/score/page.tsx`, `src/lib/score-scope.ts`, `src/app/api/score/route.ts`, `src/app/api/score/stream/route.ts` |
 | Personal dashboard (`/dashboard`) | All signed-in | Live | `src/app/dashboard/` |
 | Figma install/manage detail page (`/dashboard/figma`) | All signed-in | Live (#273) | `src/app/dashboard/figma/page.tsx`, `src/components/promos/FigmaPromoCard.tsx` |
 | Claude Skill install/manage detail page (`/dashboard/claude`) | All signed-in | Live (#273) | `src/app/dashboard/claude/page.tsx`, `src/components/skill/useSkillInstall.ts`, `src/components/promos/ClaudePromoCard.tsx` |

--- a/src/content/hq/glossary.mdx
+++ b/src/content/hq/glossary.mdx
@@ -1,8 +1,8 @@
 ---
 title: Glossary
-updatedAt: 2026-05-29
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 261
+lastPr: 322
 ---
 
 ## Why this exists
@@ -53,6 +53,16 @@ See [Roles](/hq/roles) for the full matrix. Quick reference:
 | **Pulse User** | Customer on a Pulse engagement. |
 | **Admin** | Internal Drawbackwards admin (Ward, Michael, Jordan). |
 | **Super Admin** | Ward only. |
+
+## Score visibility
+
+How a saved score is exposed. The public/private toggle on the scan screen drives a single `isPublic` flag; the label shown depends on the account ([#290](https://github.com/drawbackwards/runladder/issues/290) / [#301](https://github.com/drawbackwards/runladder/issues/301)).
+
+| Term | Definition |
+| --- | --- |
+| **Public score** | `isPublic = true`. Saved to the dashboard and visible on runladder.com. Free accounts' scores are always public — private scoring is a paid feature. |
+| **Private score** | A non-public score on a single-user account (Free/Pro). Only the owner can see it. Labeled "Private." Free users can't create these. |
+| **Internal score** | A non-public score on a team-context account (Team/Pulse). Same `isPublic = false` flag as Private, but labeled **"Internal"** because it's visible to the team, not just one person. Pulse counts as a team context for labeling even though it doesn't hit the scan toggle yet. |
 
 ## Engagements
 

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,9 +17,16 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.4";
+export const CURRENT_APP_VERSION = "0.5.7";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header
 // so clients can log which contract they hit.
 export const CURRENT_API_VERSION = "1.0.0";
+
+// Ladder scoring engine (the prompt + rubric + model behaviour that turns a
+// screen into a score). Tracked independently of the app and API: the engine
+// can be retuned without an app release, and we want every shipped score to be
+// attributable to an engine version. Surfaced in the footer. Bump on any
+// change to scoring behaviour and add a matching CHANGELOG.md entry.
+export const CURRENT_ENGINE_VERSION = "1.2";

--- a/src/lib/score-scope.ts
+++ b/src/lib/score-scope.ts
@@ -1,0 +1,31 @@
+/**
+ * Visibility label for a non-public score (#301).
+ *
+ * A single-user account (free / pro) keeps a non-public score truly private —
+ * only they can see it, so the badge reads "Private". A team-tier account
+ * shares scores within the organization: a non-public score is still visible
+ * to the team (and Team Leads), so the accurate word is "Internal", not
+ * "Private". The public/private toggle itself is unchanged; this only renames
+ * the not-public state for team accounts.
+ */
+export function privateScopeLabel(isTeam: boolean): "Private" | "Internal" {
+  return isTeam ? "Internal" : "Private";
+}
+
+/**
+ * Whether an account sits in a team/org context for scoring-visibility
+ * purposes. Single users (free / pro) are not; team and pulse accounts are.
+ * Pulse isn't folded into the scan flow yet, but we treat it as a team context
+ * now so labels are correct the moment it is (#290 / #301).
+ */
+export function isTeamScope(tier: string | null | undefined): boolean {
+  return tier === "team" || tier === "pulse";
+}
+
+/**
+ * Whether an account may save a score privately at all. Free accounts cannot —
+ * private scoring is a paid feature (#290). Every paid/team tier can.
+ */
+export function canScorePrivately(tier: string | null | undefined): boolean {
+  return tier === "pro" || tier === "team" || tier === "pulse";
+}


### PR DESCRIPTION
Ships four MVP Launch milestone items together.

## #290 + #301 — Private / Internal scoring (paid feature)
- Scan-screen toggle is tier-aware:
  - **Free**: toggle disabled, locked to public, with an "Upgrade to keep your scores private" prompt.
  - **Pro / Team / Pulse**: toggle **defaults to private**; flipping to public shows an inline warning.
- Tier-aware label everywhere a non-public score shows (dashboard list, score detail, designer detail): single users (free/pro) → **"Private"**, team-context (team/pulse) → **"Internal"**.
- Enforced **client-side and server-side** — `/api/score` and `/api/score/stream` force `isPublic` for free users so the gate can't be bypassed via the API.
- New shared helper `src/lib/score-scope.ts` (`privateScopeLabel`, `isTeamScope`, `canScorePrivately`).

## #309 — Scoring-engine version
- New `CURRENT_ENGINE_VERSION` (scoring algorithm), started at **1.2**, tracked independently of app/API versions.
- Footer now reads **"Scoring Engine v1.2 · App v0.5.7"**.

## #303 — Team dashboard hover fix
- Member-row Archive/Delete actions fade in as the score stats + drill arrow fade out, so the actions no longer overlap the numbers. Gated to rows that have actions.

## Versioning
- App bumped **0.5.4 → 0.5.7** (0.5.5/0.5.6 are reserved by provisioning work #200/#217), `package.json` mirrored, CHANGELOG entry added.

## /hq lockstep
- Architecture (Versioning), Decisions Log (private-scoring decision + engine version), Glossary (Score visibility), Features (private-scoring row). Frontmatter stamped.

## Verification
- `tsc --noEmit` clean. Lint clean on changed files (only the known pre-existing `Date.now()` warning in UpgradeStrip remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)