### PR TITLE
Launch gating (heatmap/eval/reviews) + Team Lead score detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.8 / api 1.0.0 (2026-06-08)
+
+**Launch gating + Team Lead score visibility.**
+
+- **Free tier loses design rhythm + heatmap (#289).** The design-rhythm card and activity heatmap on the personal dashboard are now paid-only (pro/team/pulse). Gate respects the dev "view as" override.
+- **Surface tags on the designer detail page (#299).** Each score row now shows a surface tag (Figma / Claude / Web / Skill / Pulse), parsed from the score name. Extracted the parser into a shared `src/lib/surface.ts` (de-duplicated from the dashboard).
+- **Evaluations + Reviews hidden for launch (#302).** The Evaluations tab (member detail) and the Reviews tab (team dashboard) are hidden behind a single restorable flag, `SHOW_EVALUATIONS_AND_REVIEWS` in `src/lib/feature-flags.ts`.
+- **Team Lead can open a member's score detail (#300).** From the designer detail page, a Team Lead can click any of that member's scores and see the full score detail. The score-detail API (`/api/dashboard/scores/[id]`) accepts `?member=<userId>` and authorizes the cross-user read as `org:admin` + member-in-org (mirroring the member-detail endpoint); soft-deleted scores are included for audit. The detail page reframes the back link + badge for the Team Lead view.
+- **Dev "view as" now drives the scan-screen toggle.** Selecting Free/Pro/Team in the dev switcher exercises the private-scoring toggle states without juggling accounts (UI preview only; saves still use the real server-side tier).
+- `/hq` updated: GTM (Team Lead persona), API (member-scoped score detail), Features (4 rows), Roles (capability matrix).
+
+---
+
 ## app 0.5.7 / api 1.0.0 (2026-06-08)
 
 **Private scoring as a paid feature, scoring-engine versioning, and dashboard polish.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.7",
+  "version": "0.5.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/dashboard/scores/[id]/route.ts
+++ b/src/app/api/dashboard/scores/[id]/route.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { redis } from "@/lib/redis";
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const { userId } = await auth();
+  const { userId, orgId, orgRole } = await auth();
 
   if (!userId) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -14,17 +14,54 @@ export async function GET(
 
   const { id } = await params;
 
-  const scores = await redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true });
+  // A Team Lead can open a score belonging to a member of their team from the
+  // designer detail page (#300). When `?member=<userId>` is present and isn't
+  // the requester, authorize exactly like the member-detail endpoint: the
+  // requester must be org:admin and the member must be in their active org.
+  const memberParam = new URL(req.url).searchParams.get("member");
+  const isTeamLeadView = !!memberParam && memberParam !== userId;
+  let ownerId = userId;
+
+  if (isTeamLeadView) {
+    if (!orgId) {
+      return NextResponse.json({ error: "No active team" }, { status: 404 });
+    }
+    if (orgRole !== "org:admin") {
+      return NextResponse.json(
+        { error: "Team Lead access required" },
+        { status: 403 }
+      );
+    }
+    const client = await clerkClient();
+    const memberships =
+      await client.organizations.getOrganizationMembershipList({
+        organizationId: orgId,
+        limit: 100,
+      });
+    const inOrg = memberships.data.some(
+      (m) => m.publicUserData?.userId === memberParam
+    );
+    if (!inOrg) {
+      return NextResponse.json(
+        { error: "Member not found in this team" },
+        { status: 404 }
+      );
+    }
+    ownerId = memberParam;
+  }
+
+  const scores = await redis.zrange(`user:${ownerId}:scores`, 0, -1, {
+    rev: true,
+  });
 
   for (const entry of scores as string[]) {
     try {
       const parsed = typeof entry === "string" ? JSON.parse(entry) : entry;
       if (parsed.id !== id) continue;
-      // Soft-deleted scores are invisible to the owner. Team admins
-      // view another member's history via /api/dashboard/team/members/
-      // [userId], not this endpoint, so the auth user IS always the
-      // score owner here — 404 is correct.
-      if (parsed.deletedAt) {
+      // Soft-deleted scores are invisible to the owner, but a Team Lead keeps
+      // the audit trail (mirrors the member-detail endpoint), so they may open
+      // a deleted score's detail.
+      if (parsed.deletedAt && !isTeamLeadView) {
         return NextResponse.json({ error: "Score not found" }, { status: 404 });
       }
       return NextResponse.json(parsed);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
 import { privateScopeLabel, isTeamScope } from "@/lib/score-scope";
+import { surfaceParts } from "@/lib/surface";
 import { FigmaPromoCard } from "@/components/promos/FigmaPromoCard";
 import { ClaudePromoCard } from "@/components/promos/ClaudePromoCard";
 import { UsageMeter } from "@/components/UsageMeter";
@@ -250,20 +251,6 @@ function StatsSummaryCard({ stats }: { stats: UserStats }) {
       </div>
     </div>
   );
-}
-
-// Score names carry a surface suffix like "(Figma)" / "(Skill)" (see
-// scores.ts). Strip it from the title and show it as a small gray badge
-// instead of inline text.
-const SURFACE_SUFFIX_RE = /\s*\((figma|skill|web|claude|pulse)\)\s*$/i;
-function surfaceParts(label: string): { name: string; surface: string | null } {
-  const m = label.match(SURFACE_SUFFIX_RE);
-  if (!m) return { name: label, surface: null };
-  const s = m[1].toLowerCase();
-  return {
-    name: label.replace(SURFACE_SUFFIX_RE, "").trim(),
-    surface: s.charAt(0).toUpperCase() + s.slice(1),
-  };
 }
 
 const META_BADGE =
@@ -615,11 +602,14 @@ export default function DashboardPage() {
             <RequestReviewCTA /> here (gated on tier team/pulse) once Reviews
             ships. */}
 
-        {showLoading ? (
-          <DesignRhythmSkeleton />
-        ) : (
-          <DesignRhythmCard scores={scores} />
-        )}
+        {/* Design rhythm + activity heatmap are a paid feature — hidden for
+            free users (#289). Paid tiers (pro/team/pulse) keep both. */}
+        {paid &&
+          (showLoading ? (
+            <DesignRhythmSkeleton />
+          ) : (
+            <DesignRhythmCard scores={scores} />
+          ))}
 
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_340px] gap-8 items-start">
           <main>

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -91,13 +91,23 @@ export default function ScoreDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [recent, setRecent] = useState<RecentScore[]>([]);
+  // Set when a Team Lead opens this score from a designer's detail page
+  // (?member=<userId>). Drives the authorized fetch + the back link (#300).
+  const [memberId, setMemberId] = useState<string | null>(null);
 
   useEffect(() => {
     if (!isSignedIn) return;
 
+    const member =
+      typeof window !== "undefined"
+        ? new URLSearchParams(window.location.search).get("member")
+        : null;
+    setMemberId(member);
+
     async function fetchScore() {
       try {
-        const res = await fetch(`/api/dashboard/scores/${params.id}`);
+        const qs = member ? `?member=${encodeURIComponent(member)}` : "";
+        const res = await fetch(`/api/dashboard/scores/${params.id}${qs}`);
         if (!res.ok) throw new Error("Score not found");
         const json = await res.json();
         setData(json);
@@ -109,6 +119,9 @@ export default function ScoreDetailPage() {
     }
 
     async function fetchRecent() {
+      // The recent strip shows the viewer's own scores — irrelevant (and
+      // confusing) when a Team Lead is viewing a member's score.
+      if (member) return;
       try {
         const res = await fetch("/api/dashboard");
         if (!res.ok) return;
@@ -164,12 +177,15 @@ export default function ScoreDetailPage() {
 
         {/* Back + meta */}
         <div className="flex items-center justify-between mb-8 gap-4 flex-wrap">
-          <Link href="/dashboard" className="text-[11px] text-muted uppercase tracking-widest hover:text-foreground transition-colors">
-            &larr; Dashboard
+          <Link
+            href={memberId ? `/dashboard/team/members/${memberId}` : "/dashboard"}
+            className="text-[11px] text-muted uppercase tracking-widest hover:text-foreground transition-colors"
+          >
+            &larr; {memberId ? "Back to designer" : "Dashboard"}
           </Link>
           <div className="flex items-center gap-3">
             <span className="text-[10px] uppercase tracking-widest text-ladder-green border border-ladder-green/30 bg-ladder-green/5 px-2 py-0.5">
-              ✓ Saved to your dashboard
+              {memberId ? "Team member's score" : "✓ Saved to your dashboard"}
             </span>
             <span className={`text-[9px] uppercase tracking-widest px-2 py-0.5 border ${
               data.isPublic

--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -5,6 +5,8 @@ import { useParams } from "next/navigation";
 import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
+import { surfaceParts } from "@/lib/surface";
+import { SHOW_EVALUATIONS_AND_REVIEWS } from "@/lib/feature-flags";
 import {
   ActivityHeatmap,
   type DailyActivity,
@@ -113,11 +115,24 @@ function StatPill({
   );
 }
 
-function ScoreRow({ entry }: { entry: ScoreEntry }) {
+function ScoreRow({
+  entry,
+  memberUserId,
+}: {
+  entry: ScoreEntry;
+  memberUserId: string;
+}) {
   const isDeleted = typeof entry.deletedAt === "number";
+  // Clean display name + the surface it was scored on (#299).
+  const { name: displayName, surface } = surfaceParts(
+    entry.screenName || entry.source,
+  );
+  // The Team Lead can open any of this designer's scores (#300). The detail
+  // page authorizes the cross-user read via the ?member param.
   return (
-    <div
-      className={`border transition-colors ${
+    <Link
+      href={`/dashboard/scores/${entry.id}?member=${memberUserId}`}
+      className={`block border transition-colors ${
         isDeleted
           ? // Faded + dashed border for audit-only entries the member
             // has removed from their own view.
@@ -163,8 +178,15 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
                   : "text-foreground"
               }`}
             >
-              {entry.screenName || entry.source}
+              {displayName}
             </p>
+            {/* Surface tag — where the score was made (Figma / Claude / Web /
+                Skill / Pulse), parsed from the name suffix (#299). */}
+            {surface && (
+              <span className="text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5 flex-shrink-0">
+                {surface}
+              </span>
+            )}
             {isDeleted && (
               <span
                 className="text-[8px] uppercase tracking-widest border px-1.5 py-0.5 flex-shrink-0"
@@ -211,7 +233,7 @@ function ScoreRow({ entry }: { entry: ScoreEntry }) {
           </p>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }
 
@@ -426,12 +448,15 @@ export default function TeamMemberDetailPage() {
             active={tab === "design"}
             onClick={() => setTab("design")}
           />
-          <TabButton
-            label="Evaluations"
-            count={evaluation.scores.length}
-            active={tab === "evaluation"}
-            onClick={() => setTab("evaluation")}
-          />
+          {/* Evaluations hidden for launch (#302). */}
+          {SHOW_EVALUATIONS_AND_REVIEWS && (
+            <TabButton
+              label="Evaluations"
+              count={evaluation.scores.length}
+              active={tab === "evaluation"}
+              onClick={() => setTab("evaluation")}
+            />
+          )}
           <span className="ml-auto pb-3 text-[10px] text-muted">
             {tab === "design"
               ? "Their own design work"
@@ -536,7 +561,7 @@ export default function TeamMemberDetailPage() {
         ) : (
           <div className="space-y-1.5">
             {bucket.scores.map((entry) => (
-              <ScoreRow key={entry.id} entry={entry} />
+              <ScoreRow key={entry.id} entry={entry} memberUserId={userId ?? ""} />
             ))}
           </div>
         )}

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -21,6 +21,7 @@ import {
   ActiveReviewsList,
 } from "@/components/reviews/ReviewsOverview";
 import { TabButton } from "@/components/Tabs";
+import { SHOW_EVALUATIONS_AND_REVIEWS } from "@/lib/feature-flags";
 import { SectionLabel } from "@/components/SectionLabel";
 import { Skeleton } from "@/components/Skeleton";
 import { useEnsureActiveOrg } from "@/hooks/use-ensure-active-org";
@@ -974,12 +975,15 @@ export default function TeamPage() {
             active={teamTab === "members"}
             onClick={() => setTeamTab("members")}
           />
-          <TabButton
-            label="Reviews"
-            badge="Beta"
-            active={teamTab === "reviews"}
-            onClick={() => setTeamTab("reviews")}
-          />
+          {/* Reviews hidden for launch (#302). */}
+          {SHOW_EVALUATIONS_AND_REVIEWS && (
+            <TabButton
+              label="Reviews"
+              badge="Beta"
+              active={teamTab === "reviews"}
+              onClick={() => setTeamTab("reviews")}
+            />
+          )}
         </div>
 
         {/* Reviews tab. Team Lead sees the live panels; designers get a

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, Suspense } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth, useUser, useOrganization, SignUpButton } from "@clerk/nextjs";
 import { canScorePrivately as tierCanScorePrivately, isTeamScope } from "@/lib/score-scope";
+import { useViewAs } from "@/lib/dev/view-as";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
@@ -302,12 +303,17 @@ export default function ScorePage() {
   const router = useRouter();
   const { isSignedIn, isLoaded } = useAuth();
   const { user, isLoaded: userLoaded } = useUser();
+  const viewAs = useViewAs();
   // Tier drives private-scoring access + labeling (#290 / #301). Free can't
   // score privately; paid tiers default to private; team/pulse label it
-  // "Internal" rather than "Private".
-  const tier = (user?.publicMetadata as { tier?: string } | undefined)?.tier;
-  const canScorePrivately = tierCanScorePrivately(tier);
-  const internalScope = isTeamScope(tier);
+  // "Internal" rather than "Private". In dev "view as", the switcher's plan
+  // overrides the real Clerk tier so the toggle states can be exercised
+  // without juggling accounts (useViewAs returns null in production).
+  const realTier = (user?.publicMetadata as { tier?: string } | undefined)
+    ?.tier;
+  const effectiveTier = viewAs ? viewAs.plan : realTier;
+  const canScorePrivately = tierCanScorePrivately(effectiveTier);
+  const internalScope = isTeamScope(effectiveTier);
   // Active Clerk organization = the user is currently scoring in a team
   // context. Only team members ever see the design/evaluation session
   // prompt — for free/Pro users the bucketing has no surface to show up
@@ -350,17 +356,14 @@ export default function ScorePage() {
   const fileRef = useRef<HTMLInputElement>(null);
   // Guards the one-shot claim of a pending anonymous score after sign-up.
   const claimedRef = useRef(false);
-  // Guards the one-shot tier-based privacy default so it doesn't clobber a
-  // manual toggle on later re-renders (#290).
-  const privacyDefaultApplied = useRef(false);
-
-  // Paid tiers (pro/team/pulse) default to a private score; free users stay
-  // public and can't change it. Applied once, after the Clerk user (and thus
-  // tier) has loaded, so it doesn't override a manual toggle.
+  // Default the toggle to the tier-appropriate state once the tier is known:
+  // paid tiers (pro/team/pulse) default to private, free is forced public.
+  // Keyed on canScorePrivately so a dev "view as" plan switch re-applies the
+  // default; in production the tier is stable after load, so this runs once
+  // and never clobbers a later manual toggle.
   useEffect(() => {
-    if (!userLoaded || !user || privacyDefaultApplied.current) return;
-    privacyDefaultApplied.current = true;
-    if (canScorePrivately) setIsPublic(false);
+    if (!userLoaded || !user) return;
+    setIsPublic(!canScorePrivately);
   }, [userLoaded, user, canScorePrivately]);
 
   // Recent-scores list source:

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -1,8 +1,8 @@
 ---
 title: API Protocols
-updatedAt: 2026-05-27
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 229
+lastPr: 323
 ---
 
 ## Two surfaces, one to come
@@ -23,7 +23,7 @@ All endpoints below are real routes in this repo. Find them under `src/app/api/`
 | `/api/top-100` | GET | Public | Top 100 listing. |
 | `/api/dashboard` | GET | Clerk session | Personal dashboard data. |
 | `/api/dashboard/scores` | GET | Clerk session | User's score history. |
-| `/api/dashboard/scores/[id]` | GET | Clerk session | Individual score detail. |
+| `/api/dashboard/scores/[id]` | GET | Clerk session | Individual score detail. Owner by default; a Team Lead can pass `?member=<userId>` to read a score owned by a member of their active org (authorized as `org:admin` + member-in-org, mirroring the member-detail endpoint). Team Leads also receive soft-deleted scores for audit (#300). |
 | `/api/dashboard/scores/[id]/annotations` | GET, POST | Clerk session | Reviews pin annotations. |
 | `/api/dashboard/team` | GET | Clerk Org (team) | Team dashboard data. |
 | `/api/skill/token` | POST | Clerk session | Issue a Skill token for use in Claude.ai. |

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 322
+lastPr: 323
 ---
 
 ## How to read this page
@@ -30,6 +30,10 @@ When you ship a feature, add the row here in the same PR. Template:
 | Public scoring tool (`/score`) | All signed-in | Live | `src/app/score/` |
 | Private / Internal scoring (paid feature; toggle defaults on for paid, free locked to public, off-warning, tier-aware "Private"/"Internal" label) | Pro / Team / Pulse (free = public only) | Live (v0.5.7, [#290](https://github.com/drawbackwards/runladder/issues/290) / [#301](https://github.com/drawbackwards/runladder/issues/301)) | `src/app/score/page.tsx`, `src/lib/score-scope.ts`, `src/app/api/score/route.ts`, `src/app/api/score/stream/route.ts` |
 | Personal dashboard (`/dashboard`) | All signed-in | Live | `src/app/dashboard/` |
+| Design rhythm + activity heatmap on personal dashboard (paid only) | Pro / Team / Pulse | Live (#289) | `src/app/dashboard/page.tsx` (gated on `paid`) |
+| Designer detail page: per-score surface tag (Figma/Claude/Web/Skill/Pulse) | Team Lead | Live (#299) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/lib/surface.ts` |
+| Team Lead opens a member's score detail from the designer page | Team Lead | Live (#300) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/app/dashboard/scores/[id]/page.tsx`, `src/app/api/dashboard/scores/[id]/route.ts` |
+| Evaluations (member detail) + Reviews (team) tabs | — | Hidden for launch (#302) | `src/lib/feature-flags.ts` (`SHOW_EVALUATIONS_AND_REVIEWS`); supersedes the "Reviews" rows below until relaunch |
 | Figma install/manage detail page (`/dashboard/figma`) | All signed-in | Live (#273) | `src/app/dashboard/figma/page.tsx`, `src/components/promos/FigmaPromoCard.tsx` |
 | Claude Skill install/manage detail page (`/dashboard/claude`) | All signed-in | Live (#273) | `src/app/dashboard/claude/page.tsx`, `src/components/skill/useSkillInstall.ts`, `src/components/promos/ClaudePromoCard.tsx` |
 | Framework page (`/framework`) | Public | Live | `src/app/framework/` |

--- a/src/content/hq/gtm.mdx
+++ b/src/content/hq/gtm.mdx
@@ -1,8 +1,8 @@
 ---
 title: Go-to-Market Strategy
-updatedAt: 2026-05-19
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 179
+lastPr: 323
 ---
 
 ## How to read this page
@@ -49,6 +49,15 @@ Secondary archetypes (for prioritization, not equal weight):
 - **Developer / AI-tooling teams** integrating the MCP and API into their own agent workflows.
 
 We do not chase: enterprise design system buyers (out of scope), pure accessibility-only buyers (wrong wedge), pre-launch startups without traction (no signal to score against).
+
+## Persona: the Team Lead (#294)
+
+The **Team Lead** (the `org:admin` on a Team engagement) is usually **not a designer**. More often they're a PM, eng manager, or founder who has been handed a design team to manage and has no framework for judging design quality. They feel the pain (shipping work they can't confidently assess) but lack the vocabulary to act on it.
+
+Implications:
+- **Product:** the team dashboard must make quality legible to a non-designer — scores, trends, and "is this getting better" at a glance, not design jargon. The Team Lead reads the dashboard to manage, not to critique pixels.
+- **Messaging:** speak to the manager who needs accountability and a shared standard, not to the craft-obsessed IC. "Know whether your team's work is getting better" over "annotate your redlines."
+- **Open question (not yet decided):** does the marketing site need copy changes to address this manager-not-designer persona directly? Flagged for Ward — this entry documents the persona; any homepage/pricing copy revision is a separate, owner-approved change, not made here.
 
 ## The funnel
 

--- a/src/content/hq/roles.mdx
+++ b/src/content/hq/roles.mdx
@@ -1,8 +1,8 @@
 ---
 title: Roles
-updatedAt: 2026-06-05
+updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 285
+lastPr: 323
 ---
 
 ## End-user roles
@@ -39,6 +39,7 @@ These gate access to platform internals. Email-based allowlist defined in `src/l
 | UX copywriting | - | Yes | Yes | Yes | Yes | Yes | Yes |
 | Personal dashboard | Basic | Enhanced | Enhanced | Enhanced | Enhanced | Yes | Yes |
 | Team dashboard + leaderboard | - | - | View | Manage | - | View | Manage |
+| Open a team member's score detail | - | - | - | Yes | - | Yes | Yes |
 | Pulse dashboard (in `ladder-beta`) | - | - | - | - | Yes | View | View |
 | Invite team members | - | - | - | Yes | - | - | Yes |
 | `/admin` console | - | - | - | - | - | Yes | Yes |

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,7 +17,7 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.7";
+export const CURRENT_APP_VERSION = "0.5.8";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,11 @@
+/**
+ * Launch-time feature flags. Keep these few and well-commented — each one is a
+ * thing we deliberately hid for the MVP launch and intend to restore.
+ */
+
+/**
+ * #302 — Evaluations (member-detail tab) and Reviews (team-dashboard tab) are
+ * hidden for the MVP launch. The code stays in place; flip this to `true` to
+ * bring both tabs back once the features are ready to show customers.
+ */
+export const SHOW_EVALUATIONS_AND_REVIEWS = false;

--- a/src/lib/surface.ts
+++ b/src/lib/surface.ts
@@ -1,0 +1,22 @@
+/**
+ * Score names carry a surface suffix like "Login (Figma)" / "Onboarding
+ * (Skill)" (added in scores.ts when a score is persisted). This module strips
+ * that suffix from the display name and exposes the surface so a UI can render
+ * it as a tag instead of inline text (#299).
+ *
+ * Recognized surfaces: figma, skill (Ladder for Claude), web, claude, pulse.
+ */
+export const SURFACE_SUFFIX_RE = /\s*\((figma|skill|web|claude|pulse)\)\s*$/i;
+
+export function surfaceParts(label: string): {
+  name: string;
+  surface: string | null;
+} {
+  const m = label.match(SURFACE_SUFFIX_RE);
+  if (!m) return { name: label, surface: null };
+  const s = m[1].toLowerCase();
+  return {
+    name: label.replace(SURFACE_SUFFIX_RE, "").trim(),
+    surface: s.charAt(0).toUpperCase() + s.slice(1),
+  };
+}


### PR DESCRIPTION
Five MVP Launch milestone items, building on #322.

## #289 — Free tier loses design rhythm + heatmap
Design-rhythm card + activity heatmap on the personal dashboard are now paid-only (pro/team/pulse). Gate uses `paid` from `effectiveData`, so the dev "view as" switcher exercises it.

## #299 — Surface tags on the designer detail page
Each score row shows a surface tag (Figma / Claude / Web / Skill / Pulse), parsed from the score name. Parser extracted to a shared `src/lib/surface.ts` (de-duplicated from the dashboard).

## #302 — Evaluations + Reviews hidden for launch
The Evaluations tab (member detail) and Reviews tab (team dashboard) are hidden behind one restorable flag, `SHOW_EVALUATIONS_AND_REVIEWS` (`src/lib/feature-flags.ts`). Flip to `true` to restore both.

## #300 — Team Lead can open a member's score detail
From the designer detail page, a Team Lead clicks any of that member's scores → full score detail. `/api/dashboard/scores/[id]` accepts `?member=<userId>` and authorizes the cross-user read as **`org:admin` + member-in-org** (mirrors the member-detail endpoint). Soft-deleted scores are included for audit. The detail page reframes the back link + badge for the lead view. Reuses the existing detail page (no new page).

## Dev "view as" → scan toggle
Selecting Free/Pro/Team in the dev switcher now drives the private-scoring toggle states (UI preview only — saves still enforce on the real server-side tier).

## Versioning
App **0.5.7 → 0.5.8**, package.json mirrored, CHANGELOG entry added.

## /hq lockstep
GTM (Team Lead persona, #294), API (member-scoped score detail), Features (4 rows), Roles (capability matrix). Frontmatter stamped.

## Verification
`tsc --noEmit` clean. Lint clean on changed files (only the known pre-existing `Date.now()` warning in UpgradeStrip remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)