### PR TITLE
#302 follow-up: hide score-screen session-type prompt + pill (Evaluations)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.9 / api 1.0.0 (2026-06-08)
+
+**Fully hide the Evaluations concept for launch (#302, follow-up).**
+
+- The score screen no longer shows the "What kind of session is this?" prompt or the top-right session-type pill — every score is logged as a design session. This completes #302: the design-vs-evaluation "Evaluations" concept (prompt + pill on the score screen, member-detail Evaluations tab, team Reviews tab) is gone from the customer-facing app for launch, all behind the single `SHOW_EVALUATIONS_AND_REVIEWS` flag.
+- The internal admin tool at `/admin/evaluations` (client evaluation reports) is a separate feature and is intentionally left intact.
+- `/hq` updated: Features (#302 row expanded to cover the score-screen pieces).
+
+---
+
 ## app 0.5.8 / api 1.0.0 (2026-06-08)
 
 **Launch gating + Team Lead score visibility.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useAuth, useUser, useOrganization, SignUpButton } from "@clerk/nextjs";
 import { canScorePrivately as tierCanScorePrivately, isTeamScope } from "@/lib/score-scope";
 import { useViewAs } from "@/lib/dev/view-as";
+import { SHOW_EVALUATIONS_AND_REVIEWS } from "@/lib/feature-flags";
 import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
 import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
@@ -670,7 +671,11 @@ export default function ScorePage() {
   // Free, Pro, and Pulse users scoring outside a team context don't
   // need to declare intent. The pill that lets you change session
   // type is gated on the same condition below.
+  // Evaluations (the design-vs-evaluation session concept) are hidden for
+  // launch (#302) — the prompt + pill never render, so every score is logged
+  // as a design session. Restore via SHOW_EVALUATIONS_AND_REVIEWS.
   const showSessionTypePrompt =
+    SHOW_EVALUATIONS_AND_REVIEWS &&
     isLoaded &&
     isSignedIn &&
     onTeam &&
@@ -724,7 +729,7 @@ export default function ScorePage() {
           </div>
         )}
 
-        {isLoaded && isSignedIn && onTeam && sessionType && !result && !loading && !capturing && (
+        {SHOW_EVALUATIONS_AND_REVIEWS && isLoaded && isSignedIn && onTeam && sessionType && !result && !loading && !capturing && (
           <div className="flex justify-end mb-4">
             <SessionTypePill type={sessionType} onChange={clearSessionType} />
           </div>

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-06-08
 updatedBy: Sara
-lastPr: 323
+lastPr: 325
 ---
 
 ## How to read this page
@@ -33,7 +33,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Design rhythm + activity heatmap on personal dashboard (paid only) | Pro / Team / Pulse | Live (#289) | `src/app/dashboard/page.tsx` (gated on `paid`) |
 | Designer detail page: per-score surface tag (Figma/Claude/Web/Skill/Pulse) | Team Lead | Live (#299) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/lib/surface.ts` |
 | Team Lead opens a member's score detail from the designer page | Team Lead | Live (#300) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/app/dashboard/scores/[id]/page.tsx`, `src/app/api/dashboard/scores/[id]/route.ts` |
-| Evaluations (member detail) + Reviews (team) tabs | — | Hidden for launch (#302) | `src/lib/feature-flags.ts` (`SHOW_EVALUATIONS_AND_REVIEWS`); supersedes the "Reviews" rows below until relaunch |
+| Evaluations concept hidden for launch: score-screen session-type prompt + pill, member-detail Evaluations tab, team Reviews tab (all scores log as "design") | — | Hidden for launch (#302) | `src/lib/feature-flags.ts` (`SHOW_EVALUATIONS_AND_REVIEWS`), `src/app/score/page.tsx`, `src/app/dashboard/team/members/[userId]/page.tsx`, `src/app/dashboard/team/page.tsx`; supersedes the "Reviews" rows below until relaunch. Admin `/admin/evaluations` (client reports) is a separate tool, left intact. |
 | Figma install/manage detail page (`/dashboard/figma`) | All signed-in | Live (#273) | `src/app/dashboard/figma/page.tsx`, `src/components/promos/FigmaPromoCard.tsx` |
 | Claude Skill install/manage detail page (`/dashboard/claude`) | All signed-in | Live (#273) | `src/app/dashboard/claude/page.tsx`, `src/components/skill/useSkillInstall.ts`, `src/components/promos/ClaudePromoCard.tsx` |
 | Framework page (`/framework`) | Public | Live | `src/app/framework/` |

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,7 +17,7 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.8";
+export const CURRENT_APP_VERSION = "0.5.9";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
Completes #302. The customer-facing **Evaluations** concept (the design-vs-evaluation session type) isn't ready for launch, and it surfaced on more than the two tabs hidden in #323.

This removes the remaining pieces on the **score screen**:
- The "What kind of session is this?" prompt (`SessionTypeModal`)
- The top-right session-type pill (`SessionTypePill`)

Both are gated behind the existing `SHOW_EVALUATIONS_AND_REVIEWS` flag, so every score is now logged as a **design** session. Combined with the already-hidden member-detail Evaluations tab and team Reviews tab, the concept is fully gone from the customer-facing app for launch and trivially restorable.

**Scope:** customer-facing only (per Chester). The internal admin tool at `/admin/evaluations` (client evaluation reports) is a separate feature and is left intact.

## Versioning
App **0.5.8 → 0.5.9**, package.json mirrored, CHANGELOG entry added.

## /hq lockstep
Features (#302 row expanded to cover the score-screen pieces + note the admin tool is separate).

## Verification
`tsc --noEmit` clean; lint clean on the score page (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)