### PR TITLE
feat(#330): centralize all-surface feedback in Admin → Feedback

### DIFF
--- a/src/app/admin/(tabbed)/feedback/page.tsx
+++ b/src/app/admin/(tabbed)/feedback/page.tsx
@@ -3,6 +3,11 @@
 import { useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import { getScoreColor } from "@/lib/ladder";
+import { surfaceParts } from "@/lib/surface";
+
+// Surface chip (Web / Figma / Skill / …) — matches the dashboard score-row badge.
+const SURFACE_BADGE =
+  "flex-shrink-0 text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5";
 
 type FeedbackEntry = {
   scoreId: string;
@@ -172,9 +177,14 @@ export default function AdminFeedbackPage() {
                       </p>
                     </div>
                     <div className="flex-1 min-w-0">
-                      <p className="text-sm text-foreground font-sans truncate">
-                        {e.screenName || "Untitled screen"}
-                      </p>
+                      <div className="flex items-center gap-2 min-w-0">
+                        <p className="text-sm text-foreground font-sans truncate">
+                          {surfaceParts(e.screenName ?? "").name || "Untitled screen"}
+                        </p>
+                        <span className={SURFACE_BADGE}>
+                          {surfaceParts(e.screenName ?? "").surface}
+                        </span>
+                      </div>
                       <p className="text-xs text-muted font-sans truncate">
                         {e.userName ?? "—"} · {e.userEmail ?? "—"}
                         {e.orgName && (

--- a/src/app/api/admin/feedback/route.ts
+++ b/src/app/api/admin/feedback/route.ts
@@ -3,11 +3,18 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { getAdminEmail } from "@/lib/admin";
 import { redis } from "@/lib/redis";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
+import {
+  FEEDBACK_INDEX_KEY,
+  recordKey,
+  type StoredFeedback,
+} from "@/lib/score-feedback";
 
 /**
  * Admin feedback aggregation — surfaces every analysis-quality rating users
- * have submitted via /api/feedback/score, enriched with the user's email
- * and the underlying score (so QA can quickly see what was rated).
+ * have submitted, from any surface: web (/api/feedback/score) and the Figma
+ * plugin (/api/plugin/feedback) share one store (@/lib/score-feedback). Each
+ * record is enriched with the user's email and the underlying score, and the UI
+ * derives the surface tag from the score-name suffix.
  *
  * GET /api/admin/feedback?limit=50
  *   → { feedback: EnrichedFeedback[] } most-recent-first
@@ -16,16 +23,6 @@ import { CURRENT_API_VERSION } from "@/lib/app-version";
  */
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
-const FEEDBACK_INDEX_KEY = "score-feedback:index";
-
-type StoredFeedback = {
-  scoreId: string;
-  userId: string;
-  orgId: string | null;
-  rating: "up" | "down";
-  note: string;
-  ts: number;
-};
 
 type EnrichedFeedback = StoredFeedback & {
   userEmail: string | null;
@@ -42,10 +39,6 @@ type ScoreSnapshot = {
   label?: string;
   screenName?: string;
 };
-
-function recordKey(scoreId: string, userId: string): string {
-  return `score-feedback:${scoreId}:${userId}`;
-}
 
 export async function GET(req: NextRequest) {
   const admin = await getAdminEmail();

--- a/src/app/api/feedback/score/route.ts
+++ b/src/app/api/feedback/score/route.ts
@@ -2,40 +2,24 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { redis } from "@/lib/redis";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
+import {
+  recordKey,
+  writeScoreFeedback,
+  type StoredFeedback,
+} from "@/lib/score-feedback";
 
 /**
- * Score-analysis feedback — per-score thumbs from authenticated users.
+ * Score-analysis feedback — per-score thumbs from authenticated web users.
+ * Shares the score-feedback store (see @/lib/score-feedback) with the Figma
+ * plugin path (/api/plugin/feedback), so all of it surfaces in the admin.
  *
  * GET  ?scoreId=X        → current user's existing feedback for that score
  * POST { scoreId, rating, note? }  → upsert this user's feedback
- *
- * Storage:
- *   score-feedback:{scoreId}:{userId} → JSON record
- *   score-feedback:index              → zset (ts → "{scoreId}:{userId}")
  *
  * Anonymous viewers get 401 and the client hides the widget.
  */
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
-
-const FEEDBACK_INDEX_KEY = "score-feedback:index";
-
-function recordKey(scoreId: string, userId: string): string {
-  return `score-feedback:${scoreId}:${userId}`;
-}
-
-function indexMember(scoreId: string, userId: string): string {
-  return `${scoreId}:${userId}`;
-}
-
-type StoredFeedback = {
-  scoreId: string;
-  userId: string;
-  orgId: string | null;
-  rating: "up" | "down";
-  note: string;
-  ts: number;
-};
 
 export async function GET(req: NextRequest) {
   const { userId } = await auth();
@@ -104,25 +88,13 @@ export async function POST(req: NextRequest) {
     );
   }
 
-  const note =
-    typeof body.note === "string" ? body.note.slice(0, 1000) : "";
-  const ts = Date.now();
-  const feedback: StoredFeedback = {
+  const feedback = await writeScoreFeedback(redis, {
     scoreId: body.scoreId,
     userId,
     orgId: orgId ?? null,
     rating: body.rating,
-    note,
-    ts,
-  };
-
-  await Promise.all([
-    redis.set(recordKey(body.scoreId, userId), JSON.stringify(feedback)),
-    redis.zadd(FEEDBACK_INDEX_KEY, {
-      score: ts,
-      member: indexMember(body.scoreId, userId),
-    }),
-  ]);
+    note: body.note,
+  });
 
   return NextResponse.json(
     { ok: true, feedback },

--- a/src/app/api/plugin/feedback/route.ts
+++ b/src/app/api/plugin/feedback/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { redis } from "@/lib/redis";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+import { writeScoreFeedback } from "@/lib/score-feedback";
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+/**
+ * Per-score feedback from the Figma plugin's in-canvas widget (#330).
+ *
+ * Called server-to-server by ai-design-assistant after a user taps Helpful /
+ * Off-base, so plugin feedback lands in the SAME score-feedback store the web
+ * widget uses and shows up in the Admin → Feedback tab. The plugin backend
+ * already holds the runladder scoreId (it persisted the score via
+ * /api/plugin/persist-score) and the runladder userId.
+ *
+ * Auth model: shared service secret (X-Ladder-Service-Token header), same as
+ * /api/plugin/persist-score.
+ *
+ * Body: { userId, scoreId, rating: "up"|"down", note? }
+ * Returns: { ok: true }
+ */
+export async function POST(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    return NextResponse.json(
+      { error: "Service not configured." },
+      { status: 503, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  let body: {
+    userId?: string;
+    scoreId?: string;
+    rating?: string;
+    note?: string;
+  } = {};
+  try {
+    body = await req.json();
+  } catch {}
+
+  if (!body.userId || !body.scoreId) {
+    return NextResponse.json(
+      { error: "userId and scoreId are required." },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (body.rating !== "up" && body.rating !== "down") {
+    return NextResponse.json(
+      { error: "rating must be 'up' or 'down'" },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  await writeScoreFeedback(redis, {
+    userId: body.userId,
+    scoreId: body.scoreId,
+    rating: body.rating,
+    note: body.note,
+  });
+
+  return NextResponse.json({ ok: true }, { headers: API_VERSION_HEADERS });
+}

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -1,8 +1,8 @@
 ---
 title: API Protocols
-updatedAt: 2026-06-08
+updatedAt: 2026-06-09
 updatedBy: Sara
-lastPr: 323
+lastPr: 332
 ---
 
 ## Two surfaces, one to come
@@ -32,7 +32,8 @@ All endpoints below are real routes in this repo. Find them under `src/app/api/`
 | `/api/plugin/verify-token` | POST | Plugin token | Token introspection for the plugin. |
 | `/api/plugin/analyze` | POST | Plugin token | Scoring callable from the Figma plugin. |
 | `/api/plugin/meta` | GET | Public | Plugin metadata (version, etc.). |
-| `/api/plugin/persist-score` | POST | Plugin token | Save a plugin-originated score. |
+| `/api/plugin/persist-score` | POST | Service token | Save a plugin-originated score (server-to-server). |
+| `/api/plugin/feedback` | POST | Service token | Forward Figma in-canvas score feedback into the central admin store (#330). |
 | `/api/stripe/checkout` | POST | Clerk session | Pro upgrade Stripe checkout session. |
 | `/api/stripe/portal` | POST | Clerk session | Stripe customer portal. |
 | `/api/stripe/webhooks` | POST | Stripe webhook signature | Stripe event ingest. |

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-08
+updatedAt: 2026-06-09
 updatedBy: Sara
-lastPr: 326
+lastPr: 332
 ---
 
 ## How to read this page
@@ -139,7 +139,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | User records + tier management | Admin | Live | `src/app/admin/page.tsx` |
 | Invite codes (generate, view, copy, revoke) | Admin | Live | `src/app/admin/page.tsx` |
 | Evaluations (rubric evaluation runs) | Admin | Live | `src/app/admin/evaluations/page.tsx` |
-| Feedback inbox | Admin | Live | `src/app/admin/feedback/page.tsx` |
+| Feedback inbox — all surfaces (Web + Figma), with surface chip | Admin | Live (#332) | `src/app/admin/(tabbed)/feedback/page.tsx`, `src/lib/score-feedback.ts`, `src/app/api/plugin/feedback/route.ts` |
 | Comps (comparison scoring runs) | Admin | Live | `src/app/admin/comps/page.tsx` |
 | Plugin backend proxy (`pluginFetch`) | Admin | Live | `src/lib/admin.ts` |
 | Super-admin protection on `SUPER_ADMIN_EMAILS` | Super Admin | Live | `src/lib/admin.ts`, hardcoded, passphrase-gated |

--- a/src/lib/score-feedback.ts
+++ b/src/lib/score-feedback.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared storage for per-score "thumbs" feedback, written by every surface so it
+ * all lands in one place (the Admin → Feedback tab). Centralized in #330.
+ *
+ * Writers:
+ *   - Web widget:    POST /api/feedback/score   (Clerk session auth)
+ *   - Figma plugin:  POST /api/plugin/feedback   (service-token auth, forwarded
+ *                    by the ai-design-assistant backend with the runladder scoreId)
+ * Reader:
+ *   - Admin:         GET  /api/admin/feedback
+ *
+ * Keys:
+ *   score-feedback:{scoreId}:{userId}  → JSON record (upsert, one per user/score)
+ *   score-feedback:index               → zset (ts → "{scoreId}:{userId}")
+ *
+ * The surface (Web / Figma / …) is NOT stored here — it's derived from the score
+ * name suffix (see surfaceParts in ./surface), so there is one source of truth.
+ */
+import type { Redis } from "@upstash/redis";
+
+export const FEEDBACK_INDEX_KEY = "score-feedback:index";
+
+export type ScoreFeedbackRating = "up" | "down";
+
+export type StoredFeedback = {
+  scoreId: string;
+  userId: string;
+  orgId: string | null;
+  rating: ScoreFeedbackRating;
+  note: string;
+  ts: number;
+};
+
+export function recordKey(scoreId: string, userId: string): string {
+  return `score-feedback:${scoreId}:${userId}`;
+}
+
+export function indexMember(scoreId: string, userId: string): string {
+  return `${scoreId}:${userId}`;
+}
+
+/**
+ * Upsert one user's feedback for one score and index it by time. Returns the
+ * stored record. `note` is trimmed to 1000 chars.
+ */
+export async function writeScoreFeedback(
+  redis: Redis,
+  input: {
+    scoreId: string;
+    userId: string;
+    orgId?: string | null;
+    rating: ScoreFeedbackRating;
+    note?: string;
+    ts?: number;
+  },
+): Promise<StoredFeedback> {
+  const feedback: StoredFeedback = {
+    scoreId: input.scoreId,
+    userId: input.userId,
+    orgId: input.orgId ?? null,
+    rating: input.rating,
+    note: typeof input.note === "string" ? input.note.slice(0, 1000) : "",
+    ts: input.ts ?? Date.now(),
+  };
+
+  await Promise.all([
+    redis.set(recordKey(feedback.scoreId, feedback.userId), JSON.stringify(feedback)),
+    redis.zadd(FEEDBACK_INDEX_KEY, {
+      score: feedback.ts,
+      member: indexMember(feedback.scoreId, feedback.userId),
+    }),
+  ]);
+
+  return feedback;
+}


### PR DESCRIPTION
Closes #330.

All score feedback now lands in one store and one admin view (Web + Figma).

## runladder
- `src/lib/score-feedback.ts` — shared store helper (keys, types, `writeScoreFeedback`); single source of truth for the write.
- `POST /api/plugin/feedback` — new **service-token-authed** endpoint (same model as `persist-score`) that writes Figma in-canvas feedback into the existing `score-feedback` store, keyed by the runladder `scoreId` the plugin already persisted.
- `/api/feedback/score` (web) and `/api/admin/feedback` (reader) refactored onto the shared helper.
- Admin feedback page: **surface chip** (Web / Figma / Skill…) via `surfaceParts`, suffix stripped from the screen name.

## Pairs with
ai-design-assistant PR (forwards in-canvas feedback to `/api/plugin/feedback`). No new env vars — reuses `LADDER_SERVICE_TOKEN` / `RUNLADDER_API_BASE` that already power `persist-score`.

## How it reconciles the #305 finding
A "(Figma)"-tagged row was always possible (web feedback on a Figma-originated score — the suffix comes from the score name). What was missing: the plugin's **in-canvas** widget posted to a separate backend. This change forwards it into the central store.

## Verification
- `tsc` clean, `next build` clean, `/api/plugin/feedback` present in the bundle.
- Surface chip confirmed: `Checkout (Figma)` → "Checkout" + Figma chip; plain → Web.

## /hq
- `api.mdx`: new endpoint row. `features.mdx`: multi-surface feedback inbox row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)