### PR TITLE
fix(#307): hide Clerk "Last used" badge on Google sign-in button

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -285,6 +285,15 @@ h1, h2, h3, h4, h5, h6 {
   border-radius: 0 !important;
 }
 
+/* Clerk renders a "Last used" badge on the social sign-in button for whichever
+   provider you authenticated with last. It's absolutely positioned and straddles
+   the rounded button's top-right edge, so it reads as a clipped visual artifact
+   ("Last u…") rather than a label. We don't want a last-used hint here — hide it
+   on the social buttons only (profile/account badges are unaffected). See #307. */
+.cl-socialButtonsBlockButton .cl-badge {
+  display: none !important;
+}
+
 /* ─ Form inputs ─ */
 .cl-formFieldInput,
 .cl-phoneNumberInput,

--- a/src/lib/clerkAuthAppearance.ts
+++ b/src/lib/clerkAuthAppearance.ts
@@ -29,7 +29,7 @@ export const authAppearance = {
     main: "!gap-4",
     socialButtons: "!gap-2",
     socialButtonsBlockButton:
-      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !py-3 !shadow-none !overflow-hidden !relative",
+      "!bg-card !border !border-border !text-foreground hover:!bg-card-hover !rounded-full !py-3 !shadow-none",
     socialButtonsBlockButtonText: "!text-foreground !font-medium !text-sm",
     socialButtonsProviderIcon: "!w-4 !h-4",
     dividerLine: "!bg-border",


### PR DESCRIPTION
## What

The "Last used" badge Clerk stamps on the last-used social button is absolutely positioned over the rounded button's top-right corner, so it rendered as a clipped `Last u…` sliver instead of a clean label (the artifact reported in #307).

PR #110 tried to suppress it with `!overflow-hidden !relative` on the button, but that only truncated the badge horizontally rather than removing it — so it kept reappearing.

## Change

- `globals.css` — hide the badge on social buttons only (`.cl-socialButtonsBlockButton .cl-badge`). Account/profile badges are untouched.
- `clerkAuthAppearance.ts` — drop the now-unneeded `!overflow-hidden !relative` band-aid.

## Notes

- The badge only renders when that provider was the last-used sign-in method in the browser's Clerk cookies, so it's not reproducible in every session. tsc is clean.
- The separate question in #307 — Google's "You're signing back in" screen after disconnecting — is expected behavior: disconnecting in Settings unlinks inside Clerk but does not revoke the OAuth grant on Google's side. No code change needed for that.

No `/hq` doc consequence: cosmetic auth-UI fix, no feature/journey/API/decision change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)