### PR TITLE
docs(hq): sync journeys with launch gating + Team Lead score drill-in

### DIFF
--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 321
+lastPr: 324
 ---
 
 ## How to read this page
@@ -54,8 +54,9 @@ After provisioning, the Team Lead gets the `org:admin` invite. On accept, the fi
 1. Land on `/dashboard/team` with an empty roster. The page **activates their org** (`setActive`) on first visit if no org is the session's active one — before #190, self-serve `CreateOrganization` set the org active automatically; the invite-based flow does not, so without this the page hung on "Loading your team…".
 2. Invite designers by email. Clerk Organization handles the invite.
 3. Accepted invitees auto-get a `tier: team` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
-4. The team page is organized into two tabs (#274): **Team** (member roster with letter grades A–F, the Team Pool meter, and Invite) and **Reviews** (Beta). The Team Pool box mirrors the dashboard Usage meter — used/limit, monthly reset, hard cap, and a soft-cap tick. Designers see the same tabs; their Reviews tab shows a coming-soon placeholder. The page's top "Team" plan strip was removed (#274; comp-expiry surfacing tracked in #196).
-5. Reviews flow: the Reviews tab (Lead) shows the Review Requests inbox plus the reviews overview — the same content as the dedicated `/dashboard/reviews` route, via shared components (`ReviewsIntro` / `ReviewsStats` / `ActiveReviewsList`) so the two don't drift. A designer requests a review, the Team Lead accepts or declines, the designer scores iterations in `/dashboard/reviews/[slug]`, and the Team Lead and peers add Team Takes and pin annotations.
+4. The team page is organized into two tabs (#274): **Team** (member roster with letter grades A–F, the Team Pool meter, and Invite) and **Reviews** (Beta). **For the MVP launch the Reviews tab is hidden (#302)** — only the Team tab renders; restore both Reviews and the member-detail Evaluations tab by flipping `SHOW_EVALUATIONS_AND_REVIEWS` in `src/lib/feature-flags.ts`. The Team Pool box mirrors the dashboard Usage meter — used/limit, monthly reset, hard cap, and a soft-cap tick. The page's top "Team" plan strip was removed (#274; comp-expiry surfacing tracked in #196).
+5. Drill into a designer: clicking a roster member opens their detail page (scores, stats, activity heatmap, per-score surface tags #299). The Team Lead can click **any of that designer's scores** to open the full score detail (#300) — the score-detail page authorizes the cross-user read via `?member=<userId>` (`org:admin` + member-in-org). The member-detail Evaluations tab is hidden for launch (#302); only Design sessions show.
+6. Reviews flow (**hidden for launch, #302**): the Reviews tab (Lead) shows the Review Requests inbox plus the reviews overview — the same content as the dedicated `/dashboard/reviews` route, via shared components (`ReviewsIntro` / `ReviewsStats` / `ActiveReviewsList`) so the two don't drift. A designer requests a review, the Team Lead accepts or declines, the designer scores iterations in `/dashboard/reviews/[slug]`, and the Team Lead and peers add Team Takes and pin annotations.
 
 See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipped Reviews features.
 


### PR DESCRIPTION
Post-merge `/hq` verification for #323 surfaced two stale spots in User Journeys:

- The **Reviews** tab (team) and **Evaluations** tab (member detail) are hidden for launch (#302). Journeys now notes this and points at the `SHOW_EVALUATIONS_AND_REVIEWS` restore flag.
- The Team Lead can now **drill into a designer's score detail** (#300) and sees **per-score surface tags** (#299). Added as a step in the Team Lead flow.

Docs-only follow-up to keep `/hq` in lockstep with shipped code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)