### PR TITLE
feat(#397): Team overage MVP — admin Team Detail (roster + usage-by-month)

### DIFF
--- a/src/app/admin/(tabbed)/clients/page.tsx
+++ b/src/app/admin/(tabbed)/clients/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useAuth } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { Skeleton } from "@/components/Skeleton";
 
@@ -68,6 +69,7 @@ function fmtDate(ms: number | null | undefined) {
 
 export default function ManageClientsPage() {
   const { isSignedIn } = useAuth();
+  const router = useRouter();
   const [teamClients, setTeamClients] = useState<TeamClient[]>([]);
   const [proClients, setProClients] = useState<ProClient[]>([]);
   const [freeUsers, setFreeUsers] = useState<FreeUser[]>([]);
@@ -206,7 +208,8 @@ export default function ManageClientsPage() {
                     return (
                       <tr
                         key={c.id}
-                        className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                        onClick={() => router.push(`/admin/clients/${c.id}`)}
+                        className="border-b border-[#222] last:border-0 hover:bg-[#222] cursor-pointer"
                       >
                         <td className="p-3 text-foreground">
                           {c.name}
@@ -250,14 +253,15 @@ export default function ManageClientsPage() {
                             <span className="text-[10px] text-muted">Protected</span>
                           ) : (
                             <button
-                              onClick={() =>
+                              onClick={(e) => {
+                                e.stopPropagation();
                                 patch(
                                   c.id,
                                   c.status === "suspended"
                                     ? "reactivate"
                                     : "suspend",
-                                )
-                              }
+                                );
+                              }}
                               disabled={busyOrg === c.id}
                               className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors disabled:opacity-40"
                             >

--- a/src/app/admin/clients/[orgId]/page.tsx
+++ b/src/app/admin/clients/[orgId]/page.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useAuth } from "@clerk/nextjs";
+import Link from "next/link";
+import { Skeleton } from "@/components/Skeleton";
+
+/**
+ * Team Detail (#397) — admin drill-in for one Team workspace. Shows the
+ * member roster and month-by-month pooled usage so we can review overage at
+ * month end (manual billing check; enforcement is post-MVP). Data comes from
+ * GET /api/admin/clients/:orgId. Lives outside the (tabbed) route group, so
+ * it renders its own chrome (back link + heading) like /admin/clients/new.
+ */
+
+type OrgInfo = {
+  id: string;
+  name: string;
+  internal: boolean;
+  status: "pending" | "active" | "suspended";
+  createdAt: number;
+  teamLead: { firstName?: string; lastName?: string; email?: string } | null;
+};
+
+type Member = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  role: string;
+  scoresThisMonth: number;
+};
+
+type MonthUsage = {
+  month: string;
+  scores: number;
+  distinctActiveMembers: number;
+};
+
+type Detail = {
+  org: OrgInfo;
+  pool: number;
+  members: Member[];
+  usageByMonth: MonthUsage[];
+};
+
+/**
+ * Skeleton rows that mirror the real table: one shimmer bar per column, in the
+ * same `<td>`s the data lands in. Matches the /admin/clients pattern.
+ */
+function TableSkeleton({ cols, rows = 4 }: { cols: number; rows?: number }) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <tr key={r} className="border-b border-[#222] last:border-0">
+          {Array.from({ length: cols }).map((_, c) => (
+            <td key={c} className="p-3">
+              <Skeleton className={`h-3.5 ${c === 0 ? "w-4/5" : "w-1/2"}`} />
+            </td>
+          ))}
+        </tr>
+      ))}
+    </>
+  );
+}
+
+function fmtDate(ms: number | null | undefined) {
+  if (!ms) return "—";
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** "2026-07" → "July 2026". Parsed as UTC to match the bucket boundary. */
+function fmtMonth(yyyymm: string) {
+  const [y, m] = yyyymm.split("-").map(Number);
+  if (!y || !m) return yyyymm;
+  return new Date(Date.UTC(y, m - 1, 1)).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+export default function TeamDetailPage() {
+  const params = useParams<{ orgId: string }>();
+  const orgId = params.orgId;
+  const { isSignedIn } = useAuth();
+  const [detail, setDetail] = useState<Detail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Auth + access gating live in the parent /admin layout (#231).
+  useEffect(() => {
+    if (!isSignedIn || !orgId) return;
+    let active = true;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await fetch(`/api/admin/clients/${orgId}`);
+        if (!res.ok) throw new Error(`Detail fetch ${res.status}`);
+        const j = await res.json();
+        if (active) setDetail(j as Detail);
+      } catch (e) {
+        if (active) setError(e instanceof Error ? e.message : "Failed to load");
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [isSignedIn, orgId]);
+
+  const org = detail?.org;
+  const pool = detail?.pool ?? 0;
+
+  return (
+    <div className="pt-20 font-mono">
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <Link
+          href="/admin/clients"
+          className="text-[10px] uppercase tracking-widest text-muted hover:text-foreground transition-colors inline-block mb-4"
+        >
+          ← Clients
+        </Link>
+
+        <div className="mb-8">
+          {loading ? (
+            <Skeleton className="h-6 w-56" />
+          ) : (
+            <h1 className="text-xl text-foreground font-sans flex items-center">
+              {org?.name ?? "Team"}
+              {org?.internal && (
+                <span className="ml-2 text-[9px] uppercase tracking-widest text-ladder-green border border-ladder-green/40 bg-ladder-green/5 px-1.5 py-0.5">
+                  Internal
+                </span>
+              )}
+            </h1>
+          )}
+          {!loading && org && (
+            <p className="text-xs text-muted font-sans mt-1">
+              {org.status === "suspended"
+                ? "Archived"
+                : org.status === "pending"
+                  ? "Pending"
+                  : "Active"}{" "}
+              · Joined {fmtDate(org.createdAt)}
+            </p>
+          )}
+        </div>
+
+        {error && (
+          <div className="mb-6 border border-ladder-red/40 bg-ladder-red/5 text-ladder-red text-xs font-sans p-3">
+            {error}
+          </div>
+        )}
+
+        {/* ── Members ───────────────────────────────────────────── */}
+        <section className="mb-12">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Members
+            </span>
+            {loading ? (
+              <Skeleton className="h-3 w-12" />
+            ) : (
+              <span className="text-[10px] text-muted">
+                {detail?.members.length ?? 0} total
+              </span>
+            )}
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs table-fixed">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  <th className="text-left p-3 w-1/4">Name</th>
+                  <th className="text-left p-3 w-1/4">Email</th>
+                  <th className="text-left p-3 w-1/4">Role</th>
+                  <th className="text-left p-3 w-1/4 whitespace-nowrap">
+                    Scores this month
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <TableSkeleton cols={4} />
+                ) : (detail?.members.length ?? 0) === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="p-6 text-center text-muted font-sans">
+                      No members yet.
+                    </td>
+                  </tr>
+                ) : (
+                  detail!.members.map((m) => (
+                    <tr
+                      key={m.userId}
+                      className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                    >
+                      <td className="p-3 text-foreground truncate">
+                        {m.name ?? "—"}
+                      </td>
+                      <td className="p-3 text-muted truncate">{m.email ?? "—"}</td>
+                      <td className="p-3">
+                        {m.role === "org:admin" ? (
+                          <span className="text-[9px] text-ladder-green uppercase tracking-widest">
+                            Team Lead
+                          </span>
+                        ) : (
+                          <span className="text-[9px] text-muted uppercase tracking-widest">
+                            Member
+                          </span>
+                        )}
+                      </td>
+                      <td className="p-3 text-left tabular-nums text-muted">
+                        {m.scoresThisMonth.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {/* ── Usage by month ────────────────────────────────────── */}
+        <section>
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-[10px] text-muted uppercase tracking-widest">
+              Usage
+            </span>
+            {!loading && (
+              <span className="text-[10px] text-muted">
+                Pool {pool.toLocaleString()} / mo
+              </span>
+            )}
+          </div>
+
+          <div className="border border-[#333] bg-[#1e1e1e]">
+            <table className="w-full text-xs table-fixed">
+              <thead>
+                <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
+                  {/* Widths land on the Members grid (col 1 / 2 / 4) so the two
+                      tables line up: Month↔Name, Scores used↔Email, Distinct↔
+                      Scores this month. */}
+                  <th className="text-left p-3 w-1/4">Month</th>
+                  <th className="text-left p-3 w-1/2">Scores used</th>
+                  <th className="text-left p-3 w-1/4 whitespace-nowrap">
+                    Active members
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {loading ? (
+                  <TableSkeleton cols={3} />
+                ) : (detail?.usageByMonth.length ?? 0) === 0 ? (
+                  <tr>
+                    <td colSpan={3} className="p-6 text-center text-muted font-sans">
+                      No usage yet.
+                    </td>
+                  </tr>
+                ) : (
+                  detail!.usageByMonth.map((u) => {
+                    const over = u.scores >= pool;
+                    return (
+                      <tr
+                        key={u.month}
+                        className="border-b border-[#222] last:border-0 hover:bg-[#222]"
+                      >
+                        <td className="p-3 text-foreground">
+                          {fmtMonth(u.month)}
+                          {over && (
+                            <span className="ml-2 text-[9px] uppercase tracking-widest text-ladder-orange border border-ladder-orange/40 bg-ladder-orange/5 px-1.5 py-0.5 whitespace-nowrap">
+                              Overage
+                            </span>
+                          )}
+                        </td>
+                        <td className="p-3 text-left tabular-nums whitespace-nowrap">
+                          <span className={over ? "text-ladder-orange" : "text-muted"}>
+                            {u.scores.toLocaleString()}
+                          </span>
+                          <span className="text-[#444]">
+                            {" "}
+                            / {pool.toLocaleString()}
+                          </span>
+                        </td>
+                        <td className="p-3 text-left tabular-nums text-muted">
+                          {u.distinctActiveMembers.toLocaleString()}
+                        </td>
+                      </tr>
+                    );
+                  })
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/clients/[orgId]/route.ts
+++ b/src/app/api/admin/clients/[orgId]/route.ts
@@ -1,11 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { getAdminEmail } from "@/lib/admin";
-import { isInternalOrg, orgMeta } from "@/lib/orgs";
+import { isInternalOrg, orgMeta, orgStatus, provisioningUserId } from "@/lib/orgs";
+import { redis, currentYearMonth } from "@/lib/redis";
+import { TEAM_MONTHLY_POOL } from "@/lib/plans";
 
 /**
- * Org lifecycle management (#190).
+ * Org lifecycle management (#190) + Team Detail read (#397).
  *
+ *   GET    /api/admin/clients/:orgId   — Team Detail: org info, member roster,
+ *                                        and usage-by-month for the workspace.
  *   PATCH  /api/admin/clients/:orgId   body { action }
  *     - "suspend" | "reactivate"      → toggle publicMetadata.status
  *     - "markInternal" | "unmarkInternal" → toggle publicMetadata.internal
@@ -18,6 +22,158 @@ import { isInternalOrg, orgMeta } from "@/lib/orgs";
 
 function unauthorized() {
   return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+}
+
+/** One persisted score entry from a member's history zset. */
+type RawScore = { score?: number; timestamp?: number };
+
+/** UTC "YYYY-MM" bucket for a score timestamp — same boundary as the counters. */
+function yearMonthOf(ts: number): string {
+  return currentYearMonth(new Date(ts));
+}
+
+type DetailMember = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  /** Clerk role, e.g. "org:admin" (Team Lead) or "org:member". */
+  role: string;
+  scoresThisMonth: number;
+};
+
+type MonthUsage = {
+  /** "YYYY-MM". */
+  month: string;
+  /** Pooled scoring calls across the workspace that month (all surfaces). */
+  scores: number;
+  /** Members with at least one scoring call that month. */
+  distinctActiveMembers: number;
+};
+
+/**
+ * GET — Team Detail (#397).
+ *
+ * Usage is reconstructed from each current member's durable score history
+ * (`user:{id}:scores`, no TTL), bucketed into UTC months. This is the same
+ * event a scoring call increments the monthly counter on, so the numbers line
+ * up with the pool meter on the clients list — but unlike the 40-day counter,
+ * the history retains full month-by-month totals for billing review.
+ *
+ * Attribution follows CURRENT membership (same limitation as the pool meter):
+ * a departed member's past scores are not counted toward the workspace.
+ */
+export async function GET(
+  _req: NextRequest,
+  { params }: { params: Promise<{ orgId: string }> },
+) {
+  if (!(await getAdminEmail())) return unauthorized();
+
+  const { orgId } = await params;
+  const client = await clerkClient();
+
+  const org = await client.organizations.getOrganization({
+    organizationId: orgId,
+  });
+
+  const provisioner = provisioningUserId();
+  const memberships = await client.organizations.getOrganizationMembershipList({
+    organizationId: orgId,
+    limit: 100,
+  });
+
+  // Real members only — the hidden provisioning service account owns the org
+  // but is never a real teammate, so it's excluded from the roster and usage.
+  const members = memberships.data.filter(
+    (m) => m.publicUserData?.userId && m.publicUserData.userId !== provisioner,
+  );
+
+  const thisMonth = currentYearMonth();
+
+  // Pull every member's full score history once, in parallel.
+  const histories = await Promise.all(
+    members.map(async (m) => {
+      const userId = m.publicUserData!.userId!;
+      let entries: RawScore[] = [];
+      try {
+        const raw = await redis.zrange<unknown[]>(
+          `user:${userId}:scores`,
+          0,
+          -1,
+        );
+        entries = raw.map((e) =>
+          typeof e === "string" ? (JSON.parse(e) as RawScore) : (e as RawScore),
+        );
+      } catch {
+        entries = [];
+      }
+      return { userId, entries };
+    }),
+  );
+
+  // Roster (member row) + per-month rollup, in one pass over the histories.
+  const monthTotals = new Map<string, { scores: number; active: Set<string> }>();
+  const roster: DetailMember[] = members.map((m, i) => {
+    const userId = m.publicUserData!.userId!;
+    const { entries } = histories[i];
+    let scoresThisMonth = 0;
+
+    for (const e of entries) {
+      if (typeof e.timestamp !== "number") continue;
+      const ym = yearMonthOf(e.timestamp);
+      const bucket = monthTotals.get(ym) ?? { scores: 0, active: new Set() };
+      bucket.scores += 1;
+      bucket.active.add(userId);
+      monthTotals.set(ym, bucket);
+      if (ym === thisMonth) scoresThisMonth += 1;
+    }
+
+    const pd = m.publicUserData;
+    const name =
+      [pd?.firstName, pd?.lastName].filter(Boolean).join(" ") || null;
+    return {
+      userId,
+      name,
+      email: pd?.identifier ?? null,
+      role: m.role,
+      scoresThisMonth,
+    };
+  });
+
+  // Always surface the current month (even at zero) so it anchors the top.
+  if (!monthTotals.has(thisMonth)) {
+    monthTotals.set(thisMonth, { scores: 0, active: new Set() });
+  }
+
+  const usageByMonth: MonthUsage[] = Array.from(monthTotals.entries())
+    .map(([month, b]) => ({
+      month,
+      scores: b.scores,
+      distinctActiveMembers: b.active.size,
+    }))
+    // "YYYY-MM" sorts correctly as a string; newest first.
+    .sort((a, b) => (a.month < b.month ? 1 : a.month > b.month ? -1 : 0));
+
+  // Team Lead first, then members, then by name — mirrors the roster order
+  // used elsewhere in the team UI.
+  roster.sort((a, b) => {
+    const lead = (r: DetailMember) => (r.role === "org:admin" ? 0 : 1);
+    if (lead(a) !== lead(b)) return lead(a) - lead(b);
+    return (a.name ?? a.email ?? "").localeCompare(b.name ?? b.email ?? "");
+  });
+
+  return NextResponse.json({
+    org: {
+      id: org.id,
+      name: org.name,
+      internal: isInternalOrg(org),
+      status: orgStatus(org),
+      createdAt: org.createdAt,
+      teamLead: orgMeta(org).teamLead ?? null,
+    },
+    pool: TEAM_MONTHLY_POOL,
+    members: roster,
+    usageByMonth,
+  });
 }
 
 export async function PATCH(

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-07-10
+updatedAt: 2026-07-27
 updatedBy: Sara
-lastPr: 393
+lastPr: 397
 ---
 
 ## How to read this page
@@ -67,7 +67,7 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
 | Score persistence from plugin (also runs the team style-compliance pass so plugin scores show Style Guide findings on the dashboard, #364) | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
 | Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
-| Plugin bundle (v1.13.0) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
+| Plugin bundle (v1.12.0) | All | Live | `drawbackwards/ai-design-assistant`, version synced via `scripts/sync-skill-version.mjs` |
 | Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |
 | Marketplace listing demo flow | Public | Roadmap | Gates the relaunch (re-review restarted 2026-04-18 per memory) |
 | Batch scoring of a frame stack | Pro+ | Roadmap | Open question per Journeys |
@@ -151,6 +151,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Provision Team org + invite Team Lead as `org:admin` | Admin | Live (v0.5.5) | `src/app/api/admin/clients/route.ts` |
 | Org lifecycle: archive / restore (no hard delete — client data is never destroyed) | Admin | Live (#295) | `src/app/admin/(tabbed)/clients/page.tsx`. Underlying state is still the `suspended` flag (`/api/admin/clients/[orgId]` PATCH); the destructive DELETE path was removed. |
 | Pooled monthly usage column on the admin Clients list | Admin | Live (#297) | `src/app/api/admin/clients/route.ts` (`getTeamMonthlyTotal`), `src/app/admin/(tabbed)/clients/page.tsx` |
+| Team Detail: per-org member roster + usage-by-month (reconstructed from durable score history, `Overage` tag at ≥ pool); clients rows link through | Admin | Live (#397) | `src/app/admin/clients/[orgId]/page.tsx`, `src/app/api/admin/clients/[orgId]/route.ts` (GET) |
 | Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |
 | Admin-only "Admin" entry in Account menu (single row; lands on Clients tab) | Admin | Live | `src/components/UserMenu.tsx`, `src/app/api/admin/status/route.ts` |
 | Unified Admin shell with tabs (Clients / Evaluations / Feedback / Comps / Beta Codes) | Admin | Live (#231) | `src/app/admin/layout.tsx`, `src/components/Tabs.tsx` |

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-07-27
 updatedBy: Sara
-lastPr: 397
+lastPr: 404
 ---
 
 ## How to read this page

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-07-27
 updatedBy: Sara
-lastPr: 397
+lastPr: 404
 ---
 
 ## How to read this page

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -1,8 +1,8 @@
 ---
 title: User Journeys
-updatedAt: 2026-07-10
+updatedAt: 2026-07-27
 updatedBy: Sara
-lastPr: 393
+lastPr: 397
 ---
 
 ## How to read this page
@@ -46,6 +46,7 @@ Provisioning moved in-app. After a Drawbackwards Teams engagement closes, a plat
 2. We create a Clerk Organization owned by a hidden **provisioning service account** (`createdBy = PROVISIONING_USER_ID`), not the acting admin — so individual Drawbackwards admins never become members of (or get trapped in) a client org. The service account never logs in and is filtered out of the client's roster and member counts (`isProvisioningUser`). We then send the Team Lead an `org:admin` invitation (inviter is the service account). The org shows as **Pending** until the Team Lead accepts and signs in, at which point the Clerk membership webhook flips it to **Active**.
 3. Self-serve org creation is disabled — clients can no longer spin up their own orgs.
 4. Lifecycle: admins can **suspend/reactivate** an org when a contract pauses/ends (suspended orgs see a "team access paused" notice; members keep their tier for now) and **delete** test orgs (type-the-name to confirm). The internal **Drawbackwards** org is protected from both.
+5. Usage review (#397): clicking a team row opens **Team Detail** (`/admin/clients/[orgId]`) — member roster plus month-by-month pooled usage vs the 25,000 pool, with an **Overage** tag on months at/over pool. It's the manual month-end billing check; the pool is not auto-enforced (throttle + metered billing are post-MVP).
 
 ### Team Lead flow (Live, post-engagement)
 
@@ -72,7 +73,7 @@ See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipp
 
 ## Figma plugin: Live (in marketplace re-review per memory)
 
-The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.13.0 (synced via `scripts/sync-skill-version.mjs`).
+The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.12.0 (synced via `scripts/sync-skill-version.mjs`).
 
 ### Plugin first-run (Live, with caveats)
 


### PR DESCRIPTION
## What

MVP for #397 — an admin **Team Detail** page so we can monitor (and, at month end, manually bill) a client's usage against the 25,000 pool.

- New **Team Detail** page at `/admin/clients/[orgId]`, opened by clicking any Team row on the Clients tab (whole row is now clickable).
- **Members** table: Name · Email · Role (Team Lead / Member) · Scores this month.
- **Usage** table: Month (newest first) · Scores used `/ 25,000` · Active members. Any month at/over the pool shows an orange **Overage** tag and orange count.
- `GET /api/admin/clients/[orgId]` returns org info, roster, and `usageByMonth`, reconstructed from each current member's **durable score history** (`user:{id}:scores`, no TTL). This counts every surface (web, Figma plugin, Claude Skill) since all persist through `persistScoreEntry`. The 40-day monthly counter can't provide real history; the score zset can.

Usage is attributed to **current** members (same limitation as the existing pool meter): a departed member's past scores aren't counted.

## Out of scope (post-MVP, per the issue)

Metered $50/1k Stripe billing, pre-billing written notice, and the throttle. The 25,000 pool is **not** auto-enforced today — this page is the manual review.

## /hq lockstep

- `features.mdx`: Admin-console row for Team Detail.
- `journeys.mdx`: usage-review step in the admin provisioning flow.

## Also bundled (unrelated to #397)

A pre-existing working-tree `/hq` edit that was already present on the `hq-fix-plugin-version` branch: Figma plugin version **1.13.0 → 1.12.0** in `features.mdx` + `journeys.mdx`. Bundled per request. Worth a sanity check that 1.12.0 is the correct current version.

## Verification

- `tsc --noEmit` clean, `eslint` clean.
- `next build` passes; new routes `/admin/clients/[orgId]` (page) and `/api/admin/clients/[orgId]` present.

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)