### PR TITLE
fix(#338): Stripe webhook acknowledges unknown-user events instead of 500ing

### DIFF
--- a/src/app/api/stripe/webhooks/route.ts
+++ b/src/app/api/stripe/webhooks/route.ts
@@ -11,6 +11,20 @@ import { setUserSubscription, userIdForStripeCustomer } from "@/lib/tier";
 export const runtime = "nodejs";
 
 /**
+ * Clerk throws a 4xx ClerkAPIResponseError (e.g. 404 "Not Found") when an event
+ * references a user that doesn't exist — typically test-mode events whose
+ * reference IDs aren't users in this Clerk instance, or a since-deleted user.
+ * That's permanent: acknowledge it (2xx) so Stripe stops retrying. 5xx /
+ * network errors are transient and should bubble to a 500 so Stripe retries
+ * (#338 — unguarded checkout events were 500ing and threatening endpoint
+ * disablement).
+ */
+function isPermanentUserError(err: unknown): boolean {
+  const status = (err as { status?: number })?.status;
+  return typeof status === "number" && status >= 400 && status < 500;
+}
+
+/**
  * Stripe webhook receiver. Validates the signature, then mirrors subscription
  * state into Clerk publicMetadata.tier so every surface (web, Skill, MCP, API)
  * sees a consistent tier.
@@ -54,10 +68,18 @@ export async function POST(req: NextRequest) {
             : session.customer?.id;
         if (userId && customerId) {
           // Subscription event will follow with full state — record the customer now.
-          await setUserSubscription(userId, {
-            tier: "pro",
-            stripeCustomerId: customerId,
-          });
+          try {
+            await setUserSubscription(userId, {
+              tier: "pro",
+              stripeCustomerId: customerId,
+            });
+          } catch (err) {
+            if (!isPermanentUserError(err)) throw err;
+            console.warn(
+              "[LADDER:STRIPE] checkout.session.completed references unknown user; acknowledging.",
+              { userId, customerId }
+            );
+          }
         }
         break;
       }
@@ -85,13 +107,21 @@ export async function POST(req: NextRequest) {
         const active = isActiveSubscription(sub.status);
         const tier = active ? tierForPriceId(priceId) : "free";
 
-        await setUserSubscription(userId, {
-          tier,
-          stripeCustomerId: customerId,
-          stripeSubscriptionId: sub.id,
-          currentPeriodEnd: sub.items.data[0]?.current_period_end ?? undefined,
-          cancelAtPeriodEnd: sub.cancel_at_period_end,
-        });
+        try {
+          await setUserSubscription(userId, {
+            tier,
+            stripeCustomerId: customerId,
+            stripeSubscriptionId: sub.id,
+            currentPeriodEnd: sub.items.data[0]?.current_period_end ?? undefined,
+            cancelAtPeriodEnd: sub.cancel_at_period_end,
+          });
+        } catch (err) {
+          if (!isPermanentUserError(err)) throw err;
+          console.warn(
+            "[LADDER:STRIPE] subscription event references unknown user; acknowledging.",
+            { userId, customerId }
+          );
+        }
         break;
       }
 


### PR DESCRIPTION
## What
`/api/stripe/webhooks` returned **HTTP 500** when an event referenced a user not in Clerk (test-mode events, stale/foreign reference IDs) — `setUserSubscription` → `clerkClient.getUser()` threw and the catch-all 500'd. Stripe retried and warned it would disable the endpoint (#338).

## Fix
- 4xx Clerk error (e.g. 404 user-not-found) → treated as **permanent**: log + acknowledge (2xx) so Stripe stops retrying.
- 5xx / network errors → still bubble to **500** so Stripe retries genuine transient failures.
- Signature failures → still **400**.

## Verified locally
Replayed signed events against the handler: checkout-with-unknown-user now returns **200** (was 500); unknown-customer subscription event 200; unhandled type 200; bad signature 400.

## Context
Root cause of the #338 emails was test-mode checkout events hitting prod before the live env vars were finished on June 8. The live webhook endpoint itself is healthy (200 OK deliveries confirmed). This patch hardens the handler so stray/test events can't 500 and trip Stripe's auto-disable.

No /hq consequence: endpoint shape, auth (Stripe signature), and purpose unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)