### PR TITLE
fix(middleware): redirect app routes on runladder.com to app.runladder.com

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,24 @@
 import { clerkMiddleware } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+// Routes that belong to the app, not the marketing site.
+// Requests to these paths on runladder.com / www.runladder.com are
+// permanently redirected to app.runladder.com so customers never
+// interact with the app on the marketing domain.
+const APP_ROUTES = /^\/(dashboard|score|settings|login|sign-up|hq|admin)(\/|$)/;
+const MARKETING_HOST = /^(www\.)?runladder\.com$/;
+
+export default clerkMiddleware((auth, request) => {
+  const { nextUrl } = request;
+
+  if (MARKETING_HOST.test(nextUrl.hostname) && APP_ROUTES.test(nextUrl.pathname)) {
+    const destination = new URL(
+      nextUrl.pathname + nextUrl.search,
+      "https://app.runladder.com"
+    );
+    return NextResponse.redirect(destination, { status: 308 });
+  }
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
## Summary
- Customers hitting app routes (`/dashboard`, `/score`, `/settings`, `/login`, `/sign-up`, `/hq`, `/admin`) on `runladder.com` are now permanently redirected (308) to the same path on `app.runladder.com`
- Marketing routes (`/`, `/pricing`, `/framework`, `/blog`, etc.) are unaffected — they stay on `runladder.com`
- `/api/*` routes are unaffected — JavaScript calls from the marketing site still work
- Local dev and `dev.runladder.com` are unaffected — the redirect only fires when hostname matches `runladder.com` or `www.runladder.com`

## Test plan
- [ ] Merge and let auto-deploy to `dev.runladder.com` complete
- [ ] After promoting to prod: go to `runladder.com/dashboard` — should redirect to `app.runladder.com/dashboard`
- [ ] Go to `runladder.com/login` — should redirect to `app.runladder.com/login`
- [ ] Go to `runladder.com/score` — should redirect to `app.runladder.com/score`
- [ ] Go to `runladder.com/` — should stay on `runladder.com` (marketing, no redirect)
- [ ] Go to `runladder.com/pricing` — should stay on `runladder.com` (marketing, no redirect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)