### PR TITLE
Heatmap: local-day buckets + timezone-safe friendly tooltip dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.11 / api 1.0.0 (2026-06-08)
+
+**Design-rhythm heatmap: local-day buckets + friendlier tooltips.**
+
+- `bucketActivity` now buckets scores by the viewer's **local** calendar day instead of UTC. UTC bucketing was a latent off-by-one for scores made near midnight or outside US timezones (it could collapse two days into one, or label a cell with the wrong day). Active Days, Sessions, and the heatmap all key off local days now.
+- Heatmap tooltips show a friendly, timezone-safe date ("Jun 2, 2026") instead of the raw ISO string. The date is parsed from local parts so it never shifts a day under `toLocaleDateString`.
+- No data change; existing scores re-bucket correctly. (The "Active Days = 1" report was a stale dashboard view — the underlying data was always 2 distinct days.)
+
+---
+
 ## app 0.5.10 / api 1.0.0 (2026-06-08)
 
 **Admin archive-not-delete, client usage, and score-detail/admin polish.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -41,7 +41,6 @@ type ScoreEntry = {
   sessionType?: "design" | "evaluation";
 };
 
-const DAY_MS = 24 * 60 * 60 * 1000;
 const RHYTHM_WINDOW_DAYS = 91;
 
 /**
@@ -53,25 +52,27 @@ function bucketActivity(
   scores: ScoreEntry[],
   windowDays: number,
 ): DailyActivity[] {
-  const todayMidnight = (() => {
-    const d = new Date();
-    return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-  })();
+  // Bucket by the viewer's LOCAL calendar day, not UTC. With UTC bucketing,
+  // scores logged late one evening and the next morning can land in the same
+  // UTC day and collapse into a single "active day" (#327). This runs in the
+  // browser, so local Date getters reflect the user's timezone. Day math
+  // decrements the date field (not a fixed 24h offset) so DST transitions
+  // don't shift bucket boundaries.
+  const localKey = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(
+      d.getDate(),
+    ).padStart(2, "0")}`;
 
-  const buckets = new Map<number, { count: number; total: number }>();
+  const now = new Date();
+  const buckets = new Map<string, { count: number; total: number }>();
   for (let i = windowDays - 1; i >= 0; i--) {
-    buckets.set(todayMidnight - i * DAY_MS, { count: 0, total: 0 });
+    const day = new Date(now.getFullYear(), now.getMonth(), now.getDate() - i);
+    buckets.set(localKey(day), { count: 0, total: 0 });
   }
 
   for (const s of scores) {
     if (typeof s.timestamp !== "number") continue;
-    const d = new Date(s.timestamp);
-    const dayMidnight = Date.UTC(
-      d.getUTCFullYear(),
-      d.getUTCMonth(),
-      d.getUTCDate(),
-    );
-    const bucket = buckets.get(dayMidnight);
+    const bucket = buckets.get(localKey(new Date(s.timestamp)));
     if (!bucket) continue;
     bucket.count += 1;
     if (typeof s.score === "number" && Number.isFinite(s.score)) {
@@ -80,9 +81,9 @@ function bucketActivity(
   }
 
   return Array.from(buckets.entries())
-    .sort((a, b) => a[0] - b[0])
-    .map(([ts, b]) => ({
-      date: new Date(ts).toISOString().slice(0, 10),
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([date, b]) => ({
+      date,
       count: b.count,
       avgScore: b.count > 0 ? Math.round((b.total / b.count) * 10) / 10 : null,
     }));

--- a/src/components/ActivityHeatmap.tsx
+++ b/src/components/ActivityHeatmap.tsx
@@ -1,13 +1,28 @@
 "use client";
 
 export type DailyActivity = {
-  /** YYYY-MM-DD (UTC) */
+  /** YYYY-MM-DD in the viewer's local day (see bucketActivity). */
   date: string;
   /** Number of scores logged that day. */
   count: number;
   /** Average score for the day, or null if no scores. */
   avgScore: number | null;
 };
+
+/**
+ * Format a YYYY-MM-DD day string for a tooltip without a timezone shift.
+ * `new Date("2026-06-02")` parses as UTC midnight and renders as the previous
+ * day in behind-UTC zones; building the Date from local parts avoids that.
+ */
+function friendlyDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  return new Date(y, m - 1, d).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
 
 /**
  * GitHub-style activity grid for a member's last N days of scoring.
@@ -79,7 +94,7 @@ export function ActivityHeatmap({
           {week.map((cell, di) => {
             const intensity = intensityClass(cell?.count ?? 0);
             const titleText = cell
-              ? `${cell.date}: ${cell.count} score${cell.count === 1 ? "" : "s"}${
+              ? `${friendlyDate(cell.date)}: ${cell.count} score${cell.count === 1 ? "" : "s"}${
                   cell.avgScore !== null ? ` · avg ${cell.avgScore.toFixed(1)}` : ""
                 }`
               : undefined;

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,7 +17,7 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.10";
+export const CURRENT_APP_VERSION = "0.5.11";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
Follow-up to the "Active Days / odd hover dates" report.

**What I found (verified against prod data):**
- The "Active Days = 1" was a **stale dashboard view** — `chester@drawbackwards.com` has exactly 2 scores on 2 distinct local days (May 29 + June 2), both `design`, both in-window. After a hard refresh it correctly shows **Active Days: 2**. No count bug.
- The hover dates read "odd" because the tooltip showed the **raw ISO string** (`2026-06-02`) and cells were bucketed/labeled by **UTC day** — a latent off-by-one for scores near midnight or outside US timezones.

**Fix:**
- `bucketActivity` buckets by the viewer's **local** calendar day (DST-safe day math) instead of UTC — corrects Active Days / Sessions / heatmap for edge cases.
- `ActivityHeatmap` tooltips show a **timezone-safe friendly date** ("Jun 2, 2026"), parsed from local parts so `toLocaleDateString` never shifts a day.

Benefits both the personal dashboard rhythm card and the member-detail heatmap.

App **0.5.10 → 0.5.11**, CHANGELOG entry. No `/hq` consequence (refines existing behavior).

`tsc` clean; `friendlyDate` verified TZ-safe in US-Pacific and UTC+ zones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)