### PR TITLE
fix(#362): compute style compliance once per scan and cache it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 - The plugin's Improve Copy was still classifying style differently from the web score (e.g. "Order no" → ABBREVIATION in the plugin vs CAPITALIZATION on web) because it ran its own copy prompt. `POST /api/plugin/analyze/copy` now returns **two separate sections**: `styleGuide` (computed by the SAME `analyzeStyleCompliance` engine the web score uses — byte-identical findings) and `general` (a general UX copy audit that deliberately skips style matters, so it never duplicates or contradicts the style section). Response shape changed from `{ ladder, copy }` to `{ mode, styleGuide, general }` (api 1.2.0).
 - `auditCopy` is now general-only — the style-guide block was removed; style compliance has a single source of truth.
 - The style + copy passes run at `temperature: 0` so the same screen yields the same findings across surfaces and re-scans (#362, #343).
-- Plugin UI now renders a "Style Guide" section (in the web's tag / strikethrough → suggestion / reason layout) and a separate "General suggestions" section. Web score display is unchanged.
+- **Style compliance is computed once per scan and cached** (content-addressed by org + ruleset + exact text). The plugin's in-canvas Improve Copy and the persisted score that the web displays now reuse the *same* result instead of each making an independent model call — so they can no longer drift (different count/categories). Editing the guide or the screen produces a fresh result (the key changes).
+- Plugin UI now renders a "Style Guide" section (in the web's tag / strikethrough → suggestion / reason layout) and a separate "General suggestions" section, with green section headings. Web score display is unchanged.
 
 ---
 

--- a/src/app/api/plugin/analyze/copy/route.ts
+++ b/src/app/api/plugin/analyze/copy/route.ts
@@ -3,7 +3,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import { parseImageDataUrl } from "@/lib/scoring";
 import {
   getOrgStyleGuide,
-  analyzeStyleCompliance,
+  analyzeStyleComplianceCached,
   hasFrameText,
   type FrameText,
   type StyleGuideResult,
@@ -69,11 +69,12 @@ export async function POST(req: NextRequest) {
     // Resolve the team's style ruleset from the user's org (best-effort).
     let ruleset: string | null = null;
     let teamName: string | null = null;
+    let orgId: string | null = null;
     if (userId) {
       try {
         const clerk = await clerkClient();
         const memberships = await clerk.users.getOrganizationMembershipList({ userId });
-        const orgId = memberships.data[0]?.organization?.id ?? null;
+        orgId = memberships.data[0]?.organization?.id ?? null;
         const orgGuide = orgId ? await getOrgStyleGuide(orgId) : null;
         if (orgGuide) {
           ruleset = orgGuide.ruleset;
@@ -89,7 +90,7 @@ export async function POST(req: NextRequest) {
     // style matters. Each degrades on its own without failing the other.
     const [styleGuide, general] = await Promise.all([
       ruleset
-        ? analyzeStyleCompliance({ image: imageInput, frameText }, ruleset)
+        ? analyzeStyleComplianceCached({ image: imageInput, frameText }, ruleset, orgId)
             .then(
               (outcome): StyleGuideResult => ({
                 status: outcome.findings.length > 0 ? "issues" : "compliant",

--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -6,7 +6,7 @@ import { makeThumbnail } from "@/lib/thumbnail";
 import { persistScoreEntry, type ScoreEntryInput } from "@/lib/scores";
 import {
   getOrgStyleGuide,
-  analyzeStyleCompliance,
+  analyzeStyleComplianceCached,
   hasFrameText,
   type StyleGuideResult,
   type FrameText,
@@ -113,9 +113,11 @@ export async function POST(req: NextRequest) {
         if (orgGuide) {
           try {
             // Prefer the plugin's ground-truth frame text; the screenshot is a
-            // best-effort fallback. Same engine + same text as the in-canvas
-            // Improve Copy, so the dashboard card agrees with it (#362/#363).
-            const outcome = await analyzeStyleCompliance(
+            // best-effort fallback. Cached by (org, ruleset, text) so this
+            // computes ONCE per scan and the in-canvas Improve Copy reuses the
+            // identical result — the dashboard card and the plugin never drift
+            // (#362/#363).
+            const outcome = await analyzeStyleComplianceCached(
               {
                 image: parsed
                   ? { mediaType: parsed.mediaType, base64Data: parsed.base64Data }
@@ -123,6 +125,7 @@ export async function POST(req: NextRequest) {
                 frameText,
               },
               orgGuide.ruleset,
+              orgId,
             );
             styleGuide = {
               status: outcome.findings.length > 0 ? "issues" : "compliant",

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-06-29
 updatedBy: Sara
-lastPr: 367
+lastPr: 368
 ---
 
 ## How to read this page
@@ -28,7 +28,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
 | Public scoring tool (`/score`) | All signed-in | Live | `src/app/score/` |
-| Team style guide compliance: Team Lead uploads a PDF writing style guide (Settings → Style Guide); Ladder flags on-screen copy that deviates from it, with a suggested fix and category, on web scores, in the Figma plugin's Improve Copy, and on plugin-originated scores on the dashboard. **Text-driven (#362 Chunk 1, PR #366):** checks ground-truth text from Figma layers / a URL's DOM; raw image uploads are best-effort with a gold caveat. **One engine everywhere (PR #367):** the plugin's Improve Copy shows a "Style Guide" section (identical findings to the web score, same `analyzeStyleCompliance` engine, same layout) plus a separate "General suggestions" section; style passes run at temperature 0. Advisory only, never affects the score. | Team Lead (upload) / Team (sees findings) | Live (PR #361, #364, #366, #367) | `src/lib/style-guide.ts`, `src/lib/copy-audit.ts`, `src/app/api/plugin/analyze/copy/route.ts`, `src/app/api/screenshot/route.ts`, `src/lib/scoring.ts`, `src/app/api/plugin/persist-score/route.ts`, `src/components/StyleGuideFindings.tsx`, `src/app/api/org/style-guide/` |
+| Team style guide compliance: Team Lead uploads a PDF writing style guide (Settings → Style Guide); Ladder flags on-screen copy that deviates from it, with a suggested fix and category, on web scores, in the Figma plugin's Improve Copy, and on plugin-originated scores on the dashboard. **Text-driven (#362 Chunk 1, PR #366):** checks ground-truth text from Figma layers / a URL's DOM; raw image uploads are best-effort with a gold caveat. **One engine everywhere (PR #367):** the plugin's Improve Copy shows a "Style Guide" section (identical findings to the web score, same `analyzeStyleCompliance` engine, same layout) plus a separate "General suggestions" section; style passes run at temperature 0. **Computed once per scan and cached (PR #368)** by org+ruleset+text, so the plugin and the persisted score the web shows reuse the same result and can't drift. Advisory only, never affects the score. | Team Lead (upload) / Team (sees findings) | Live (PR #361, #364, #366, #367, #368) | `src/lib/style-guide.ts`, `src/lib/copy-audit.ts`, `src/app/api/plugin/analyze/copy/route.ts`, `src/app/api/screenshot/route.ts`, `src/lib/scoring.ts`, `src/app/api/plugin/persist-score/route.ts`, `src/components/StyleGuideFindings.tsx`, `src/app/api/org/style-guide/` |
 | Private / Internal scoring (paid feature; toggle defaults on for paid, free locked to public, off-warning, tier-aware "Private"/"Internal" label) | Pro / Team / Pulse (free = public only) | Live (v0.5.7, [#290](https://github.com/drawbackwards/runladder/issues/290) / [#301](https://github.com/drawbackwards/runladder/issues/301)) | `src/app/score/page.tsx`, `src/lib/score-scope.ts`, `src/app/api/score/route.ts`, `src/app/api/score/stream/route.ts` |
 | Personal dashboard (`/dashboard`) | All signed-in | Live | `src/app/dashboard/` |
 | Design rhythm + activity heatmap on personal dashboard (paid only) | Pro / Team / Pulse | Live (#289) | `src/app/dashboard/page.tsx` (gated on `paid`) |

--- a/src/lib/style-guide.ts
+++ b/src/lib/style-guide.ts
@@ -13,6 +13,7 @@
  * MUST stay server-side. Never log the ruleset or prompt text to clients.
  */
 import Anthropic from "@anthropic-ai/sdk";
+import { createHash } from "crypto";
 import type { MediaType } from "./scoring";
 import { extractJsonObject } from "./json-extract";
 import { redis } from "./redis";
@@ -311,4 +312,55 @@ export async function analyzeStyleCompliance(
     .filter((f): f is StyleGuideFinding => f !== null);
 
   return { findings, textSource };
+}
+
+/** Content-addressed cache key: same org + ruleset + exact text → same key. */
+function styleCacheKey(orgId: string, ruleset: string, frameText: FrameText): string {
+  const basis = `${ruleset}\n---\n${(frameText.textContent ?? []).join("\n")}`;
+  const hash = createHash("sha256").update(basis).digest("hex").slice(0, 32);
+  return `style:cache:${orgId}:${hash}`;
+}
+
+/**
+ * Style compliance, computed ONCE per (org, ruleset, exact text) and reused.
+ *
+ * A single screen is "scanned once" from the user's point of view, so its
+ * style-guide findings must be identical no matter which surface or action
+ * triggers the check — the plugin's in-canvas Improve Copy, the score the
+ * plugin persists, and the web dashboard that displays it (#362). Without this,
+ * each call to `analyzeStyleCompliance` is an independent model call that can
+ * drift (different count/categories) even at temperature 0.
+ *
+ * Only caches when we have ground-truth `frameText` (a stable, content-addressed
+ * key) and an org. Image-only/best-effort checks always recompute. The key
+ * includes the ruleset, so editing the team guide invalidates it; it includes
+ * the exact text, so editing the screen produces a fresh result.
+ */
+export async function analyzeStyleComplianceCached(
+  input: {
+    image?: { mediaType: MediaType; base64Data: string } | null;
+    frameText?: FrameText | null;
+  },
+  ruleset: string,
+  orgId: string | null,
+): Promise<StyleComplianceOutcome> {
+  if (!orgId || !hasFrameText(input.frameText)) {
+    return analyzeStyleCompliance(input, ruleset);
+  }
+  const key = styleCacheKey(orgId, ruleset, input.frameText);
+  try {
+    const cached = await redis.get<StyleComplianceOutcome>(key);
+    if (cached && Array.isArray(cached.findings)) return cached;
+  } catch {
+    // cache read is best-effort
+  }
+  const outcome = await analyzeStyleCompliance(input, ruleset);
+  try {
+    // 24h TTL; the key is content-addressed so it's safe to keep — a changed
+    // guide or changed screen produces a different key, not a stale hit.
+    await redis.set(key, outcome, { ex: 60 * 60 * 24 });
+  } catch {
+    // cache write is best-effort
+  }
+  return outcome;
 }


### PR DESCRIPTION
Second in-Figma test (correctly) flagged that the plugin's Style Guide and the web's still differed (6 vs 7, different categories) **for a single scan**. Root cause: the plugin's in-canvas Improve Copy and the persisted score the web displays were each making an **independent `analyzeStyleCompliance` call** — same engine, two calls, so they drift even at temperature 0.

Chester's point is the right architecture: scan once → compute once → display everywhere.

## Fix
- **`analyzeStyleComplianceCached`** — content-addressed cache keyed on (org + ruleset + exact text), 24h TTL. The first caller computes; every other surface reuses the **identical** result. Only caches when there's ground-truth `frameText` (a stable key); image-only stays best-effort/uncached. Editing the guide or the screen changes the key → fresh result.
- **`persist-score`** and **`/api/plugin/analyze/copy`** both use it, so a single plugin scan yields one shared style result on web and in-canvas.

No contract change (copy still returns `{ styleGuide, general }`). app 0.5.12 / api 1.2.0.

## Verification
- `tsc` / eslint / `next build` green.
- In-Figma re-test: plugin Style Guide section === web dashboard Style Guide (same count, categories, rewrites).

## /hq
features (computed-once-and-cached note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)