### PR TITLE
fix(#363): plugin scores show Style Guide analysis on the dashboard

### DIFF
--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -1,9 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
 import { redis } from "@/lib/redis";
 import { parseImageDataUrl } from "@/lib/scoring";
 import { makeThumbnail } from "@/lib/thumbnail";
 import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
+import {
+  getOrgStyleGuide,
+  analyzeStyleCompliance,
+  type StyleGuideResult,
+} from "@/lib/style-guide";
 import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+// Persisting a plugin score now runs the same style-compliance pass the web
+// score route does (an extra Sonnet call), so give it room past the default.
+export const maxDuration = 60;
 
 const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
 
@@ -50,11 +60,12 @@ export async function POST(req: NextRequest) {
       );
     }
 
+    const parsed = image ? parseImageDataUrl(image) : null;
+
     /* ── Optional thumbnail: caller passes the raw image data URL, we resize ── */
     let thumbnail: string | undefined = score.thumbnail;
     let thumbnailDiag = "preset-or-none";
     if (!thumbnail && image) {
-      const parsed = parseImageDataUrl(image);
       if (!parsed) {
         thumbnailDiag = "image-not-parseable";
       } else {
@@ -73,6 +84,61 @@ export async function POST(req: NextRequest) {
       thumbnailDiag = "no-image-no-thumbnail";
     }
 
+    /* ── Team style-guide compliance ──────────────────────────────────────
+     * The plugin's "improve" (scoring) action never runs the style pass, so
+     * plugin-originated entries used to reach the dashboard with no Style
+     * Guide section at all (#363). Run the SAME pass the web score route uses
+     * here, on the same image, resolving the user's org → ruleset exactly as
+     * verify-token does — so plugin and web dashboard views are consistent.
+     *
+     * Advisory only: it NEVER affects the numeric score, and a failure becomes
+     * an "unavailable" status (or no section when the team has no guide). The
+     * whole block is best-effort and never fails the persist. We skip it if the
+     * caller already attached a styleGuide, so we don't double-spend the call. */
+    let styleGuide: StyleGuideResult | undefined = score.styleGuide as
+      | StyleGuideResult
+      | undefined;
+    let styleDiag = styleGuide ? "preset" : "skipped";
+    if (!styleGuide && parsed) {
+      try {
+        const clerk = await clerkClient();
+        const memberships = await clerk.users.getOrganizationMembershipList({
+          userId,
+        });
+        const orgId = memberships.data[0]?.organization?.id ?? null;
+        const orgGuide = orgId ? await getOrgStyleGuide(orgId) : null;
+        if (orgGuide) {
+          try {
+            const findings = await analyzeStyleCompliance(
+              { mediaType: parsed.mediaType, base64Data: parsed.base64Data },
+              orgGuide.ruleset,
+            );
+            styleGuide = {
+              status: findings.length > 0 ? "issues" : "compliant",
+              teamName: orgGuide.teamName,
+              findings,
+            };
+            styleDiag = `computed-${styleGuide.status}`;
+          } catch (e) {
+            console.warn("[LADDER:WARN] plugin style-guide pass failed:", e);
+            styleGuide = {
+              status: "unavailable",
+              teamName: orgGuide.teamName,
+              findings: [],
+            };
+            styleDiag = "unavailable";
+          }
+        } else {
+          styleDiag = "no-org-guide";
+        }
+      } catch (e) {
+        // Org/ruleset lookup failed — leave styleGuide unset (no section),
+        // never block the persist.
+        console.warn("[LADDER:WARN] plugin style-guide lookup failed:", e);
+        styleDiag = "lookup-failed";
+      }
+    }
+
     const stored = await persistScoreEntry(userId, {
       id: score.id,
       score: score.score,
@@ -82,6 +148,7 @@ export async function POST(req: NextRequest) {
       next: score.next,
       findings: score.findings,
       rungs: score.rungs,
+      styleGuide,
       source: score.source || "figma",
       thumbnail,
       isPublic: !!score.isPublic,
@@ -108,6 +175,7 @@ export async function POST(req: NextRequest) {
           imageBytes: image ? image.length : 0,
           thumbnail: thumbnailDiag,
           thumbnailLength: thumbnail ? thumbnail.length : 0,
+          styleGuide: styleDiag,
           ok: true,
         }),
       );

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-24
+updatedAt: 2026-06-29
 updatedBy: Sara
-lastPr: 361
+lastPr: 364
 ---
 
 ## How to read this page
@@ -28,7 +28,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
 | Public scoring tool (`/score`) | All signed-in | Live | `src/app/score/` |
-| Team style guide compliance: Team Lead uploads a PDF writing style guide (Settings → Style Guide); Ladder flags on-screen copy that deviates from it, with a suggested fix and category, on web scores and in the Figma plugin's Improve Copy. Advisory only, never affects the score. | Team Lead (upload) / Team (sees findings) | Live (PR #361) | `src/app/settings/page.tsx`, `src/app/api/org/style-guide/`, `src/lib/style-guide.ts`, `src/lib/scoring.ts`, `src/app/api/plugin/verify-token/route.ts` + `ai-design-assistant` copy mode |
+| Team style guide compliance: Team Lead uploads a PDF writing style guide (Settings → Style Guide); Ladder flags on-screen copy that deviates from it, with a suggested fix and category, on web scores, in the Figma plugin's Improve Copy, and (PR #364) on plugin-originated scores when they appear on the dashboard. Advisory only, never affects the score. | Team Lead (upload) / Team (sees findings) | Live (PR #361, #364) | `src/app/settings/page.tsx`, `src/app/api/org/style-guide/`, `src/lib/style-guide.ts`, `src/lib/scoring.ts`, `src/app/api/plugin/verify-token/route.ts`, `src/app/api/plugin/persist-score/route.ts` + `ai-design-assistant` copy mode |
 | Private / Internal scoring (paid feature; toggle defaults on for paid, free locked to public, off-warning, tier-aware "Private"/"Internal" label) | Pro / Team / Pulse (free = public only) | Live (v0.5.7, [#290](https://github.com/drawbackwards/runladder/issues/290) / [#301](https://github.com/drawbackwards/runladder/issues/301)) | `src/app/score/page.tsx`, `src/lib/score-scope.ts`, `src/app/api/score/route.ts`, `src/app/api/score/stream/route.ts` |
 | Personal dashboard (`/dashboard`) | All signed-in | Live | `src/app/dashboard/` |
 | Design rhythm + activity heatmap on personal dashboard (paid only) | Pro / Team / Pulse | Live (#289) | `src/app/dashboard/page.tsx` (gated on `paid`) |
@@ -63,7 +63,7 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 | In-canvas frame scoring | Pro+ | Live | `src/app/api/plugin/analyze/route.ts` |
 | Plugin token issuance | All signed-in | Live | `src/app/api/plugin/issue-token/route.ts` |
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
-| Score persistence from plugin | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
+| Score persistence from plugin (also runs the team style-compliance pass so plugin scores show Style Guide findings on the dashboard, #364) | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
 | Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
 | Plugin bundle (v1.0.8) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
 | Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |


### PR DESCRIPTION
## What
Plugin-originated scores now run the team **style-compliance pass** when they persist, so they show a Style Guide section on the Web dashboard — same as web-originated scores. Closes #363.

## Why
The plugin's scoring ("improve") and Improve Copy (style) are separate actions; only the score was sent to `persist-score`, which never attached `styleGuide`. The dashboard reads `entry.styleGuide`, so plugin entries rendered no Style Guide section at all.

## How
`persist-score` resolves `userId → org → ruleset` (same Clerk membership lookup `verify-token` uses) and runs `analyzeStyleCompliance` on the image — the **same engine and same `StyleGuideResult` shape** `/api/score` produces. So plugin and web dashboard detail views are consistent.

- Advisory only: never affects the numeric score.
- Best-effort: a pass error → `"unavailable"`; no team guide → no section; lookup failure never blocks the persist.
- Skips the call if the caller already attached `styleGuide` (no double-spend).
- Reuses the already-parsed image; adds `maxDuration = 60` for the extra Sonnet call.

Runladder-only — no plugin change. Stepping stone toward the #362 one-engine consolidation.

## Verification
- `tsc --noEmit` clean, eslint clean.
- Write/read shapes confirmed against `StyleGuideFindings` (dashboard component) — exact match.

## /hq
Lockstep stamp included: updated the Team style-guide + plugin persistence rows in `/hq/features`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)