### PR TITLE
fix(auth): redirect login to app.runladder.com

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,13 +54,16 @@ export default function RootLayout({
 }>) {
   const gateEnabled = !!process.env.SITE_PASSWORD;
 
+  const appUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+
   return (
     <ClerkProvider
-      signInUrl="/login"
-      signUpUrl="/sign-up"
-      signInFallbackRedirectUrl="/dashboard"
-      signUpFallbackRedirectUrl="/score"
-      afterSignOutUrl="/"
+      signInUrl={`${appUrl}/login`}
+      signUpUrl={`${appUrl}/sign-up`}
+      signInFallbackRedirectUrl={`${appUrl}/dashboard`}
+      signUpFallbackRedirectUrl={`${appUrl}/score`}
+      afterSignOutUrl={appUrl || "/"}
+
       appearance={{
         variables: {
           colorPrimary: "#6AC89B",


### PR DESCRIPTION
## Summary
- Login button on `runladder.com` was redirecting to `runladder.com/login` because `ClerkProvider` had relative paths for `signInUrl`/`signUpUrl`
- Changed to use `NEXT_PUBLIC_APP_URL` so all auth flows point to `app.runladder.com/login` in production

## Test plan
- [ ] Go to `runladder.com`, click Login — should redirect to `app.runladder.com/login`
- [ ] Go to `runladder.com`, click Sign up — should redirect to `app.runladder.com/sign-up`
- [ ] Sign in successfully — should land on `app.runladder.com/dashboard`
- [ ] Sign out — should land on `app.runladder.com` (the app home)
- [ ] Local dev unaffected — `NEXT_PUBLIC_APP_URL=http://localhost:3000` so behavior is identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)