### PR TITLE
fix(#343): unify Figma scoring onto the canonical engine + consistency harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.18 / api 1.4.0 (2026-07-06)
+
+**Figma scoring unified onto the one canonical engine (#343).**
+
+- The Figma plugin's Ladder score used to run in the plugin's own backend, calling Anthropic directly at the API default temperature with no cache, so the same screen drifted (measured ~0.18 avg score range across 10 runs, worst 0.7, vs ~0.005 on the canonical engine) and never matched web/Skill. The plugin now scores through runladder's **one canonical engine** (temperature 0, content-addressed cache) — the same path web and Skill already use — so a given screen scores identically on every surface.
+- New endpoint `POST /api/plugin/analyze/stream` (additive → api 1.4.0): service-token auth, wraps `scoreImageStream`, emits the plugin's SSE event shape (score / label / screenName / complete / error) so the in-canvas score still streams in. Usage counting + persistence stay on the plugin side (single writer of Figma scores).
+- Engine behavior is unchanged (still v1.3); this only changes which engine the plugin calls. `scoreImage` gains internal-only `bypassCache` / `temperature` overrides used by the consistency harness (`scripts/score-consistency.mjs`); production callers never set them.
+- Known follow-up: routing through the shared engine adds a moderation round-trip + a network hop before the score streams, so the in-canvas number appears a little later than before. Tracked separately (perf, not consistency).
+
+---
+
 ## app 0.5.17 / api 1.3.0 (2026-06-30)
 
 **Score determinism: the same screenshot now scores the same (#210/#343). Scoring engine → v1.3.**

--- a/docs/deterministic-scoring-plan.md
+++ b/docs/deterministic-scoring-plan.md
@@ -1,0 +1,216 @@
+# Deterministic Ladder Scoring — Engineering Plan
+
+Status: approved to build (Chester, 2026-07-02). Not started. Tracks GitHub #343.
+Owner: Chester + Sara (AI pair). Resume here after the holiday weekend.
+
+## The goal (the contract)
+
+For a given engine version, a given screen produces the same Ladder score every
+time and on every surface. A score moves for exactly two reasons: the screen
+changed, or we deliberately versioned the engine and announced it. Nothing else.
+This is what makes the core product loop trustworthy: measure a screen, improve
+it, remeasure to validate the improvement.
+
+Precise wording of the promise: **same pixels, same score.** Not "a design
+mockup and its shipped code score identically."
+
+## Why "same pixels, same score" is the right contract
+
+The engine scores an image. Every surface reduces to pixels before scoring:
+Figma rasterizes a frame to an image, Web takes an uploaded image, URL takes a
+screenshot of rendered code. So cross-surface consistency is just two things:
+one deterministic engine, and surfaces that hand it the same pixels when the
+source genuinely is the same artifact.
+
+That is why only pairs can be compared, not the trio:
+
+- Figma and Web: yes. Export the frame as a PNG, upload that PNG to Web.
+  Identical pixels, identical score.
+- Web and URL: yes. Screenshot the live page, upload that screenshot to Web.
+  Identical pixels, identical score.
+- All three: no. A Figma frame is a design. The URL is the built, live code.
+  Different renderings of the same screen (real fonts, real data, responsive
+  layout, engineering drift), so different pixels. Different scores there are
+  correct, not a defect.
+
+## What is broken today (grounded in the code)
+
+1. The screen score is a number the model invents holistically. In
+   `src/lib/scoring.ts` the model returns a JSON `score` field and the code uses
+   it verbatim (`JSON.parse(...).score`). Holistic numbers are high variance.
+   Per-rung scores are also model-emitted, and the prompt tells the model to do
+   the weighted combination itself. Code does no math.
+2. "Determinism" was never real. It was a cache with a 30-day TTL
+   (`setCachedScore`, `redis.set(key, core, { ex: 60*60*24*30 })`) hiding the
+   variance. It only matches byte-identical images, and it expires.
+3. Three different engines, and the #377 determinism fix touched only one:
+   - Web + Skill: `scoreImage` in `src/lib/scoring.ts`, model `claude-haiku-4-5`,
+     temperature 0, 30-day cache.
+   - Figma plugin: its own backend `ai-design-assistant/api/analyze.js`, builds
+     its own prompt (`buildPrompt`), calls Anthropic directly via `fetch` with
+     NO temperature field (so API default ~1.0) and NO score cache. Drifts on
+     every scan and never matched Web. It fetches only the framework CONTENT
+     from runladder (`/api/framework` via `_ladder.js`), not the scoring logic.
+   - Pulse: separate repo `ladder-beta`, OpenAI, out of scope (see below).
+
+## Design principles
+
+- The model MEASURES. Code COMPUTES the score with a fixed formula. We already
+  do exactly this for Pulse: `scoreFromSentiments` in
+  `src/lib/ladder-framework.ts` maps per-rung values to a score via a weighted
+  formula and a `RUNG_WEIGHTS` table. Screens never got that treatment.
+- One engine, all surfaces.
+- Pin the model version and the engine version. The engine version is the only
+  thing that intentionally moves scores.
+- Constrain the model's outputs to discrete, checkable judgments to minimize
+  measurement variance.
+- Any cache is a pure performance optimization that returns what the engine
+  would compute. It is never the source of "sameness."
+- The Ladder score and Style Guide compliance are separate features. Compliance
+  NEVER affects the number. This invariant is now stated in
+  `src/content/hq/architecture.mdx` (working-tree edit, not yet shipped).
+
+## Locked decisions (Chester, 2026-07-02)
+
+- No real customers use the tool yet, so a one-time score shift when we move to
+  computed scoring is acceptable, as long as new scores are not wildly different
+  from today's. Wildly different is a signal the formula needs tuning, not a
+  blocker.
+- Figma unification is critical and moves early. The client's designers work in
+  Figma daily and most screens will be scored there. We cannot measure
+  consistency while the plugin runs a different engine.
+- Contract wording is "same pixels, same score."
+
+## Out of scope: rebuilding Pulse
+
+Ladder Pulse (in `ladder-beta`, on OpenAI) has been in use by the target client
+for about a year. It is out of scope to rebuild it on Anthropic. The same client
+will use Pulse and the new screen-scoring tool at the same time, so we stay aware
+of it.
+
+Plain-language framing for Ward when he asks: Pulse measures what customers SAY
+about an experience (survey feedback). The new tool measures what a SCREEN IS
+(its UX quality). Same Ladder, same five rungs, same style of math, but different
+inputs, so for the same product a Pulse score and a screen score answer different
+questions and will not necessarily match. That is expected. Pulse is already
+consistent because it is math over survey answers. We leave it untouched and make
+the screen score equally rock solid.
+
+## The phased plan
+
+### Phase 0. Consistency harness (no scoring changes)
+
+Objective: make the problem measurable and give ourselves a regression gate. Its
+absence is why the drift went unseen.
+
+- New script, e.g. `scripts/score-consistency.mjs`:
+  - Score a fixed set of fixture images (`public/screenshots/*`) N times each and
+    report the score spread per image. Must run with the cache DISABLED, or it
+    trivially passes on cache hits and measures nothing.
+  - Valid-pair check: score a Figma-exported PNG through the plugin path and
+    through the web path (same bytes), and a URL screenshot vs a web upload of
+    that screenshot. Expect identical once the engine is unified.
+  - Baseline vs current: snapshot today's scores to a JSON baseline, then compare
+    later phases against it to catch "wildly different."
+- Done when: the report exists, today's variance is quantified, baseline captured.
+
+### Phase 1. Unify Figma onto runladder's engine
+
+Objective: one engine, all surfaces. Kill the plugin's separate scorer. This
+alone stops the plugin's default-temperature drift and makes comparisons valid.
+
+- In `ai-design-assistant/api/analyze.js`, route "improve" mode (the Ladder
+  score) to runladder's canonical scoring, the same way "copy" mode was routed in
+  #362 Chunk 1 (see `forwardCopyAudit` and the copy-mode branch). Remove the local
+  `buildPrompt` + direct Anthropic `fetch` for the score.
+- runladder side: `src/app/api/plugin/analyze/route.ts` already calls
+  `scoreImage`. Confirm/extend it as the canonical plugin score endpoint. Ensure
+  the frame image (and any ground-truth data we choose to send) flows through it.
+- Done when: plugin improve-mode score is computed by runladder, and the Phase 0
+  pair check shows a Figma export and its web upload scoring identically.
+
+### Phase 2. Model measures, code computes
+
+Objective: the score becomes a deterministic function of measurements.
+
+- Add `scoreFromScreen(measurements)` to `src/lib/ladder-framework.ts`, a sibling
+  to `scoreFromSentiments`, with an explicit weighted formula.
+- Simplest first cut: the model already returns per-rung scores. Ignore the
+  model's `score` total and compute it deterministically from the rungs (reuse
+  `RUNG_WEIGHTS` / the `scoreFromSentiments` shape). Tune weights so results are
+  not wildly different from the Phase 0 baseline.
+- In `src/lib/scoring.ts`, stop trusting the model's `score`; set
+  `result.score = scoreFromScreen(result.rungs)`.
+- Bump `CURRENT_ENGINE_VERSION` (deliberate, announced change) and add a CHANGELOG
+  entry.
+- Done when: total score is computed by code, and the baseline comparison is
+  within an acceptable band.
+
+### Phase 3. Constrain the measurements
+
+Objective: squeeze residual variance out of the measurements themselves.
+
+- Convert the seven evaluation dimensions (already concrete yes/no criteria in
+  `EVALUATION_DIMENSIONS`) into explicit discrete answers (yes / partial / no, or
+  a 0 to 2 ordinal). Map criteria to dimension scores to rung scores to the final
+  score, all deterministically.
+- Temperature 0 everywhere (now includes Figma via Phase 1).
+- If the harness still shows wobble on borderline criteria, add a "best of three,
+  take the majority" measurement pass. Note the cost and latency tradeoff before
+  turning it on.
+- Done when: the harness shows near-zero spread across repeats.
+
+### Phase 4. Input parity for the valid pairs
+
+Objective: make the same artifact produce the same pixels across a valid pair.
+
+- Align capture and resize so a Figma export, a URL screenshot, and a web upload
+  of the same artifact match. Reconcile `resizeForScoring` in
+  `src/app/score/page.tsx` with the plugin's export settings and the URL
+  screenshot path in `src/app/api/screenshot/route.ts`.
+- Be explicit in docs and UI copy that design vs live code is outside this
+  promise.
+- Done when: the Phase 0 pair checks pass within tolerance.
+
+### Phase 5. Cache becomes a pure speed optimization
+
+Objective: remove the illusion, keep the performance.
+
+- Remove the 30-day TTL in `setCachedScore`. With a deterministic engine the
+  cache returns exactly what would be recomputed, so it is memoization, not
+  truth. Keep the engine version in the key so a version bump invalidates cleanly.
+- Verify the prod KV binding actually hits. `getCachedScore` swallows errors and
+  returns null, so a misconfigured binding silently misses and re-scores. This is
+  a real risk given the KV migration history.
+- Done when: no TTL, cache documented as perf-only, prod hit-rate confirmed.
+
+## Open questions to resolve during execution
+
+- The exact weight table for `scoreFromScreen`. Start from `RUNG_WEIGHTS` and tune
+  against the Phase 0 baseline so scores are coherent with today's.
+- Whether best-of-three (Phase 3) is needed. Decide from harness data, not upfront.
+- The canonical plugin score endpoint shape (extend `/api/plugin/analyze` vs a new
+  route), and what, if anything, beyond the raster image we send from Figma.
+
+## Key file map
+
+- `src/lib/scoring.ts` — screen scoring pipeline, cache, model call.
+- `src/lib/ladder-framework.ts` — rubric, dimensions, `RUNG_WEIGHTS`,
+  `scoreFromSentiments` (the deterministic pattern to reuse).
+- `src/lib/app-version.ts` — `CURRENT_ENGINE_VERSION`.
+- `src/app/api/score/route.ts`, `src/app/api/score/stream/route.ts` — web.
+- `src/app/api/skill/score/route.ts` — Skill (already on the shared engine).
+- `src/app/api/plugin/analyze/route.ts` — runladder plugin endpoint (calls
+  `scoreImage`).
+- `src/app/api/screenshot/route.ts` — URL capture + DOM text.
+- `ai-design-assistant/api/analyze.js` — the plugin's separate scorer to retire.
+- `ai-design-assistant/api/_ladder.js` — plugin's framework fetcher.
+
+## Working-tree state at handoff
+
+- `src/content/hq/architecture.mdx` has an uncommitted edit stating the
+  score-vs-style-guide separation invariant, plus an `updatedAt` bump. Per the
+  no-auto-commit workflow it is left uncommitted, to ship when work resumes.
+- The separate Style Guide bug (the incoherent "Next ship date to Quantity"
+  finding) is NOT part of this plan. It is a separate compliance-pass bug to
+  triage on its own.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.17",
+  "version": "0.5.18",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/scripts/score-consistency.baseline.json
+++ b/scripts/score-consistency.baseline.json
@@ -1,0 +1,2927 @@
+{
+  "generatedAt": "2026-07-06T18:11:12.673Z",
+  "runs": 10,
+  "screens": [
+    {
+      "product": "stripe",
+      "path": "public/screenshots/stripe/hero.png",
+      "sha": "8455cedde6cc",
+      "runs": [
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.4,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.7,
+          2.8,
+          2.8,
+          2.8,
+          2.8,
+          2.8,
+          2.8,
+          2.8,
+          2.7,
+          2.8
+        ],
+        "distinct": [
+          2.7,
+          2.8
+        ],
+        "min": 2.7,
+        "max": 2.8,
+        "range": 0.1,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0,
+          "comfortable": 0.2,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "airbnb",
+      "path": "public/screenshots/airbnb/hero.png",
+      "sha": "d8cdd93bcd24",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.6,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.6,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.6,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6
+        ],
+        "distinct": [
+          3.6
+        ],
+        "min": 3.6,
+        "max": 3.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.2,
+          "comfortable": 0.2,
+          "delightful": 0.6,
+          "meaningful": 0.6
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "notion",
+      "path": "public/screenshots/notion/hero.png",
+      "sha": "1c301d77e225",
+      "runs": [
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.5,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 2.9,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.4,
+            "comfortable": 2.2,
+            "usable": 3.1,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.5,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.4,
+            "comfortable": 2.2,
+            "usable": 3.1,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6
+        ],
+        "min": 2.6,
+        "max": 2.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.4,
+          "comfortable": 0.2,
+          "delightful": 0.3,
+          "meaningful": 0.2
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "linear",
+      "path": "public/screenshots/linear/hero.png",
+      "sha": "dd4aefbd3234",
+      "runs": [
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6
+        ],
+        "min": 2.6,
+        "max": 2.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.1,
+          "comfortable": 0.2,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "figma",
+      "path": "public/screenshots/figma/hero.png",
+      "sha": "6e91748f49dc",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "spotify",
+      "path": "public/screenshots/spotify/hero.png",
+      "sha": "e10a88595c40",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "vercel",
+      "path": "public/screenshots/vercel/hero.png",
+      "sha": "320c8e92028e",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.2,
+          "comfortable": 0.4,
+          "delightful": 0.2,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "webflow",
+      "path": "public/screenshots/webflow/hero.png",
+      "sha": "e920dfd28e40",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "retool",
+      "path": "public/screenshots/retool/hero.png",
+      "sha": "fb4d49d83f22",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.2,
+          "comfortable": 0.2,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "salesforce",
+      "path": "public/screenshots/salesforce/hero.png",
+      "sha": "87010a66f3a7",
+      "runs": [
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3
+        ],
+        "distinct": [
+          2.3
+        ],
+        "min": 2.3,
+        "max": 2.3,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "venmo",
+      "path": "public/screenshots/venmo/hero.png",
+      "sha": "9fad05c3658e",
+      "runs": [
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4
+        ],
+        "distinct": [
+          3.4
+        ],
+        "min": 3.4,
+        "max": 3.4,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0.1,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "revolut",
+      "path": "public/screenshots/revolut/hero.png",
+      "sha": "bc97a3b5dc99",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.2,
+          "comfortable": 0.2,
+          "delightful": 0.2,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "uber",
+      "path": "public/screenshots/uber/hero.png",
+      "sha": "80fc7489477d",
+      "runs": [
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.6
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.6
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4
+        ],
+        "distinct": [
+          3.4
+        ],
+        "min": 3.4,
+        "max": 3.4,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.4,
+          "usable": 0.3,
+          "comfortable": 0.2,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "youtube",
+      "path": "public/screenshots/youtube/hero.png",
+      "sha": "535ba87e4595",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.2,
+          "comfortable": 0.2,
+          "delightful": 0.3,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "slack",
+      "path": "public/screenshots/slack/hero.png",
+      "sha": "5482f0ae1ae2",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "shopify",
+      "path": "public/screenshots/shopify/hero.png",
+      "sha": "07b0619c38d3",
+      "runs": [
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3
+        ],
+        "distinct": [
+          2.3
+        ],
+        "min": 2.3,
+        "max": 2.3,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0.1,
+          "meaningful": 0.2
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "postman",
+      "path": "public/screenshots/postman/hero.png",
+      "sha": "db84f024172f",
+      "runs": [
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.8
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.8
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6
+        ],
+        "min": 2.6,
+        "max": 2.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.3,
+          "comfortable": 0.3,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "supabase",
+      "path": "public/screenshots/supabase/hero.png",
+      "sha": "38f6b881dcef",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6
+        ],
+        "distinct": [
+          3.6
+        ],
+        "min": 3.6,
+        "max": 3.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "raycast",
+      "path": "public/screenshots/raycast/hero.png",
+      "sha": "2e45d52d7ea2",
+      "runs": [
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.3
+        ],
+        "distinct": [
+          2.3
+        ],
+        "min": 2.3,
+        "max": 2.3,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0.1,
+          "comfortable": 0,
+          "delightful": 0.1,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "todoist",
+      "path": "public/screenshots/todoist/hero.png",
+      "sha": "40458562c0cf",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6
+        ],
+        "distinct": [
+          3.6
+        ],
+        "min": 3.6,
+        "max": 3.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0,
+          "usable": 0,
+          "comfortable": 0,
+          "delightful": 0,
+          "meaningful": 0
+        },
+        "exact": true
+      }
+    }
+  ]
+}

--- a/scripts/score-consistency.mjs
+++ b/scripts/score-consistency.mjs
@@ -1,0 +1,176 @@
+/**
+ * Ladder score CONSISTENCY harness (#343, Phase 0).
+ *
+ * Measures the scoring engine's true run-to-run variance: it scores the same
+ * unchanged image many times with the cache BYPASSED, so it measures the model,
+ * not the cache. The target is exact equality — the same pixels must return the
+ * same score every time. This quantifies how far today's engine is from that.
+ *
+ * It also writes a baseline JSON so later phases (model-measures / code-computes)
+ * can prove scores did not drift wildly from where they are today.
+ *
+ * Run (needs a real ANTHROPIC_API_KEY in .env.local; note the shadow-var unset):
+ *   unset ANTHROPIC_API_KEY && npx tsx scripts/score-consistency.mjs
+ *
+ * Options (env vars):
+ *   RUNS=10         repeats per screen
+ *   SCREENS=20      how many genuinely-unique screens to sample
+ *   CONCURRENCY=5   parallel in-flight scoring calls
+ *
+ * NOT wired into CI — it makes live model calls and costs money. It is a manual
+ * guardrail for humans working on the engine, like scripts/eval-style-guide.mjs.
+ */
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, existsSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import nextEnv from "@next/env";
+nextEnv.loadEnvConfig(process.cwd(), true);
+
+const { scoreImage } = await import("../src/lib/scoring.ts");
+
+const RUNS = Number(process.env.RUNS || 10);
+const SCREENS = Number(process.env.SCREENS || 20);
+const CONCURRENCY = Number(process.env.CONCURRENCY || 5);
+const TEMP = process.env.TEMP !== undefined ? Number(process.env.TEMP) : 0;
+const SHOTS_DIR = "public/screenshots";
+const OUT =
+  TEMP === 0
+    ? "scripts/score-consistency.baseline.json"
+    : `scripts/score-consistency.temp${TEMP}.json`;
+
+/* ── Curate genuinely-unique screens ──────────────────────────────────────
+ * Each product dir holds hero/mid/lower — three vertical slices of ONE page,
+ * not three screens. So we take ONE slice (hero) per product, dedupe by content
+ * hash (some files are exact byte-duplicates), and sample a diverse subset. */
+const PREFERRED = [
+  "stripe", "airbnb", "notion", "linear", "figma", "spotify", "vercel",
+  "webflow", "retool", "salesforce", "venmo", "revolut", "uber", "youtube",
+  "slack", "shopify", "postman", "supabase", "raycast", "todoist",
+];
+
+function heroPath(product) {
+  for (const name of ["hero.png", "hero.jpg", "hero.jpeg", "hero.webp"]) {
+    const p = join(SHOTS_DIR, product, name);
+    if (existsSync(p)) return p;
+  }
+  return null;
+}
+
+function pickScreens() {
+  const allProducts = readdirSync(SHOTS_DIR, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => d.name);
+  const ordered = [...PREFERRED, ...allProducts.filter((p) => !PREFERRED.includes(p))];
+
+  const seenHashes = new Set();
+  const chosen = [];
+  for (const product of ordered) {
+    if (chosen.length >= SCREENS) break;
+    const path = heroPath(product);
+    if (!path) continue;
+    const bytes = readFileSync(path);
+    const sha = createHash("sha256").update(bytes).digest("hex");
+    if (seenHashes.has(sha)) continue; // skip exact byte-duplicates
+    seenHashes.add(sha);
+    chosen.push({
+      product,
+      path,
+      sha: sha.slice(0, 12),
+      base64: bytes.toString("base64"),
+    });
+  }
+  return chosen;
+}
+
+/* ── Run N scores per screen, cache bypassed ─────────────────────────────── */
+async function scoreOnce(base64) {
+  const res = await scoreImage(
+    { mediaType: "image/png", base64Data: base64 },
+    { bypassCache: true, temperature: TEMP },
+  );
+  if (res && typeof res.score === "number") {
+    const rungs = res.rungs || {};
+    return {
+      score: res.score,
+      label: res.label,
+      rungs: Object.fromEntries(
+        Object.entries(rungs).map(([k, v]) => [k, v?.score]),
+      ),
+    };
+  }
+  return { error: res?.error || "unknown scoring error" };
+}
+
+async function pool(items, limit, fn) {
+  const out = new Array(items.length);
+  let i = 0;
+  async function worker() {
+    while (i < items.length) {
+      const idx = i++;
+      out[idx] = await fn(items[idx], idx);
+    }
+  }
+  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker));
+  return out;
+}
+
+function summarizeScreen(runs) {
+  const scores = runs.filter((r) => typeof r.score === "number").map((r) => r.score);
+  const errors = runs.length - scores.length;
+  const distinct = [...new Set(scores)].sort((a, b) => a - b);
+  const min = scores.length ? Math.min(...scores) : null;
+  const max = scores.length ? Math.max(...scores) : null;
+  const range = min !== null ? +(max - min).toFixed(2) : null;
+  // per-rung spread
+  const rungKeys = ["functional", "usable", "comfortable", "delightful", "meaningful"];
+  const rungSpread = {};
+  for (const k of rungKeys) {
+    const vals = runs.map((r) => r.rungs?.[k]).filter((v) => typeof v === "number");
+    if (vals.length) rungSpread[k] = +(Math.max(...vals) - Math.min(...vals)).toFixed(2);
+  }
+  return { scores, distinct, min, max, range, errors, rungSpread, exact: distinct.length <= 1 && errors === 0 };
+}
+
+/* ── Main ─────────────────────────────────────────────────────────────────── */
+const screens = pickScreens();
+console.log(`\nLadder score consistency harness (#343 Phase 0)`);
+console.log(`Screens: ${screens.length} unique | Runs each: ${RUNS} | cache: BYPASSED | temp: ${TEMP}${TEMP === 1 ? " (simulates the Figma plugin's default-temp path)" : TEMP === 0 ? " (pinned engine default)" : ""}\n`);
+console.log(screens.map((s) => s.product).join(", ") + "\n");
+
+const results = [];
+for (const s of screens) {
+  process.stdout.write(`scoring ${s.product} x${RUNS} ... `);
+  const runs = await pool(Array.from({ length: RUNS }), CONCURRENCY, () => scoreOnce(s.base64));
+  const sum = summarizeScreen(runs);
+  results.push({ product: s.product, path: s.path, sha: s.sha, runs, summary: sum });
+  console.log(
+    sum.exact
+      ? `EXACT (${sum.distinct[0]})`
+      : `DRIFT range=${sum.range} distinct=[${sum.distinct.join(", ")}]${sum.errors ? ` errors=${sum.errors}` : ""}`,
+  );
+}
+
+/* ── Report ───────────────────────────────────────────────────────────────── */
+const scored = results.filter((r) => r.summary.scores.length > 0);
+const exactCount = scored.filter((r) => r.summary.exact).length;
+const worst = [...scored].sort((a, b) => (b.summary.range ?? 0) - (a.summary.range ?? 0))[0];
+const avgRange = scored.length
+  ? +(scored.reduce((a, r) => a + (r.summary.range ?? 0), 0) / scored.length).toFixed(3)
+  : null;
+
+console.log(`\n──────── SUMMARY ────────`);
+console.log(`Exactly consistent screens: ${exactCount}/${scored.length}`);
+console.log(`Avg score range across ${RUNS} runs: ${avgRange}`);
+if (worst) console.log(`Worst screen: ${worst.product} range=${worst.summary.range} distinct=[${worst.summary.distinct.join(", ")}]`);
+console.log(`Target: exact equality (range 0.00 on every screen).`);
+
+writeFileSync(
+  OUT,
+  JSON.stringify(
+    { generatedAt: new Date().toISOString(), runs: RUNS, screens: results },
+    null,
+    2,
+  ),
+);
+console.log(`\nBaseline written to ${OUT}\n`);

--- a/scripts/score-consistency.temp1.json
+++ b/scripts/score-consistency.temp1.json
@@ -1,0 +1,2919 @@
+{
+  "generatedAt": "2026-07-06T20:41:40.241Z",
+  "runs": 10,
+  "screens": [
+    {
+      "product": "stripe",
+      "path": "public/screenshots/stripe/hero.png",
+      "sha": "8455cedde6cc",
+      "runs": [
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.6,
+            "comfortable": 2.4,
+            "usable": 3.2,
+            "functional": 3.8
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.6,
+            "comfortable": 2.9,
+            "usable": 3.2,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.4,
+            "comfortable": 2.6,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.4,
+            "usable": 3.1,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.3,
+            "comfortable": 2.4,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.3,
+            "comfortable": 2.4,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.4,
+            "usable": 2.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.6,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.6,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.1,
+            "delightful": 1.3,
+            "comfortable": 2.4,
+            "usable": 3.2,
+            "functional": 3.7
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.8,
+          2.8,
+          2.7,
+          2.8,
+          2.6,
+          2.8,
+          2.7,
+          2.8,
+          2.8,
+          2.6
+        ],
+        "distinct": [
+          2.6,
+          2.7,
+          2.8
+        ],
+        "min": 2.6,
+        "max": 2.8,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.6,
+          "usable": 0.5,
+          "comfortable": 0.5,
+          "delightful": 0.4,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "airbnb",
+      "path": "public/screenshots/airbnb/hero.png",
+      "sha": "d8cdd93bcd24",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.7,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.8,
+            "usable": 4,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.5
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.4,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.4,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.4,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6
+        ],
+        "distinct": [
+          3.6
+        ],
+        "min": 3.6,
+        "max": 3.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.4,
+          "usable": 0.3,
+          "comfortable": 0.3,
+          "delightful": 0.7,
+          "meaningful": 1.1
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "notion",
+      "path": "public/screenshots/notion/hero.png",
+      "sha": "1c301d77e225",
+      "runs": [
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.5,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.5,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.4,
+            "comfortable": 2.1,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.2,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 2.8,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.6,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 2.9,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.2,
+            "usable": 2.9,
+            "functional": 3.4
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.6,
+          2.7,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.7,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6,
+          2.7
+        ],
+        "min": 2.6,
+        "max": 2.7,
+        "range": 0.1,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.5,
+          "usable": 0.4,
+          "comfortable": 0.2,
+          "delightful": 0.4,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "linear",
+      "path": "public/screenshots/linear/hero.png",
+      "sha": "dd4aefbd3234",
+      "runs": [
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3,
+            "functional": 3.8
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 2.9,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 2.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 2.9,
+            "functional": 3.8
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.3,
+            "comfortable": 2.2,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.1,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.2,
+            "functional": 3.9
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.7,
+          2.6,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6,
+          2.7
+        ],
+        "min": 2.6,
+        "max": 2.7,
+        "range": 0.1,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.6,
+          "usable": 0.6,
+          "comfortable": 0.2,
+          "delightful": 0.1,
+          "meaningful": 0
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "figma",
+      "path": "public/screenshots/figma/hero.png",
+      "sha": "6e91748f49dc",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 3.5,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 4.2,
+            "delightful": 2.8,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.4,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 4.2,
+            "delightful": 2.8,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.4,
+          "comfortable": 0.4,
+          "delightful": 0.7,
+          "meaningful": 3.2
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "spotify",
+      "path": "public/screenshots/spotify/hero.png",
+      "sha": "e10a88595c40",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 4.1,
+            "delightful": 3.3,
+            "comfortable": 3.2,
+            "usable": 3.4,
+            "functional": 3.8
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.6,
+            "comfortable": 3.4,
+            "usable": 3.5,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.6,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "error": "Failed to parse scoring response"
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.4,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.4,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 1,
+        "rungSpread": {
+          "functional": 0.5,
+          "usable": 0.5,
+          "comfortable": 0.4,
+          "delightful": 1.2,
+          "meaningful": 2.9
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "vercel",
+      "path": "public/screenshots/vercel/hero.png",
+      "sha": "320c8e92028e",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.4,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.4,
+            "comfortable": 3.6,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2
+        ],
+        "min": 3.2,
+        "max": 3.2,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.4,
+          "comfortable": 0.4,
+          "delightful": 0.6,
+          "meaningful": 0.8
+        },
+        "exact": true
+      }
+    },
+    {
+      "product": "webflow",
+      "path": "public/screenshots/webflow/hero.png",
+      "sha": "e920dfd28e40",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.5,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.1,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.1,
+            "usable": 3.4,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.1
+        ],
+        "distinct": [
+          3.1,
+          3.2
+        ],
+        "min": 3.1,
+        "max": 3.2,
+        "range": 0.1,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.3,
+          "usable": 0.4,
+          "comfortable": 0.5,
+          "delightful": 1,
+          "meaningful": 1.1
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "retool",
+      "path": "public/screenshots/retool/hero.png",
+      "sha": "fb4d49d83f22",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.4,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.7,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.4,
+            "comfortable": 3.5,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.6,
+            "comfortable": 3.8,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.6,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2,
+          3.6
+        ],
+        "min": 3.2,
+        "max": 3.6,
+        "range": 0.4,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.5,
+          "comfortable": 0.6,
+          "delightful": 0.7,
+          "meaningful": 1.1
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "salesforce",
+      "path": "public/screenshots/salesforce/hero.png",
+      "sha": "87010a66f3a7",
+      "runs": [
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "error": "Failed to parse scoring response"
+        },
+        {
+          "score": 2.2,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.2,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 4
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.3,
+          2.2,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          2.2,
+          2.3,
+          2.3
+        ],
+        "distinct": [
+          2.2,
+          2.3
+        ],
+        "min": 2.2,
+        "max": 2.3,
+        "range": 0.1,
+        "errors": 1,
+        "rungSpread": {
+          "functional": 0.4,
+          "usable": 0.1,
+          "comfortable": 0,
+          "delightful": 0.1,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "venmo",
+      "path": "public/screenshots/venmo/hero.png",
+      "sha": "9fad05c3658e",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 4.2,
+            "functional": 4.5
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.2,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.8,
+            "usable": 4.2,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.6,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.4,
+          3.4,
+          3.4,
+          3.6,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.4
+        ],
+        "distinct": [
+          3.4,
+          3.6
+        ],
+        "min": 3.4,
+        "max": 3.6,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.4,
+          "usable": 0.6,
+          "comfortable": 0.4,
+          "delightful": 0.7,
+          "meaningful": 1.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "revolut",
+      "path": "public/screenshots/revolut/hero.png",
+      "sha": "bc97a3b5dc99",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 4.1,
+            "functional": 4.6
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.5,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.4
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.4,
+          3.4,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2,
+          3.4
+        ],
+        "min": 3.2,
+        "max": 3.4,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.5,
+          "usable": 0.4,
+          "comfortable": 0.3,
+          "delightful": 0.7,
+          "meaningful": 1.1
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "uber",
+      "path": "public/screenshots/uber/hero.png",
+      "sha": "80fc7489477d",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.8,
+            "usable": 3.9,
+            "functional": 4.6
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "error": "Failed to parse scoring response"
+        },
+        {
+          "score": 3.3,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.7,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.8,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.7,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.2,
+          3.2,
+          3.3,
+          3.4,
+          3.4,
+          3.4,
+          3.4,
+          3.6
+        ],
+        "distinct": [
+          3.2,
+          3.3,
+          3.4,
+          3.6
+        ],
+        "min": 3.2,
+        "max": 3.6,
+        "range": 0.4,
+        "errors": 1,
+        "rungSpread": {
+          "functional": 0.5,
+          "usable": 0.4,
+          "comfortable": 0.2,
+          "delightful": 0.7,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "youtube",
+      "path": "public/screenshots/youtube/hero.png",
+      "sha": "535ba87e4595",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.5,
+            "usable": 3.6,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.2,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.4,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2
+        ],
+        "distinct": [
+          3.2,
+          3.4
+        ],
+        "min": 3.2,
+        "max": 3.4,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.1,
+          "usable": 0.2,
+          "comfortable": 0.3,
+          "delightful": 0.2,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "slack",
+      "path": "public/screenshots/slack/hero.png",
+      "sha": "5482f0ae1ae2",
+      "runs": [
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.4,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2,
+            "delightful": 2.3,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.4,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4
+          }
+        },
+        {
+          "score": 3.2,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.2,
+            "usable": 3.6,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.4,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.2,
+          3.4
+        ],
+        "distinct": [
+          3.2,
+          3.4
+        ],
+        "min": 3.2,
+        "max": 3.4,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.3,
+          "comfortable": 0.2,
+          "delightful": 0.7,
+          "meaningful": 1.1
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "shopify",
+      "path": "public/screenshots/shopify/hero.png",
+      "sha": "07b0619c38d3",
+      "runs": [
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.6,
+            "functional": 3.4
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.9,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.3,
+            "comfortable": 2.1,
+            "usable": 2.9,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.7
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.3,
+          2.3,
+          2.3,
+          2.6,
+          2.3,
+          2.6,
+          2.3,
+          2.3,
+          2.3,
+          2.6
+        ],
+        "distinct": [
+          2.3,
+          2.6
+        ],
+        "min": 2.3,
+        "max": 2.6,
+        "range": 0.3,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.7,
+          "usable": 0.3,
+          "comfortable": 0.5,
+          "delightful": 0.2,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "postman",
+      "path": "public/screenshots/postman/hero.png",
+      "sha": "db84f024172f",
+      "runs": [
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.3,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.8,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.4,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.7,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.4,
+            "comfortable": 2.2,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 3.4,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2.1,
+            "usable": 2.8,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 2,
+            "usable": 3.1,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.1,
+            "comfortable": 2.2,
+            "usable": 3.4,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 1.8,
+            "comfortable": 2.4,
+            "usable": 3.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.6,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.3,
+            "comfortable": 2.2,
+            "usable": 3.1,
+            "functional": 3.9
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.8,
+          2.8,
+          2.7,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6,
+          2.6
+        ],
+        "distinct": [
+          2.6,
+          2.7,
+          2.8
+        ],
+        "min": 2.6,
+        "max": 2.8,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.5,
+          "usable": 0.6,
+          "comfortable": 0.4,
+          "delightful": 0.7,
+          "meaningful": 0.2
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "supabase",
+      "path": "public/screenshots/supabase/hero.png",
+      "sha": "38f6b881dcef",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 3.8,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.6,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 3.7,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.6,
+            "comfortable": 3.9,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.9,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.2,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.7,
+            "usable": 4.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.8,
+            "delightful": 2.4,
+            "comfortable": 3.8,
+            "usable": 4.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.4,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.6,
+            "usable": 3.8,
+            "functional": 4.1
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.4,
+          3.6,
+          3.6,
+          3.4
+        ],
+        "distinct": [
+          3.4,
+          3.6
+        ],
+        "min": 3.4,
+        "max": 3.6,
+        "range": 0.2,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.2,
+          "usable": 0.5,
+          "comfortable": 0.3,
+          "delightful": 0.8,
+          "meaningful": 0.9
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "raycast",
+      "path": "public/screenshots/raycast/hero.png",
+      "sha": "2e45d52d7ea2",
+      "runs": [
+        {
+          "score": 2.1,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.9
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 3.2,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.1,
+            "comfortable": 1.8,
+            "usable": 3.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 1.6,
+          "label": "Functional",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1,
+            "comfortable": 1.1,
+            "usable": 2,
+            "functional": 2.8
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.2
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.8,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1.2,
+            "comfortable": 1.8,
+            "usable": 2.7,
+            "functional": 3.6
+          }
+        },
+        {
+          "score": 2.3,
+          "label": "Usable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 1,
+            "comfortable": 1.8,
+            "usable": 2.9,
+            "functional": 3.6
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          2.1,
+          2.3,
+          2.3,
+          2.3,
+          2.3,
+          1.6,
+          2.3,
+          2.3,
+          2.3,
+          2.3
+        ],
+        "distinct": [
+          1.6,
+          2.1,
+          2.3
+        ],
+        "min": 1.6,
+        "max": 2.3,
+        "range": 0.7,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 1.3,
+          "usable": 1.2,
+          "comfortable": 0.7,
+          "delightful": 0.2,
+          "meaningful": 0
+        },
+        "exact": false
+      }
+    },
+    {
+      "product": "todoist",
+      "path": "public/screenshots/todoist/hero.png",
+      "sha": "40458562c0cf",
+      "runs": [
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 3.4,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.8,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.6
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.9,
+            "usable": 4.2,
+            "functional": 4.1
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.3,
+            "comfortable": 3.9,
+            "usable": 4.1,
+            "functional": 4.7
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1,
+            "delightful": 2.3,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.4
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 2.1,
+            "delightful": 2.8,
+            "comfortable": 3.8,
+            "usable": 4.1,
+            "functional": 4.3
+          }
+        },
+        {
+          "score": 3.6,
+          "label": "Comfortable",
+          "rungs": {
+            "meaningful": 1.2,
+            "delightful": 2.1,
+            "comfortable": 3.7,
+            "usable": 3.9,
+            "functional": 4.2
+          }
+        }
+      ],
+      "summary": {
+        "scores": [
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6,
+          3.6
+        ],
+        "distinct": [
+          3.6
+        ],
+        "min": 3.6,
+        "max": 3.6,
+        "range": 0,
+        "errors": 0,
+        "rungSpread": {
+          "functional": 0.6,
+          "usable": 0.8,
+          "comfortable": 0.2,
+          "delightful": 0.7,
+          "meaningful": 1.1
+        },
+        "exact": true
+      }
+    }
+  ]
+}

--- a/src/app/api/plugin/analyze/stream/route.ts
+++ b/src/app/api/plugin/analyze/stream/route.ts
@@ -1,0 +1,147 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  parseImageDataUrl,
+  scoreImageStream,
+  type ScoreResult,
+} from "@/lib/scoring";
+import { DESIGN_TYPES } from "@/lib/ladder-framework";
+import { CURRENT_API_VERSION } from "@/lib/app-version";
+
+export const maxDuration = 60;
+
+const API_VERSION_HEADERS = { "X-Ladder-API-Version": CURRENT_API_VERSION };
+
+/**
+ * Streaming plugin scoring endpoint — the streaming sibling of
+ * `/api/plugin/analyze`. Called server-to-server by the Figma plugin backend
+ * (ai-design-assistant) after it has authenticated the end user.
+ *
+ * Why this exists: the Figma plugin used to score in its OWN backend, calling
+ * Anthropic directly at the API default temperature with no cache, so the same
+ * screen drifted (measured ~0.18 avg vs ~0.005 on this engine) and never
+ * matched web/Skill. This endpoint runs the ONE canonical engine
+ * (`scoreImageStream`: temperature 0, content-addressed cache) so every surface
+ * scores identically (#343). It streams so the plugin keeps its fast in-canvas
+ * score reveal.
+ *
+ * Auth: shared service secret (X-Ladder-Service-Token), same as
+ * `/api/plugin/analyze`. Usage counting, end-user auth, and persistence stay on
+ * the plugin's side (the plugin is the single writer of Figma scores) — this
+ * endpoint only scores. The SSE event shape (score / label / screenName /
+ * complete / error) matches what the plugin UI already consumes; the `complete`
+ * payload is mapped to the plugin's "improve" shape so the UI needs no change.
+ */
+export async function POST(req: NextRequest) {
+  /* ── Shared-secret auth (mirrors /api/plugin/analyze) ── */
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    console.error("[LADDER:ERROR] LADDER_SERVICE_TOKEN env var is not configured.");
+    return NextResponse.json(
+      { error: "Service not configured." },
+      { status: 503, headers: API_VERSION_HEADERS },
+    );
+  }
+  if (!serviceToken || serviceToken !== expected) {
+    return NextResponse.json(
+      { error: "Invalid service token" },
+      { status: 401, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const body = await req.json();
+  const { image, designType } = body;
+  const parsed = parseImageDataUrl(image);
+  if (!parsed) {
+    return NextResponse.json(
+      { error: "Invalid image format. Use a base64 data URL." },
+      { status: 400, headers: API_VERSION_HEADERS },
+    );
+  }
+
+  const designTypeInfo = designType
+    ? DESIGN_TYPES.find((t) => t.type === designType)
+    : undefined;
+  const applyAiLens = !!designTypeInfo?.aiLens;
+
+  /* ── Map the canonical ScoreResult to the plugin's "improve" shape ──
+   * Identical mapping to the non-streaming /api/plugin/analyze, so the plugin
+   * UI and its persist path read the same fields regardless of which endpoint
+   * produced the score. */
+  const toPluginShape = (result: ScoreResult) => {
+    const findings = (result.findings ?? []).map((f) => ({
+      title: f.title,
+      impact: f.impact,
+      fix: f.fix,
+      category: f.category,
+      rung: f.rung,
+      severity: f.uplift >= 0.3 ? "high" : f.uplift >= 0.2 ? "medium" : "low",
+    }));
+    const top = result.findings?.[0];
+    const oneThing = top
+      ? {
+          title: top.title,
+          impact: top.impact,
+          fix: top.fix,
+          category: top.category,
+          scoreGain:
+            typeof top.uplift === "number" ? `+${top.uplift.toFixed(1)}` : undefined,
+        }
+      : undefined;
+    return {
+      mode: "improve",
+      designType: designType ?? undefined,
+      designTypeLabel: designTypeInfo?.label,
+      ladder: {
+        score: result.score,
+        label: result.label,
+        summary: result.summary,
+        next: result.next ?? "",
+      },
+      rungs: result.rungs,
+      findings,
+      oneThing,
+      screenName: result.screenName,
+      apiVersion: CURRENT_API_VERSION,
+    };
+  };
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    async start(controller) {
+      const send = (event: string, data: object) => {
+        controller.enqueue(
+          encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`),
+        );
+      };
+      try {
+        for await (const ev of scoreImageStream(parsed, { applyAiLens })) {
+          if (ev.kind === "error") {
+            send("error", { message: ev.value, status: ev.status });
+            controller.close();
+            return;
+          }
+          if (ev.kind === "score") send("score", { value: ev.value });
+          if (ev.kind === "label") send("label", { value: ev.value });
+          if (ev.kind === "screenName") send("screenName", { value: ev.value });
+          if (ev.kind === "complete") send("complete", { value: toPluginShape(ev.value) });
+        }
+        controller.close();
+      } catch (err) {
+        console.error("[LADDER:ERROR] Plugin analyze stream:", err);
+        send("error", { message: "Scoring failed. Please try again.", status: 500 });
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      ...API_VERSION_HEADERS,
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -2,7 +2,7 @@
 title: API Protocols
 updatedAt: 2026-07-06
 updatedBy: Sara
-lastPr: 367
+lastPr: 379
 ---
 
 ## Two surfaces, one to come

--- a/src/content/hq/api.mdx
+++ b/src/content/hq/api.mdx
@@ -1,6 +1,6 @@
 ---
 title: API Protocols
-updatedAt: 2026-06-29
+updatedAt: 2026-07-06
 updatedBy: Sara
 lastPr: 367
 ---
@@ -32,7 +32,8 @@ All endpoints below are real routes in this repo. Find them under `src/app/api/`
 | `/api/skill/score` | POST | Skill token | Scoring callable from the Ladder Skill. |
 | `/api/plugin/issue-token` | POST | Clerk session | Issue a plugin token for use in the Figma plugin. |
 | `/api/plugin/verify-token` | POST | Plugin token | Token introspection for the plugin. |
-| `/api/plugin/analyze` | POST | Plugin token | Scoring callable from the Figma plugin. |
+| `/api/plugin/analyze` | POST | Service token | Score a Figma frame on the canonical engine (non-streaming). |
+| `/api/plugin/analyze/stream` | POST | Service token | Streaming score for the Figma plugin — wraps `scoreImageStream` (temp 0, cached); SSE events score / label / screenName / complete / error. The plugin's in-canvas score now runs on this one canonical engine (#343). |
 | `/api/plugin/analyze/copy` | POST | Service token | Improve Copy. Returns `{ styleGuide, general }` — style compliance (same engine as the web score) + a separate general copy audit (#362). |
 | `/api/plugin/meta` | GET | Public | Plugin metadata (version, etc.). |
 | `/api/plugin/persist-score` | POST | Service token | Save a plugin-originated score (server-to-server). |

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -1,6 +1,6 @@
 ---
 title: Architecture
-updatedAt: 2026-06-30
+updatedAt: 2026-07-06
 updatedBy: Sara
 lastPr: 377
 ---
@@ -58,7 +58,9 @@ This diagram shows the future-target architecture (one engine, thin clients). To
 
 ## Shared services (target state, partial today)
 
-**Scoring engine.** Anthropic Claude with the Ladder rubric prompt. Server-side only. Web and Skill score through `runladder`'s engine (`src/lib/scoring.ts`). The **Figma plugin still scores in its own backend** (`ai-design-assistant/api/analyze.js`) — it was never migrated, despite the half-finished unification in #75 (the plugin's service endpoints moved to `runladder`, the scoring computation did not). Consolidating the plugin onto `runladder`'s engine is [#362](https://github.com/drawbackwards/runladder/issues/362): Chunk 1 moved style/copy checking to one canonical engine (`/api/plugin/analyze/copy`, `src/lib/copy-audit.ts`); the Ladder score itself is Chunk 2. Pulse runs its own scoring stack in `ladder-beta`.
+> **The Ladder score and Style Guide compliance are two separate features. Style Guide findings NEVER affect a screen's Ladder score — not by a point, not by a decimal, ever.** The Ladder score measures user experience (hierarchy, clarity, flow, assistance). Style Guide compliance is an advisory, team-specific check of on-screen copy against an uploaded brand/writing guide. It runs in a separate model pass (`analyzeStyleCompliance`), is attached to the result for display only, and is computed independently of the number. A screen's Ladder score is identical whether or not the team has a style guide. This separation is a hard invariant — any change that lets compliance influence the score is a bug.
+
+**Scoring engine.** Anthropic Claude with the Ladder rubric prompt. Server-side only. **Web, Skill, AND the Figma plugin now all score through `runladder`'s one canonical engine** (`src/lib/scoring.ts`, temperature 0, content-addressed cache). The plugin used to score in its own backend (`ai-design-assistant/api/analyze.js`) at the API default temperature with no cache, so the same screen drifted and never matched web; as of [#343](https://github.com/drawbackwards/runladder/issues/343) its Ladder score is routed to `POST /api/plugin/analyze/stream` (the streaming sibling of `/api/plugin/analyze`), finishing the consolidation begun in [#362](https://github.com/drawbackwards/runladder/issues/362) (Chunk 1 was style/copy via `/api/plugin/analyze/copy`; the score was Chunk 2). Only Pulse still runs its own scoring stack in `ladder-beta`.
 
 **Auth.** Clerk for human users on `runladder` surfaces. Plugin token + Skill token (server-issued via `/api/plugin/issue-token` and `/api/skill/token`). API keys for `api.runladder.com` are roadmap (the issuance UI doesn't exist yet either).
 

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-06
 updatedBy: Sara
-lastPr: 377
+lastPr: 379
 ---
 
 ## Deployment environments

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,12 +17,12 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.17";
+export const CURRENT_APP_VERSION = "0.5.18";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header
 // so clients can log which contract they hit.
-export const CURRENT_API_VERSION = "1.3.0";
+export const CURRENT_API_VERSION = "1.4.0";
 
 // Ladder scoring engine (the prompt + rubric + model behaviour that turns a
 // screen into a score). Tracked independently of the app and API: the engine

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -307,6 +307,19 @@ export async function scoreImage(
     styleTeamName?: string | null;
     /** Ground-truth on-screen text (URL DOM / future surfaces) for the style pass. */
     styleFrameText?: FrameText | null;
+    /**
+     * Skip the score cache entirely (no read, no write). Used only by the
+     * consistency harness (`scripts/score-consistency.mjs`) to measure the
+     * model's true run-to-run variance — the thing #343 is fixing. Production
+     * callers must never set this; the cache is what makes scores stable today.
+     */
+    bypassCache?: boolean;
+    /**
+     * Override the scoring temperature. Harness-only, to measure how much the
+     * plugin's default-temperature path drifts vs the pinned temp 0. Production
+     * callers must never set this; scoring is pinned to 0.
+     */
+    temperature?: number;
   } = {},
 ): Promise<ScoreResult | ScoringError> {
   // Cap image size (~5MB base64)
@@ -325,7 +338,7 @@ export async function scoreImage(
   // with the model's run-to-run variance.
   const system = buildLadderPrompt(opts);
   const cacheKey = scoreCacheKey(system, base64Data);
-  const cached = await getCachedScore(cacheKey);
+  const cached = opts.bypassCache ? null : await getCachedScore(cacheKey);
 
   // Moderation gate — only on a cache MISS (a cached score already passed it).
   if (!cached) {
@@ -361,7 +374,7 @@ export async function scoreImage(
     const response = await client.messages.create({
       model: SCORING_MODEL,
       max_tokens: 4096,
-      temperature: 0,
+      temperature: opts.temperature ?? 0,
       messages: [
         {
           role: "user",
@@ -394,7 +407,7 @@ export async function scoreImage(
     if (typeof result.score !== "number" || !result.label || !result.summary) {
       return { error: "Invalid scoring response shape", status: 500 };
     }
-    await setCachedScore(cacheKey, result);
+    if (!opts.bypassCache) await setCachedScore(cacheKey, result);
   }
 
   if (stylePromise) {


### PR DESCRIPTION
## What
The Figma plugin's Ladder score used to run in the plugin's own backend, calling Anthropic directly at the API **default temperature with no cache**, so the same screen drifted and never matched web/Skill. This routes the plugin's score through runladder's **one canonical engine** (temperature 0, content-addressed cache) via a new streaming endpoint. Every surface now scores the same screen identically.

## The measured gap (why this matters)
Consistency harness (`scripts/score-consistency.mjs`, cache bypassed, 20 unique screens x10 runs):

| | canonical engine (temp 0) | plugin's old path (temp 1.0) |
|---|---|---|
| Exactly consistent | 19/20 | 4/20 |
| Avg score range | 0.005 | 0.18 |
| Worst | 0.1 | 0.7 (crossed a rung) |

## Changes
- **New `POST /api/plugin/analyze/stream`** (service-token auth) wrapping `scoreImageStream`; emits the plugin's SSE shape (score / label / screenName / complete / error) so the in-canvas reveal is preserved. No persist here (the plugin stays the single writer).
- `scoreImage`: internal-only `bypassCache` / `temperature` overrides for the harness. Production callers never set them.
- Consistency harness + measured baselines.
- `docs/deterministic-scoring-plan.md` — the approved #343 plan.
- HQ lockstep: architecture (Figma now unified) + api (new endpoint). CHANGELOG. app 0.5.18 / api 1.4.0. Engine unchanged (v1.3) — this only changes which engine the plugin calls.

## Sequencing / companion PR
The plugin-side change (route `handleImproveStream` to this endpoint) ships in **ai-design-assistant**. This runladder PR must deploy first so the endpoint exists. Both were validated live end-to-end (a Figma score landed on the dashboard through the canonical engine).

## Known follow-ups (tracked separately, not consistency)
- Added latency: routing through the shared engine adds a moderation round-trip + a hop before the score streams.
- The "Potential score" on the result view can equal the current score (misleading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)