### PR TITLE
style(#362): polish style-guide ambiguities section on Settings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -664,33 +664,37 @@ function StyleGuideCard() {
           )}
 
           {status.present && status.conflicts && status.conflicts.length > 0 && (
-            <div className="mt-4 border border-[#b8860b]/50 bg-[#b8860b]/10 p-3">
-              <p className="text-xs text-[#e3c46b] font-sans font-semibold">
+            <div className="mt-6">
+              {/* Heading above the boxes, gold, same style as the "Team Style Guide" label. */}
+              <p className="text-[9px] text-[#d4af37] uppercase tracking-widest font-semibold">
                 {status.conflicts.length} ambiguit
                 {status.conflicts.length === 1 ? "y" : "ies"} in your guide
               </p>
-              <p className="text-[10px] text-[#e3c46b]/80 font-sans mt-1 leading-relaxed">
+              <p className="text-sm text-foreground font-sans mt-2 leading-relaxed">
                 Your guide gives conflicting direction in places. Ladder applies the
                 most specific rule (shown below). To change how these are handled,
                 edit your style guide and upload a new version.
               </p>
-              <ul className="mt-3 space-y-3">
+              <div className="mt-4 space-y-3">
                 {status.conflicts.map((c, i) => (
-                  <li key={i} className="border-t border-[#b8860b]/20 pt-2 first:border-t-0 first:pt-0">
-                    <p className="text-xs text-foreground font-sans font-semibold">
+                  <div
+                    key={i}
+                    className="border border-[#b8860b]/50 bg-[#b8860b]/10 p-4"
+                  >
+                    <p className="text-sm text-foreground font-sans font-semibold">
                       {c.topic}
                     </p>
-                    <p className="text-[11px] text-muted font-sans mt-0.5 leading-relaxed">
+                    <p className="text-sm text-foreground font-sans mt-1.5 leading-relaxed">
                       {c.summary}
                     </p>
                     {c.interpretation && (
-                      <p className="text-[11px] text-[#e3c46b] font-sans mt-1 leading-relaxed">
+                      <p className="text-sm text-[#e3c46b] font-sans mt-2 leading-relaxed">
                         Ladder applies: {c.interpretation}
                       </p>
                     )}
-                  </li>
+                  </div>
                 ))}
-              </ul>
+              </div>
             </div>
           )}
         </div>


### PR DESCRIPTION
Styling-only follow-up to the conflict-surfacing feature, per Chester's review:

- "N ambiguities in your guide" heading moves **above** the boxes, **gold**, in the same uppercase/tracked style as the "Team Style Guide" label.
- All body text bumped to `text-sm` (matches the left column).
- Gray body text → **white**; the "Ladder applies" interpretation line stays gold to set it apart.
- Each contradiction is now its **own** bordered amber box with spacing, instead of one shared box.

Pure CSS/markup on an already-documented feature — no `/hq` or version change. tsc/eslint green. (The section only renders with a Team org + a guide that has conflicts, so Chester confirms the visual.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)