### PR TITLE
docs(#392): record the Figma plugin redesign + per-frame selection in /hq

### DIFF
--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-07-10
 updatedBy: Sara
-lastPr: 235
+lastPr: 393
 ---
 
 ## How to read this page

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-07-07
+updatedAt: 2026-07-10
 updatedBy: Sara
-lastPr: 383
+lastPr: 235
 ---
 
 ## How to read this page
@@ -62,11 +62,12 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 | Feature | Roles | Status | Evidence |
 | --- | --- | --- | --- |
 | In-canvas frame scoring — now runs on runladder's **one canonical engine** (temp 0, content-addressed cache), streamed so the in-canvas reveal stays fast; unified in #343/PR #379 so the plugin score matches web/Skill instead of drifting at the old default temperature. The plugin-shape mapping keeps `rung`/`severity` AND `uplift`/`targetLevel` (#343), so Figma findings carry the forward signal and feed the dashboard "Potential score" box like web scores. Applies to scans made after this shipped; Figma scans persisted earlier lack the fields and still hide the box (re-score to populate). | Pro+ | Live (PR #379) | `src/app/api/plugin/analyze/stream/route.ts` (streaming), `src/app/api/plugin/analyze/route.ts` (non-streaming), `src/lib/scoring.ts` |
+| Plugin result screen redesigned to match the web score detail (#386, #392): tabbed **Findings / Style Guide / Copy** (sticky tab bar; Style Guide + Copy lazy-load on first open); findings cards, score card, and per-rung breakdown restyled to the web layout + tokens (square corners, dark card fills, eyebrow labels pulled out of cards); **per-frame selection memory** (re-selecting a scored frame re-displays its score instantly; button reads "Score" vs "Re-score this screen"; deselecting clears stale results); "Scoring..." button state; "More Tools" + "Analysis quality" sections. Plugin-side only, runladder backend unchanged. | Pro+ | Live (plugin PRs #233, #234, #235; frame-name title #232) | `drawbackwards/ai-design-assistant` `plugin/ui.html`, `plugin/code.js` |
 | Plugin token issuance | All signed-in | Live | `src/app/api/plugin/issue-token/route.ts` |
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
 | Score persistence from plugin (also runs the team style-compliance pass so plugin scores show Style Guide findings on the dashboard, #364) | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
 | Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
-| Plugin bundle (v1.0.8) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
+| Plugin bundle (v1.13.0) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
 | Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |
 | Marketplace listing demo flow | Public | Roadmap | Gates the relaunch (re-review restarted 2026-04-18 per memory) |
 | Batch scoring of a frame stack | Pro+ | Roadmap | Open question per Journeys |

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-07-07
+updatedAt: 2026-07-10
 updatedBy: Sara
-lastPr: 384
+lastPr: 235
 ---
 
 ## How to read this page
@@ -72,7 +72,7 @@ See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipp
 
 ## Figma plugin: Live (in marketplace re-review per memory)
 
-The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.0.6 (synced via `scripts/sync-skill-version.mjs`).
+The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.13.0 (synced via `scripts/sync-skill-version.mjs`).
 
 ### Plugin first-run (Live, with caveats)
 
@@ -83,6 +83,7 @@ Key beats:
 - Plugin token is issued via `POST /api/plugin/issue-token` (Clerk session required), then pasted into the Figma plugin. The account page at `/settings` (#203) does **not** issue these tokens yet; issuance happens via the in-plugin auth flow.
 - Token is server-issued, single-user, scoped to plugin requests. Verified via `POST /api/plugin/verify-token`.
 - Score requests hit `/api/plugin/analyze`. Same scoring engine as the web app. Persisted via `POST /api/plugin/persist-score`.
+- Result screen mirrors the web score detail (#386, #392): the score reveals into a card, then tabbed **Findings / Style Guide / Copy** (Style Guide + Copy lazy-load), a per-rung breakdown, and "More Tools" (Accessibility, follow-up) + "Analysis quality" sections. Selecting a frame that was already scored re-displays its result instantly; selecting a fresh frame shows the default state; the button reads "Score" vs "Re-score this screen".
 - Free users hit the 5-lifetime cap inside the plugin same as on web.
 - The dashboard has a dedicated **`/dashboard/figma`** detail page (#273): hero, full-width pitch, and an install/manage panel. The sidebar `FigmaPromoCard` links here and shows live connection status (New vs Connected, version, update-available) from `/api/plugin/meta`.
 

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-07-10
 updatedBy: Sara
-lastPr: 235
+lastPr: 393
 ---
 
 ## How to read this page


### PR DESCRIPTION
Keeps `/hq` in lockstep with the merged Figma plugin work (PRs #233, #234, #235 in `ai-design-assistant`; #386 per-frame selection + #392 result-screen redesign). Docs-only, no code.

- **/hq/features**: new row in the Figma plugin table for the redesigned result screen (tabbed Findings / Style Guide / Copy, restyled cards matching the web score detail, per-frame selection memory, "Scoring..." state, More Tools + Analysis quality sections). Bumped the plugin bundle row to v1.13.0.
- **/hq/journeys**: plugin result flow now describes the web-matched result screen and per-frame re-display; version bumped from the stale 1.0.6.
- Frontmatter stamped on both (updatedAt 2026-07-10, updatedBy Sara, lastPr 235).

🤖 Generated with [Claude Code](https://claude.com/claude-code)