### PR TITLE
fix(#343): Potential score reflects finding uplift, hides when signal-less

### DIFF
--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useAuth, useUser, RedirectToSignIn } from "@clerk/nextjs";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
+import { getScoreColor, getLevelColor, getLevel, getNextLevel, getGapToNext, getRungLevel, computePotentialScore } from "@/lib/ladder";
 import { privateScopeLabel, isTeamScope } from "@/lib/score-scope";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
@@ -354,16 +354,34 @@ export default function ScoreDetailPage() {
               </div>
             ))}
 
-            <div className="border border-ladder-green/40 bg-ladder-green/[0.06] p-5 mt-4">
-              <div className="flex items-center justify-between">
-                <span className="text-[10px] text-ladder-green uppercase tracking-widest">
-                  Potential score if all findings addressed
-                </span>
-                <span className="text-xl font-bold text-ladder-green">
-                  {Math.min(5, data.score + (data.findings?.reduce((s, f) => s + (f.uplift || 0), 0) || 0)).toFixed(1)}
-                </span>
-              </div>
-            </div>
+            {(() => {
+              // Potential = current + summed finding uplift, floored at the
+              // deepest targetLevel. Hidden entirely when the findings carry no
+              // uplift/targetLevel (e.g. Figma-persisted scores) so we never
+              // echo the current score back as the "potential" (#343 display).
+              const { potential, hasSignal } = computePotentialScore(
+                data.score,
+                data.findings,
+              );
+              if (!hasSignal) return null;
+              return (
+                <div className="border border-ladder-green/40 bg-ladder-green/[0.06] p-5 mt-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+                      Potential score if all findings addressed
+                    </span>
+                    <span className="flex items-baseline gap-2">
+                      <span className="text-xl font-bold text-ladder-green">
+                        {potential.toFixed(1)}
+                      </span>
+                      <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+                        {getLevel(potential)}
+                      </span>
+                    </span>
+                  </div>
+                </div>
+              );
+            })()}
           </div>
         )}
 

--- a/src/app/score/page.tsx
+++ b/src/app/score/page.tsx
@@ -6,7 +6,7 @@ import { useAuth, useUser, useOrganization, SignUpButton } from "@clerk/nextjs";
 import { canScorePrivately as tierCanScorePrivately, isTeamScope } from "@/lib/score-scope";
 import { useViewAs } from "@/lib/dev/view-as";
 import { SHOW_EVALUATIONS_AND_REVIEWS } from "@/lib/feature-flags";
-import { getScoreColor, getLevelColor, getNextLevel, getGapToNext, getRungLevel } from "@/lib/ladder";
+import { getScoreColor, getLevelColor, getLevel, getNextLevel, getGapToNext, getRungLevel, computePotentialScore } from "@/lib/ladder";
 import { ScoreBar } from "@/components/ScoreBar";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
@@ -1286,16 +1286,34 @@ export default function ScorePage() {
                   </div>
                 ))}
 
-                <div className="border border-ladder-green/40 bg-ladder-green/[0.06] p-5 mt-4">
-                  <div className="flex items-center justify-between">
-                    <span className="text-[10px] text-ladder-green uppercase tracking-widest">
-                      Potential score if all findings addressed
-                    </span>
-                    <span className="text-xl font-bold text-ladder-green">
-                      {Math.min(5, result.score + (result.findings?.reduce((s, f) => s + (f.uplift || 0), 0) || 0)).toFixed(1)}
-                    </span>
-                  </div>
-                </div>
+                {(() => {
+                  // Same potential derivation as the dashboard score-detail
+                  // view — sum uplift, floor at the deepest targetLevel, and
+                  // hide entirely when findings carry no forward signal so the
+                  // box never echoes the current score (#343 display).
+                  const { potential, hasSignal } = computePotentialScore(
+                    result.score,
+                    result.findings,
+                  );
+                  if (!hasSignal) return null;
+                  return (
+                    <div className="border border-ladder-green/40 bg-ladder-green/[0.06] p-5 mt-4">
+                      <div className="flex items-center justify-between">
+                        <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+                          Potential score if all findings addressed
+                        </span>
+                        <span className="flex items-baseline gap-2">
+                          <span className="text-xl font-bold text-ladder-green">
+                            {potential.toFixed(1)}
+                          </span>
+                          <span className="text-[10px] text-ladder-green uppercase tracking-widest">
+                            {getLevel(potential)}
+                          </span>
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })()}
               </div>
             )}
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-06-30
+updatedAt: 2026-07-06
 updatedBy: Sara
-lastPr: 377
+lastPr: 380
 ---
 
 ## How to read this page
@@ -34,6 +34,7 @@ When you ship a feature, add the row here in the same PR. Template:
 | Design rhythm + activity heatmap on personal dashboard (paid only) | Pro / Team / Pulse | Live (#289) | `src/app/dashboard/page.tsx` (gated on `paid`) |
 | Designer detail page: per-score surface tag (Figma/Claude/Web/Skill/Pulse) | Team Lead | Live (#299) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/lib/surface.ts` |
 | Team Lead opens a member's score detail from the designer page | Team Lead | Live (#300) | `src/app/dashboard/team/members/[userId]/page.tsx`, `src/app/dashboard/scores/[id]/page.tsx`, `src/app/api/dashboard/scores/[id]/route.ts` |
+| "Potential score if all findings addressed" box (score detail + public `/score`): derives from finding `uplift` summed and floored at the deepest `targetLevel` via `computePotentialScore`, so it reconciles with the "Gap to \<level\>" header; **hides** when findings carry neither signal (e.g. Figma-persisted scores) instead of echoing the current score (PR #380, #343). Plugin `ui.html` has no summed potential — gap line + per-finding `scoreGain → targetLevel`. | All signed-in | Live (PR #380) | `src/lib/ladder.ts` (`computePotentialScore`), `src/app/dashboard/scores/[id]/page.tsx`, `src/app/score/page.tsx` |
 | Evaluations concept hidden for launch: score-screen session-type prompt + pill, member-detail Evaluations tab, team Reviews tab (all scores log as "design") | — | Hidden for launch (#302) | `src/lib/feature-flags.ts` (`SHOW_EVALUATIONS_AND_REVIEWS`), `src/app/score/page.tsx`, `src/app/dashboard/team/members/[userId]/page.tsx`, `src/app/dashboard/team/page.tsx`; supersedes the "Reviews" rows below until relaunch. Admin `/admin/evaluations` (client reports) is a separate tool, left intact. |
 | Figma install/manage detail page (`/dashboard/figma`) | All signed-in | Live (#273) | `src/app/dashboard/figma/page.tsx`, `src/components/promos/FigmaPromoCard.tsx` |
 | Claude Skill install/manage detail page (`/dashboard/claude`) | All signed-in | Live (#273) | `src/app/dashboard/claude/page.tsx`, `src/components/skill/useSkillInstall.ts`, `src/components/promos/ClaudePromoCard.tsx` |

--- a/src/lib/ladder.test.ts
+++ b/src/lib/ladder.test.ts
@@ -4,6 +4,7 @@ import {
   RUNG_NAMES,
   RUNG_DISPLAY_ORDER,
   analyzeRungs,
+  computePotentialScore,
   computeTotalFromRungs,
   getGapToNext,
   getLevel,
@@ -183,6 +184,58 @@ describe("computeTotalFromRungs", () => {
       meaningful: 5,
     });
     expect(total).toBeLessThan(3.5);
+  });
+});
+
+describe("computePotentialScore", () => {
+  it("sums finding uplift on top of the current score", () => {
+    const { potential, hasSignal } = computePotentialScore(2.8, [
+      { uplift: 0.3, targetLevel: "Comfortable" },
+      { uplift: 0.2, targetLevel: "Comfortable" },
+      { uplift: 0.1, targetLevel: "Comfortable" },
+    ]);
+    expect(hasSignal).toBe(true);
+    expect(potential).toBeCloseTo(3.4, 5);
+  });
+
+  it("floors the potential at the deepest targetLevel when uplift falls short", () => {
+    // Uplift alone would land at 2.85, but a finding claims Comfortable (3.0).
+    const { potential, hasSignal } = computePotentialScore(2.8, [
+      { uplift: 0.05, targetLevel: "Comfortable" },
+    ]);
+    expect(hasSignal).toBe(true);
+    expect(potential).toBeCloseTo(3.0, 5);
+  });
+
+  it("reaches the target level with no uplift data (targetLevel only)", () => {
+    const { potential, hasSignal } = computePotentialScore(2.8, [
+      { targetLevel: "Comfortable" },
+    ]);
+    expect(hasSignal).toBe(true);
+    expect(potential).toBeCloseTo(3.0, 5);
+  });
+
+  it("reports no signal when findings carry neither uplift nor targetLevel", () => {
+    // Figma-persisted findings only have rung/severity — the box must hide,
+    // never echo the current score back as the potential (#343 display bug).
+    const { potential, hasSignal } = computePotentialScore(2.8, [
+      { uplift: null, targetLevel: null },
+      {},
+    ]);
+    expect(hasSignal).toBe(false);
+    expect(potential).toBe(2.8);
+  });
+
+  it("reports no signal with no findings", () => {
+    expect(computePotentialScore(2.8)).toEqual({ potential: 2.8, hasSignal: false });
+    expect(computePotentialScore(2.8, [])).toEqual({ potential: 2.8, hasSignal: false });
+  });
+
+  it("never exceeds 5.0", () => {
+    const { potential } = computePotentialScore(4.9, [
+      { uplift: 0.5, targetLevel: "Meaningful" },
+    ]);
+    expect(potential).toBe(5);
   });
 });
 

--- a/src/lib/ladder.ts
+++ b/src/lib/ladder.ts
@@ -155,6 +155,59 @@ export function getGapToNext(score: number): number {
   return Math.ceil(score) - score;
 }
 
+/** A finding's forward-looking signals, as far as the potential math cares. */
+type PotentialFinding = { uplift?: number | null; targetLevel?: string | null };
+
+/**
+ * The score the screen would reach if every finding were addressed.
+ *
+ * Findings carry two forward-looking signals (see the scoring prompt in
+ * `ladder-framework.ts`):
+ *   - `uplift`: points this single fix adds (0.1–0.5)
+ *   - `targetLevel`: the Ladder level reached once this fix *and every
+ *     higher-ranked fix* are applied — so the deepest targetLevel is the
+ *     destination.
+ *
+ * We combine them: sum the uplifts, then floor at the entry score of the
+ * highest targetLevel any finding names. Either signal alone is enough.
+ *
+ * When NEITHER signal is present — e.g. scores persisted from the Figma plugin,
+ * whose findings only carry `rung`/`severity` (the plugin/analyze route drops
+ * uplift/targetLevel) — there is no honest potential to show. `hasSignal` is
+ * then `false` and callers MUST hide the box rather than print the current
+ * score straight back, which reads as "fixing everything changes nothing".
+ *
+ * This is a pure display derivation; it never feeds back into the score.
+ */
+export function computePotentialScore(
+  score: number,
+  findings?: PotentialFinding[],
+): { potential: number; hasSignal: boolean } {
+  if (!findings || findings.length === 0) {
+    return { potential: score, hasSignal: false };
+  }
+
+  const upliftSum = findings.reduce(
+    (sum, f) => sum + (typeof f.uplift === "number" ? f.uplift : 0),
+    0,
+  );
+
+  // Highest level any finding claims to reach → its entry score is a floor,
+  // so the potential lines up with the "Gap to <level>" header even when the
+  // uplifts alone fall a hair short of the level boundary.
+  let targetFloor = 0;
+  for (const f of findings) {
+    if (!f.targetLevel) continue;
+    const lvl = LEVELS.find((l) => l.label === f.targetLevel);
+    if (lvl && lvl.min > targetFloor) targetFloor = lvl.min;
+  }
+
+  const potential = Math.min(5, Math.max(score + upliftSum, targetFloor));
+  const hasSignal = upliftSum > 0 || targetFloor > score;
+
+  return { potential, hasSignal };
+}
+
 /** Brand green — used for Ladder branding, not level scoring */
 export const LADDER_GREEN = "#6AC89B";
 


### PR DESCRIPTION
## Problem

On the score result/detail view the **"Potential score if all findings addressed"** box was misleading. Repro (2026-07, Figma-sourced score): current **2.8 (Usable)**, header says **"Gap to Comfortable +0.2"**, but the Potential box read **2.8** — identical to the current score.

## Root cause

The box computed `current + Σ uplift`. For plugin-persisted findings that carry only `rung`/`severity` (the plugin/analyze mapping drops `uplift`/`targetLevel`), the sum is 0, so the potential collapses to the current score. The public `/score` page shares the box but never showed it, because its findings come straight from the engine with `uplift` intact.

## Fix (display-only — no scoring change)

- New shared helper `computePotentialScore(score, findings)` in `src/lib/ladder.ts` → `{ potential, hasSignal }`:
  - sums `uplift`, then **floors at the deepest `targetLevel`'s entry score** so it reconciles with the "Gap to \<level\>" header,
  - returns `hasSignal: false` when findings carry **neither** signal.
- Both web surfaces (dashboard score-detail + public `/score`) **hide the box** when `!hasSignal` instead of echoing the current score, and now show the level label (e.g. `3.4 · Comfortable`).
- **Figma plugin `ui.html`:** no change — it never renders a summed potential (gap line + per-finding `scoreGain → targetLevel` cards), so it has no equivalent bug and now agrees with web.

## Verification

- `tsc --noEmit`: clean
- `eslint` on changed files: clean (pre-existing `<img>` warnings only)
- `vitest src/lib/ladder.test.ts`: **42 passed**, incl. 6 new cases modeling the exact repro

🤖 Generated with [Claude Code](https://claude.com/claude-code)