### PR TITLE
feat(#249): stand up dev and prod environments

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -38,12 +38,15 @@ NEXT_PUBLIC_APP_URL=http://localhost:3000
 
 
 # -----------------------------------------------------------------------------
-# Upstash Redis — REQUIRED for usage limits, skill tokens, pending comps
+# Upstash Redis (via Vercel KV) — REQUIRED for usage limits, skill tokens, pending comps
 # -----------------------------------------------------------------------------
 # Without these, signed-in features (dashboard, scoring quota, skill token
 # rotation) will throw. Public pages (/, /framework, /pricing) still render.
-UPSTASH_REDIS_REST_URL=https://...upstash.io
-UPSTASH_REDIS_REST_TOKEN=...
+# These are auto-set by Vercel when a KV store is connected to the project.
+# For local dev, run: vercel env pull .env.local
+KV_REST_API_URL=https://...upstash.io
+KV_REST_API_TOKEN=...
+KV_REST_API_READ_ONLY_TOKEN=...
 
 
 # -----------------------------------------------------------------------------

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -118,7 +118,7 @@ export default function RootLayout({
           */}
           <script
             dangerouslySetInnerHTML={{
-              __html: `(function(){try{if(!/^\\/(dashboard|score|settings|hq|admin)(\\/|$)/.test(location.pathname)){document.documentElement.classList.add('marketing')}}catch(e){}})()`,
+              __html: `(function(){try{var h=location.hostname;if(!/^(app|dev)\\.runladder\\.com$/.test(h)&&!/^\\/(dashboard|score|settings|hq|admin)(\\/|$)/.test(location.pathname)){document.documentElement.classList.add('marketing')}}catch(e){}})()`,
             }}
           />
           <MarketingScope />

--- a/src/components/MarketingScope.tsx
+++ b/src/components/MarketingScope.tsx
@@ -7,6 +7,9 @@ import { useEffect, useLayoutEffect } from "react";
 // else is the marketing site and gets the warmer treatment (Inter, darker
 // cards). This list mirrors `inProduct` in Nav.tsx — keep them in sync. The
 // same regex lives in the pre-paint inline script in app/layout.tsx.
+// On app/dev subdomains the entire site is the product — never marketing scope.
+// On runladder.com or localhost, fall back to path-based detection.
+const APP_DOMAIN = /^(app|dev)\.runladder\.com$/;
 const PRODUCT_PATH = /^\/(dashboard|score|settings|hq|admin)(\/|$)/;
 
 // Run before paint on the client so client-side navigation doesn't flash; fall
@@ -24,7 +27,8 @@ export function MarketingScope() {
   const pathname = usePathname();
 
   useIsomorphicLayoutEffect(() => {
-    const isMarketing = !PRODUCT_PATH.test(pathname ?? "");
+    const isAppDomain = APP_DOMAIN.test(window.location.hostname);
+    const isMarketing = !isAppDomain && !PRODUCT_PATH.test(pathname ?? "");
     document.documentElement.classList.toggle("marketing", isMarketing);
   }, [pathname]);
 

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-06-17
 updatedBy: Michael
-lastPr: 249
+lastPr: 355
 ---
 
 ## Deployment environments

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -1,9 +1,24 @@
 ---
 title: Architecture
-updatedAt: 2026-06-08
-updatedBy: Sara
-lastPr: 322
+updatedAt: 2026-06-17
+updatedBy: Michael
+lastPr: 249
 ---
+
+## Deployment environments
+
+`runladder` ships to two environments. Both run the same Next.js codebase from the same Vercel project.
+
+| Environment | URL | Deploy trigger | Clerk | Redis |
+| --- | --- | --- | --- | --- |
+| **Dev** | `dev.runladder.com` | Auto — every merge to `main` | Dev instance | Dev Upstash instance |
+| **Production** | `app.runladder.com` | Manual — `vercel --prod --force` | Prod instance | Prod Upstash instance |
+
+**Promotion flow:** `feature branch → PR → CI (next build + vitest) → merge to main → auto-deploy to dev → QA → manual promo to prod`
+
+`runladder.com` and `www.runladder.com` are the public marketing and content domains — same Vercel project, same build, routed as additional domains on the Production environment. Canonical content URLs (OG tags, share links, sitemaps) always reference `runladder.com`. Auth entry point is `app.runladder.com/login`.
+
+Branch protection on `main` requires a passing `build` CI check and disables force-push. Self-merge is allowed.
 
 ## One scoring framework, three codebases (today)
 

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -1,8 +1,8 @@
 ---
 title: Decisions Log
-updatedAt: 2026-06-09
-updatedBy: Sara
-lastPr: 328
+updatedAt: 2026-06-17
+updatedBy: Michael
+lastPr: 249
 ---
 
 ## How to use this page
@@ -13,13 +13,29 @@ If you want to challenge a decision, file an issue in GitHub with the proposed c
 
 ---
 
-## App stays on runladder.com for launch; `app.runladder.com` split is post-launch (2026-06-09)
+## Two-environment deployment: dev.runladder.com + app.runladder.com (2026-06-17)
 
-**Rule:** Do NOT migrate the app to `app.runladder.com` before launch. The marketing/app domain split ([#314](https://github.com/drawbackwards/runladder/issues/314)) is deferred to the week *after* launch, with a written runbook on the ticket.
+**Rule:** The platform runs two environments: `dev.runladder.com` (QA, auto-deploys from `main`) and `app.runladder.com` (production, explicit manual promotion). Marketing and content pages stay at `runladder.com`. Shipped in [#249](https://github.com/drawbackwards/runladder/issues/249).
 
-Why the split is wanted: best practice to separate the marketing site from the app. It's cleanup, not a feature, and adds zero user-facing value.
+**Domain roles:**
 
-Why not before launch: the migration rewires **Clerk (login)** and **Stripe (payments)** — the two flows we just stabilized and verified live — and Ward is demoing a real customer the same week. Breaking either breaks the demo. Nobody uses the app yet (password gate came off 2026-06-06), so waiting costs nothing and the job is the same size later, not harder; doing it now risks a potential sale to save zero days. The "you can't move it later" fear is largely false — subdomain moves are routine with 301 redirects, and the code is already domain-portable (origin-based Stripe URLs, relative Clerk redirects). Full scope + ordered runbook + rollback live on [#314](https://github.com/drawbackwards/runladder/issues/314); it has been moved out of the MVP Launch milestone.
+| URL | Role |
+| --- | --- |
+| `runladder.com` / `www.runladder.com` | Public marketing and content (framework, blog, teardowns, top-100, pricing) |
+| `app.runladder.com` | Production app (authenticated users, scoring, dashboard, login) |
+| `dev.runladder.com` | Dev/QA environment — auto-deploys from `main`, uses dev Clerk + dev Redis, safe to break |
+
+**Deploy flow:** `feature branch → PR → CI (next build) → merge to main → auto-deploys to dev.runladder.com → QA → explicit `vercel --prod --force` to app.runladder.com`
+
+**Environment variable split:**
+
+| Scope | Clerk | Redis | NEXT_PUBLIC_APP_URL |
+| --- | --- | --- | --- |
+| Production (`app.runladder.com`) | Prod Clerk instance | Prod Redis | `https://app.runladder.com` |
+| Dev (`dev.runladder.com`) + Preview | Dev Clerk instance | Dev Redis (separate Upstash instance) | `https://dev.runladder.com` |
+| Local | Dev Clerk instance | Dev Redis | `http://localhost:3000` |
+
+Why: the team was shipping directly to production with no safe QA environment. Any error in new code immediately hit real users and real data. The two-environment setup gives a stable URL to QA work before it reaches production. The subdomain move (#314) was deferred from launch week to avoid rewiring Clerk and Stripe during a live demo — that window has passed, and the migration is now part of standing up the environment infrastructure.
 
 ## Client data is archived, never deleted (2026-06-08)
 

--- a/src/content/hq/decisions.mdx
+++ b/src/content/hq/decisions.mdx
@@ -2,7 +2,7 @@
 title: Decisions Log
 updatedAt: 2026-06-17
 updatedBy: Michael
-lastPr: 249
+lastPr: 355
 ---
 
 ## How to use this page

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,9 +1,6 @@
 import { Redis } from "@upstash/redis";
 
-export const redis = new Redis({
-  url: process.env.UPSTASH_REDIS_REST_URL!,
-  token: process.env.UPSTASH_REDIS_REST_TOKEN!,
-});
+export const redis = Redis.fromEnv();
 
 /*
   Redis key schema:


### PR DESCRIPTION
## Summary

- Switches Redis from direct Upstash to Vercel KV (`Redis.fromEnv()`) with separate `runladder-prod` and `runladder-dev` stores — dev/prod data is now fully isolated
- Migrated existing prod Redis data to `runladder-prod`
- Updates `MarketingScope` to key off hostname on `app`/`dev` subdomains, falling back to path-based detection on `runladder.com` and localhost
- Updates `/hq/architecture` with two-environment deployment diagram
- Updates `/hq/decisions` with environment strategy decision, superseding the deferred `app.runladder.com` split entry

## What was done outside this PR (Vercel + DNS + GitHub)

- Branch protection on `main` — require PR + passing `build` check, no force-push
- `runladder-prod` and `runladder-dev` Vercel KV stores provisioned and connected to correct environment scopes
- `dev.runladder.com` Custom Environment created in Vercel, tracking `main`, auto-deploy enabled
- `app.runladder.com` added to Vercel Production domains
- DNS records added in Cloudflare for `dev.runladder.com` and `app.runladder.com`
- `ANTHROPIC_API_KEY` added to all three scopes (Production, Preview, Development)
- `NEXT_PUBLIC_APP_URL` split per environment: `app.runladder.com` (prod), `dev.runladder.com` (dev), `runladder.com` (preview)

## Still pending (blocked on Clerk dashboard access)

- Update prod Clerk Home URL → `https://app.runladder.com`
- Add `app.runladder.com` to Clerk allowed redirect URLs

## Test plan

- [ ] Merge to `main` and confirm `dev.runladder.com` auto-deploys
- [ ] Hit `/score` on `dev.runladder.com` and confirm scoring works
- [ ] Confirm `app.runladder.com` serves the app after Clerk is updated
- [ ] Confirm `runladder.com` marketing pages still render correctly
- [ ] Verify prod Redis data intact — sign in as Ward and confirm score history is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)