### PR TITLE
docs(hq): post-merge verification for #379 (plugin scores on canonical engine)

### DIFF
--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -61,7 +61,7 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
-| In-canvas frame scoring | Pro+ | Live | `src/app/api/plugin/analyze/route.ts` |
+| In-canvas frame scoring — now runs on runladder's **one canonical engine** (temp 0, content-addressed cache), streamed so the in-canvas reveal stays fast; unified in #343/PR #379 so the plugin score matches web/Skill instead of drifting at the old default temperature. The plugin-shape mapping keeps `rung`/`severity` but drops `uplift`/`targetLevel`, so persisted Figma findings carry no forward signal (dashboard "Potential score" box hides for them — PR #380). | Pro+ | Live (PR #379) | `src/app/api/plugin/analyze/stream/route.ts` (streaming), `src/app/api/plugin/analyze/route.ts` (non-streaming), `src/lib/scoring.ts` |
 | Plugin token issuance | All signed-in | Live | `src/app/api/plugin/issue-token/route.ts` |
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
 | Score persistence from plugin (also runs the team style-compliance pass so plugin scores show Style Guide findings on the dashboard, #364) | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-07-06
+updatedAt: 2026-07-07
 updatedBy: Sara
-lastPr: 380
+lastPr: 381
 ---
 
 ## How to read this page


### PR DESCRIPTION
Post-merge `/hq` verification handshake for **#379** (Figma scoring unified onto runladder's canonical engine), which shipped live alongside #380.

## Verified accurate against shipped code
- `hq/api.mdx` — `/api/plugin/analyze/stream` documented (service token; SSE `score`/`label`/`screenName`/`complete`/`error`), and `/api/plugin/analyze` correctly re-labeled service token. Matches `src/app/api/plugin/analyze/stream/route.ts`.
- `hq/architecture.mdx` — "Web, Skill, AND the Figma plugin now all score through runladder's one canonical engine" matches the route wrapping `scoreImageStream` (temp 0, cached).

## Fixed drift
- `hq/features.mdx` "In-canvas frame scoring" row was stale (pointed only at the non-streaming route, no mention of the unification). Updated to reflect the canonical engine + streaming endpoint, and to note the plugin-shape mapping still drops `uplift`/`targetLevel` — which is why the #380 "Potential score" box hides for Figma-persisted findings.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)