### PR TITLE
fix: show teammates' scan counts on the roster; keep avg score manager-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Version format: `<app>` covers the web app + dashboard. `<api>` covers the Ladde
 
 ---
 
+## app 0.5.21 / api 1.4.0 (2026-07-07)
+
+**Team roster: members see teammates' scan counts; average score stays manager-only.**
+
+- The team roster gated ALL per-member stats behind `org:admin`, so a regular member saw "0 scans / — avg" for everyone (including themselves), which read as broken data. Now scan **counts** (and activity) are visible to every member — seeing how active teammates are is not sensitive — while the **average score** and the team-insights panel remain manager-only, since an average reads as a "how good a designer are you" judgment. Fix is in `/api/dashboard/team` (`avgScore`/`bestScore` nulled for non-managers; quality aggregates only accumulate for the manager). No data was ever lost; this was a visibility gate, not a persistence bug.
+
+---
+
 ## app 0.5.20 / api 1.4.0 (2026-07-07)
 
 **Figma scores now feed the "Potential score" box (#343/#380).**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "runladder",
-  "version": "0.5.20",
+  "version": "0.5.21",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -284,7 +284,7 @@ export async function GET() {
         joinedAt: m.createdAt,
       };
 
-      if (!memberUserId || !isManager) {
+      if (!memberUserId) {
         return {
           ...base,
           stats: null,
@@ -321,20 +321,32 @@ export async function GET() {
         if (typeof s.timestamp !== "number") continue;
         if (s.timestamp < insightsWindowStart) continue;
         memberRecentCount += 1;
-        totalScores += 1;
-        totalScoreSum += s.score;
-        const rs = parseRungScores(s.rungs);
-        if (rs) {
-          for (const name of RUNG_NAMES) {
-            rungSums[name] += rs[name].score;
-            rungCounts[name] += 1;
+        // Team-quality aggregates (team avg + rung insights) are manager-only.
+        if (isManager) {
+          totalScores += 1;
+          totalScoreSum += s.score;
+          const rs = parseRungScores(s.rungs);
+          if (rs) {
+            for (const name of RUNG_NAMES) {
+              rungSums[name] += rs[name].score;
+              rungCounts[name] += 1;
+            }
           }
         }
       }
 
+      // Scan counts + activity are visible to ALL teammates (how many scans
+      // someone did is not sensitive). The AVERAGE (and best) score reads as a
+      // "how good a designer are you" judgment, so it stays manager-only — a
+      // member sees teammates' volume, not their grades.
+      const visibleStats =
+        stats && !isManager
+          ? { ...stats, avgScore: null, bestScore: null }
+          : stats;
+
       return {
         ...base,
-        stats,
+        stats: visibleStats,
         recentScans: memberRecentCount,
         monthlyScans,
         activity: bucketActivity(designRecent, ACTIVITY_WINDOW_DAYS),

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-06-08
+updatedAt: 2026-07-07
 updatedBy: Sara
-lastPr: 324
+lastPr: PENDING
 ---
 
 ## How to read this page
@@ -54,7 +54,7 @@ After provisioning, the Team Lead gets the `org:admin` invite. On accept, the fi
 1. Land on `/dashboard/team` with an empty roster. The page **activates their org** (`setActive`) on first visit if no org is the session's active one — before #190, self-serve `CreateOrganization` set the org active automatically; the invite-based flow does not, so without this the page hung on "Loading your team…".
 2. Invite designers by email. Clerk Organization handles the invite.
 3. Accepted invitees auto-get a `tier: team` complimentary subscription via `/api/webhooks/clerk` (shipped in v0.3.0).
-4. The team page is organized into two tabs (#274): **Team** (member roster with letter grades A–F, the Team Pool meter, and Invite) and **Reviews** (Beta). **For the MVP launch the Reviews tab is hidden (#302)** — only the Team tab renders; restore both Reviews and the member-detail Evaluations tab by flipping `SHOW_EVALUATIONS_AND_REVIEWS` in `src/lib/feature-flags.ts`. The Team Pool box mirrors the dashboard Usage meter — used/limit, monthly reset, hard cap, and a soft-cap tick. The page's top "Team" plan strip was removed (#274; comp-expiry surfacing tracked in #196).
+4. The team page is organized into two tabs (#274): **Team** (member roster with letter grades A–F, the Team Pool meter, and Invite) and **Reviews** (Beta). **For the MVP launch the Reviews tab is hidden (#302)** — only the Team tab renders; restore both Reviews and the member-detail Evaluations tab by flipping `SHOW_EVALUATIONS_AND_REVIEWS` in `src/lib/feature-flags.ts`. The Team Pool box mirrors the dashboard Usage meter — used/limit, monthly reset, hard cap, and a soft-cap tick. The page's top "Team" plan strip was removed (#274; comp-expiry surfacing tracked in #196). **Roster visibility (#343):** every member sees each teammate's **scan count** (activity/volume is not sensitive), but the **average score is manager-only** — it reads as a "how good a designer are you" judgment, so members don't see each other's grades (the average and the team-insights panel are gated on `org:admin` in `/api/dashboard/team`).
 5. Drill into a designer: clicking a roster member opens their detail page (scores, stats, activity heatmap, per-score surface tags #299). The Team Lead can click **any of that designer's scores** to open the full score detail (#300) — the score-detail page authorizes the cross-user read via `?member=<userId>` (`org:admin` + member-in-org). The member-detail Evaluations tab is hidden for launch (#302); only Design sessions show.
 6. Reviews flow (**hidden for launch, #302**): the Reviews tab (Lead) shows the Review Requests inbox plus the reviews overview — the same content as the dedicated `/dashboard/reviews` route, via shared components (`ReviewsIntro` / `ReviewsStats` / `ActiveReviewsList`) so the two don't drift. A designer requests a review, the Team Lead accepts or declines, the designer scores iterations in `/dashboard/reviews/[slug]`, and the Team Lead and peers add Team Takes and pin annotations.
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-07-07
 updatedBy: Sara
-lastPr: PENDING
+lastPr: 384
 ---
 
 ## How to read this page

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -17,7 +17,7 @@
 
 // runladder.com (this web app). Visible in the footer. Mirror this value
 // into package.json's `version` field on every bump.
-export const CURRENT_APP_VERSION = "0.5.20";
+export const CURRENT_APP_VERSION = "0.5.21";
 
 // Ladder API (plugin/analyze, framework, score, skill/score, etc.). Sent
 // back to every API caller via the X-Ladder-API-Version response header


### PR DESCRIPTION
## What
The team roster gated **all** per-member stats behind `org:admin`, so a regular member saw "0 scans / — avg" for everyone (including themselves) — which reads as broken/lost data. (This is what looked like a bug when a member viewed the Lumin demo roster after scoring.)

## Fix (per product call)
- **Scan counts + activity: visible to every member.** How active a teammate is isn't sensitive.
- **Average score + team-insights: stay manager-only.** An average reads as a "how good a designer are you" judgment and could be embarrassing, so members don't see each other's grades.

Implemented in `/api/dashboard/team`: the non-manager early-return no longer zeroes everything; `avgScore`/`bestScore` are nulled for non-managers (so the AVG column shows "—"), and the quality aggregates (team avg, rung insights) only accumulate for the manager. **No data was ever lost — this was a visibility gate, not a persistence bug** (scores are user-keyed and were recorded correctly).

## Verification
tsc, lint, prompt-leak clean. HQ journeys roster-visibility note added; app 0.5.20 → 0.5.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)