### PR TITLE
feat(#406): internal token-cost (COGS) accounting + Team Detail cost column

### DIFF
--- a/src/app/admin/clients/[orgId]/page.tsx
+++ b/src/app/admin/clients/[orgId]/page.tsx
@@ -35,7 +35,34 @@ type MonthUsage = {
   month: string;
   scores: number;
   distinctActiveMembers: number;
+  costMicroUsd: number;
+  costByCategory: Record<string, number>;
+  costEstimated: boolean;
 };
+
+/** Human labels for the cost-breakdown popover (keys from token-cost.ts). */
+const COST_CATEGORY_LABELS: Record<string, string> = {
+  score: "Score",
+  overhead: "Scoring overhead",
+  copy: "Improve Copy",
+  a11y: "Fix Accessibility",
+  "style-guide": "Style Guide",
+  annotation: "Annotation",
+  chat: "Chat",
+  feedback: "Feedback",
+};
+
+/** Micro-USD → "$1.23" (or "$0.0043" when small). Inlined to keep server-only
+ * token-cost.ts (which imports redis) out of this client bundle. */
+function fmtUsd(micro: number): string {
+  const usd = micro / 1_000_000;
+  if (usd === 0) return "$0.00";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}
 
 type Detail = {
   org: OrgInfo;
@@ -246,22 +273,22 @@ export default function TeamDetailPage() {
             <table className="w-full text-xs table-fixed">
               <thead>
                 <tr className="border-b border-[#2a2a2a] text-muted uppercase tracking-widest text-[9px]">
-                  {/* Widths land on the Members grid (col 1 / 2 / 4) so the two
-                      tables line up: Month↔Name, Scores used↔Email, Distinct↔
-                      Scores this month. */}
+                  {/* Four equal columns, matching the Members table's grid so
+                      the two tables line up. Cost is internal COGS (#406). */}
                   <th className="text-left p-3 w-1/4">Month</th>
-                  <th className="text-left p-3 w-1/2">Scores used</th>
+                  <th className="text-left p-3 w-1/4">Scores used</th>
                   <th className="text-left p-3 w-1/4 whitespace-nowrap">
                     Active members
                   </th>
+                  <th className="text-left p-3 w-1/4">Cost</th>
                 </tr>
               </thead>
               <tbody>
                 {loading ? (
-                  <TableSkeleton cols={3} />
+                  <TableSkeleton cols={4} />
                 ) : (detail?.usageByMonth.length ?? 0) === 0 ? (
                   <tr>
-                    <td colSpan={3} className="p-6 text-center text-muted font-sans">
+                    <td colSpan={4} className="p-6 text-center text-muted font-sans">
                       No usage yet.
                     </td>
                   </tr>
@@ -292,6 +319,37 @@ export default function TeamDetailPage() {
                         </td>
                         <td className="p-3 text-left tabular-nums text-muted">
                           {u.distinctActiveMembers.toLocaleString()}
+                        </td>
+                        <td className="p-3 text-left tabular-nums">
+                          <span className="group relative inline-flex items-center gap-2">
+                            <span className="text-foreground">
+                              {fmtUsd(u.costMicroUsd)}
+                            </span>
+                            {u.costEstimated && (
+                              <span className="text-[9px] uppercase tracking-widest text-muted border border-[#333] bg-[#111] px-1.5 py-0.5">
+                                Estimated
+                              </span>
+                            )}
+                            {Object.keys(u.costByCategory).length > 0 && (
+                              <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-10 min-w-[190px] border border-[#333] bg-[#1a1a1a] p-2 text-left normal-case tracking-normal shadow-lg">
+                                {Object.entries(u.costByCategory)
+                                  .sort((a, b) => b[1] - a[1])
+                                  .map(([cat, v]) => (
+                                    <div
+                                      key={cat}
+                                      className="flex items-center justify-between gap-4 py-0.5"
+                                    >
+                                      <span className="text-muted font-sans">
+                                        {COST_CATEGORY_LABELS[cat] ?? cat}
+                                      </span>
+                                      <span className="text-foreground tabular-nums">
+                                        {fmtUsd(v)}
+                                      </span>
+                                    </div>
+                                  ))}
+                              </div>
+                            )}
+                          </span>
                         </td>
                       </tr>
                     );

--- a/src/app/api/admin/clients/[orgId]/route.ts
+++ b/src/app/api/admin/clients/[orgId]/route.ts
@@ -4,6 +4,7 @@ import { getAdminEmail } from "@/lib/admin";
 import { isInternalOrg, orgMeta, orgStatus, provisioningUserId } from "@/lib/orgs";
 import { redis, currentYearMonth } from "@/lib/redis";
 import { TEAM_MONTHLY_POOL } from "@/lib/plans";
+import { getMonthlyCost, estimateScoreCostMicroUsd } from "@/lib/token-cost";
 
 /**
  * Org lifecycle management (#190) + Team Detail read (#397).
@@ -48,6 +49,16 @@ type MonthUsage = {
   scores: number;
   /** Members with at least one scoring call that month. */
   distinctActiveMembers: number;
+  /** Internal COGS: Anthropic token cost this month, in micro-USD (#406). */
+  costMicroUsd: number;
+  /** Per-category cost breakdown for the popover, micro-USD. */
+  costByCategory: Record<string, number>;
+  /**
+   * True when costMicroUsd is an estimate (score-count × per-score rate) rather
+   * than recorded token usage — i.e. a month before cost instrumentation
+   * shipped. Estimated months cover the score category only; the UI tags them.
+   */
+  costEstimated: boolean;
 };
 
 /**
@@ -144,12 +155,55 @@ export async function GET(
     monthTotals.set(thisMonth, { scores: 0, active: new Set() });
   }
 
-  const usageByMonth: MonthUsage[] = Array.from(monthTotals.entries())
-    .map(([month, b]) => ({
-      month,
-      scores: b.scores,
-      distinctActiveMembers: b.active.size,
-    }))
+  const months = Array.from(monthTotals.keys());
+
+  // Actual recorded token cost per month = sum of every current member's cost
+  // hash for that month (#406). One read per (member, month); fine at team
+  // scale. A month with no recorded cost falls back to an estimate below.
+  const memberIds = members.map((m) => m.publicUserData!.userId!);
+  const costByMonth = new Map<string, { total: number; byCategory: Record<string, number> }>(
+    months.map((mo) => [mo, { total: 0, byCategory: {} }]),
+  );
+  await Promise.all(
+    memberIds.flatMap((userId) =>
+      months.map(async (mo) => {
+        const { total, byCategory } = await getMonthlyCost(userId, mo);
+        if (total <= 0) return;
+        const agg = costByMonth.get(mo)!;
+        agg.total += total;
+        for (const [cat, v] of Object.entries(byCategory)) {
+          agg.byCategory[cat] = (agg.byCategory[cat] ?? 0) + v;
+        }
+      }),
+    ),
+  );
+
+  const usageByMonth: MonthUsage[] = months
+    .map((month) => {
+      const b = monthTotals.get(month)!;
+      const actual = costByMonth.get(month)!;
+      // Recorded cost wins; otherwise estimate from the month's score count
+      // (score category only — see costEstimated).
+      if (actual.total > 0) {
+        return {
+          month,
+          scores: b.scores,
+          distinctActiveMembers: b.active.size,
+          costMicroUsd: actual.total,
+          costByCategory: actual.byCategory,
+          costEstimated: false,
+        };
+      }
+      const estimate = estimateScoreCostMicroUsd(b.scores);
+      return {
+        month,
+        scores: b.scores,
+        distinctActiveMembers: b.active.size,
+        costMicroUsd: estimate,
+        costByCategory: estimate > 0 ? { score: estimate } : {},
+        costEstimated: estimate > 0,
+      };
+    })
     // "YYYY-MM" sorts correctly as a string; newest first.
     .sort((a, b) => (a.month < b.month ? 1 : a.month > b.month ? -1 : 0));
 

--- a/src/app/api/admin/evaluations/[id]/analyze/route.ts
+++ b/src/app/api/admin/evaluations/[id]/analyze/route.ts
@@ -39,7 +39,9 @@ export async function POST(
     const parsed = parseImageDataUrl(screen.imageData);
     if (!parsed) continue;
 
-    const result = await analyzeScreenForReport(parsed, evaluation.mode);
+    // Internal admin eval — attribute cost to the admin (never a client member,
+    // so it won't roll into any team's COGS total).
+    const result = await analyzeScreenForReport(parsed, evaluation.mode, admin);
     const idx = updatedScreens.findIndex((s) => s.id === screen.id);
     if (idx === -1) continue;
 

--- a/src/app/api/org/style-guide/route.ts
+++ b/src/app/api/org/style-guide/route.ts
@@ -79,8 +79,8 @@ export async function POST(req: NextRequest) {
   let conflicts: StyleConflict[] = [];
   try {
     [ruleset, conflicts] = await Promise.all([
-      distillStyleGuide(pdfBase64),
-      detectStyleConflicts(pdfBase64).catch((e) => {
+      distillStyleGuide(pdfBase64, userId),
+      detectStyleConflicts(pdfBase64, userId).catch((e) => {
         console.warn("[style-guide] conflict detection failed:", e);
         return [] as StyleConflict[];
       }),

--- a/src/app/api/plugin/analyze/copy/route.ts
+++ b/src/app/api/plugin/analyze/copy/route.ts
@@ -91,7 +91,7 @@ export async function POST(req: NextRequest) {
     // style matters. Each degrades on its own without failing the other.
     const [styleGuide, general] = await Promise.all([
       ruleset
-        ? analyzeStyleComplianceCached({ image: imageInput, frameText }, ruleset, orgId)
+        ? analyzeStyleComplianceCached({ image: imageInput, frameText }, ruleset, orgId, userId)
             .then(
               (outcome): StyleGuideResult => ({
                 status: outcome.findings.length > 0 ? "issues" : "compliant",
@@ -110,7 +110,7 @@ export async function POST(req: NextRequest) {
               };
             })
         : Promise.resolve(null),
-      auditCopy({ image: imageInput, frameText }).catch((e) => {
+      auditCopy({ image: imageInput, frameText }, { costUserId: userId }).catch((e) => {
         console.warn("[LADDER:WARN] plugin general copy pass failed:", e);
         return { summary: "", rewrites: [] };
       }),

--- a/src/app/api/plugin/analyze/route.ts
+++ b/src/app/api/plugin/analyze/route.ts
@@ -45,7 +45,8 @@ export async function POST(req: NextRequest) {
 
   try {
     const body = await req.json();
-    const { image, designType, mode = "improve" } = body;
+    // `userId` optional — attribute Anthropic token cost when the plugin sends it (#406).
+    const { image, designType, mode = "improve", userId } = body;
 
     if (mode !== "improve") {
       return NextResponse.json(
@@ -69,7 +70,11 @@ export async function POST(req: NextRequest) {
 
     // Trusted service-token caller scoring a signed-in designer's own frame —
     // skip the anonymous-upload moderation gate (keeps the score fast) (#343).
-    const result = await scoreImage(parsed, { applyAiLens, skipModeration: true });
+    const result = await scoreImage(parsed, {
+      applyAiLens,
+      skipModeration: true,
+      costUserId: typeof userId === "string" ? userId : null,
+    });
     if (isScoringError(result)) {
       return NextResponse.json(
         { error: result.error },

--- a/src/app/api/plugin/analyze/stream/route.ts
+++ b/src/app/api/plugin/analyze/stream/route.ts
@@ -50,7 +50,9 @@ export async function POST(req: NextRequest) {
   }
 
   const body = await req.json();
-  const { image, designType } = body;
+  // `userId` is optional today (the plugin backend owns persistence/counting);
+  // when present we attribute Anthropic token cost to that user (#406 COGS).
+  const { image, designType, userId } = body;
   const parsed = parseImageDataUrl(image);
   if (!parsed) {
     return NextResponse.json(
@@ -125,6 +127,7 @@ export async function POST(req: NextRequest) {
         for await (const ev of scoreImageStream(parsed, {
           applyAiLens,
           skipModeration: true,
+          costUserId: typeof userId === "string" ? userId : null,
         })) {
           if (ev.kind === "error") {
             send("error", { message: ev.value, status: ev.status });

--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -127,6 +127,7 @@ export async function POST(req: NextRequest) {
               },
               rulesetWithResolutions(orgGuide.ruleset, orgGuide.conflicts),
               orgId,
+              userId,
             );
             styleGuide = {
               status: outcome.findings.length > 0 ? "issues" : "compliant",

--- a/src/app/api/score/route.ts
+++ b/src/app/api/score/route.ts
@@ -140,6 +140,7 @@ export async function POST(req: NextRequest) {
         : undefined,
       styleTeamName: styleGuide?.teamName,
       styleFrameText: frameText,
+      costUserId: userId,
     });
     if (isScoringError(result)) {
       return NextResponse.json(

--- a/src/app/api/score/stream/route.ts
+++ b/src/app/api/score/stream/route.ts
@@ -147,6 +147,7 @@ export async function POST(req: NextRequest) {
             : undefined,
           styleTeamName: styleGuide?.teamName,
           styleFrameText: frameText,
+          costUserId: userId,
         })) {
           if (ev.kind === "error") {
             send("error", { message: ev.value, status: ev.status });

--- a/src/app/api/screenshot/route.ts
+++ b/src/app/api/screenshot/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import chromium from "@sparticuz/chromium-min";
 import puppeteer, { Page } from "puppeteer-core";
 import Anthropic from "@anthropic-ai/sdk";
+import { auth } from "@clerk/nextjs/server";
+import { recordTokenCost } from "@/lib/token-cost";
 
 export const maxDuration = 60;
 
@@ -115,6 +117,9 @@ async function dismissModalByAI(page: Page, action: string) {
 
 export async function POST(req: NextRequest) {
   let browser = null;
+  // Attribute the modal-detection helper call's token cost to the signed-in
+  // user when there is one (anonymous URL captures go unattributed) — #406 COGS.
+  const { userId: costUserId } = await auth();
 
   try {
     /* ── Bot detection: block known automation tools ── */
@@ -277,6 +282,12 @@ export async function POST(req: NextRequest) {
             { type: "text", text: "Is there a modal, popup, cookie banner, or overlay blocking the main page content? If yes, respond with JSON: {\"blocked\":true,\"action\":\"describe the button/link text to click to dismiss it\"}. If the page is clear, respond: {\"blocked\":false}. ONLY return JSON." },
           ],
         }],
+      });
+      void recordTokenCost({
+        userId: costUserId,
+        category: "overhead",
+        model: "claude-haiku-4-5-20251001",
+        usage: modalCheck.usage,
       });
       const modalText = modalCheck.content.find((b) => b.type === "text");
       if (modalText && modalText.type === "text") {

--- a/src/app/api/skill/score/route.ts
+++ b/src/app/api/skill/score/route.ts
@@ -104,7 +104,7 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    const result = await scoreImage(parsed);
+    const result = await scoreImage(parsed, { costUserId: userId });
     if (isScoringError(result)) {
       return NextResponse.json(
         { error: result.error },

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-28
 updatedBy: Sara
-lastPr: 406
+lastPr: 407
 ---
 
 ## Deployment environments

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -1,8 +1,8 @@
 ---
 title: Architecture
-updatedAt: 2026-07-08
+updatedAt: 2026-07-28
 updatedBy: Sara
-lastPr: 387
+lastPr: 406
 ---
 
 ## Deployment environments
@@ -67,6 +67,10 @@ This diagram shows the future-target architecture (one engine, thin clients). To
 **Billing.** Stripe. Subscriptions live in `runladder`. Pulse and the legacy Ladder engagement (Lumin Digital) bill outside of Stripe via Drawbackwards agency contracts.
 
 **Data.** Upstash Redis in `runladder` for scoring history and tier counters. Pulse uses Prisma + Postgres on Fly.io in `ladder-beta`. Postgres in `runladder` is planned but not scheduled.
+
+**Token-cost accounting (COGS, internal only).** Every Anthropic call in this repo routes its response `usage` through the single chokepoint `recordTokenCost(...)` in `src/lib/token-cost.ts`, which prices tokens per model and accumulates cost per **user, per month, per category** in the Redis hash `usage:cost:{userId}:{yyyymm}` (micro-USD, no TTL). Categories: `score`, `overhead` (moderation + transcription), `copy`, `a11y`, `style-guide`, `annotation`, `chat`, `feedback`. The admin Team Detail page ([#397](https://github.com/drawbackwards/runladder/issues/397)) sums current members' costs to show what a client costs us to run, with a per-category popover ([#406](https://github.com/drawbackwards/runladder/issues/406)). Months before this shipped have no token data, so they're shown as an **estimate** (score count × a per-score rate; score category only) and tagged "Estimated" in the UI. This number is **internal COGS only — never client-facing**, and it is intentionally decoupled from the user-facing "scores this month" count (bonus plugin features cost money but are not scores). Pricing rates live in `RATES` in `token-cost.ts`; update them when Anthropic pricing changes.
+
+> **RULE (unbreakable):** any new code path that makes an Anthropic/LLM call MUST call `recordTokenCost` with an appropriate category, or its spend is invisible to COGS. When you add a new category, add it to `CostCategory`, the category list above, and the popover labels in the Team Detail page. The Figma plugin's own direct Anthropic calls (a11y, chat, feedback in `ai-design-assistant/api/*`) write to the same shared `usage:cost:*` hash — keep both repos in sync.
 
 ## Versioning
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-07-27
+updatedAt: 2026-07-28
 updatedBy: Sara
-lastPr: 404
+lastPr: 406
 ---
 
 ## How to read this page
@@ -152,6 +152,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Org lifecycle: archive / restore (no hard delete — client data is never destroyed) | Admin | Live (#295) | `src/app/admin/(tabbed)/clients/page.tsx`. Underlying state is still the `suspended` flag (`/api/admin/clients/[orgId]` PATCH); the destructive DELETE path was removed. |
 | Pooled monthly usage column on the admin Clients list | Admin | Live (#297) | `src/app/api/admin/clients/route.ts` (`getTeamMonthlyTotal`), `src/app/admin/(tabbed)/clients/page.tsx` |
 | Team Detail: per-org member roster + usage-by-month (reconstructed from durable score history, `Overage` tag at ≥ pool); clients rows link through | Admin | Live (#397) | `src/app/admin/clients/[orgId]/page.tsx`, `src/app/api/admin/clients/[orgId]/route.ts` (GET) |
+| Team Detail token-cost (COGS) column: per-month Anthropic spend with per-category popover; `Estimated` tag for pre-instrumentation months. Internal only, never client-facing. All LLM calls route through `recordTokenCost` | Admin | Live (#406) | `src/lib/token-cost.ts`, `src/app/admin/clients/[orgId]/`; capture wired in `scoring.ts`, `style-guide.ts`, `copy-audit.ts`, `annotation-analysis.ts`, `screenshot` |
 | Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |
 | Admin-only "Admin" entry in Account menu (single row; lands on Clients tab) | Admin | Live | `src/components/UserMenu.tsx`, `src/app/api/admin/status/route.ts` |
 | Unified Admin shell with tabs (Clients / Evaluations / Feedback / Comps / Beta Codes) | Admin | Live (#231) | `src/app/admin/layout.tsx`, `src/components/Tabs.tsx` |

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-07-28
 updatedBy: Sara
-lastPr: 406
+lastPr: 407
 ---
 
 ## How to read this page

--- a/src/lib/annotation-analysis.ts
+++ b/src/lib/annotation-analysis.ts
@@ -10,6 +10,7 @@
  */
 import Anthropic from "@anthropic-ai/sdk";
 import type { MediaType } from "./scoring";
+import { recordTokenCost } from "./token-cost";
 import { getLearningContext } from "./evaluation-learning";
 import type { LearningContext } from "./evaluation-learning";
 
@@ -103,6 +104,7 @@ const client = new Anthropic();
 export async function analyzeScreenForReport(
   { mediaType, base64Data }: { mediaType: MediaType; base64Data: string },
   mode: "sample" | "audit" = "sample",
+  costUserId?: string | null,
 ): Promise<AnnotationResult | { error: string }> {
   if (base64Data.length > 7_000_000) {
     return { error: "Image too large. Please use an image under 5MB." };
@@ -143,6 +145,12 @@ export async function analyzeScreenForReport(
           ],
         },
       ],
+    });
+    void recordTokenCost({
+      userId: costUserId,
+      category: "annotation",
+      model: "claude-sonnet-4-6",
+      usage: response.usage,
     });
 
     const textBlock = response.content.find((b) => b.type === "text");

--- a/src/lib/copy-audit.ts
+++ b/src/lib/copy-audit.ts
@@ -18,6 +18,7 @@ import Anthropic from "@anthropic-ai/sdk";
 import type { MediaType } from "./scoring";
 import { extractJsonObject } from "./json-extract";
 import { hasFrameText, type FrameText } from "./style-guide";
+import { recordTokenCost } from "./token-cost";
 
 /** Copy types the audit classifies each string as, then judges by its own rules. */
 export const COPY_TYPES = [
@@ -120,13 +121,16 @@ RULES:
  * Returns an empty result on an unparseable response so callers degrade
  * gracefully. At least one of image/frameText must be provided.
  */
-export async function auditCopy({
-  image,
-  frameText,
-}: {
-  image?: { mediaType: MediaType; base64Data: string } | null;
-  frameText?: FrameText | null;
-}): Promise<GeneralCopyResult> {
+export async function auditCopy(
+  {
+    image,
+    frameText,
+  }: {
+    image?: { mediaType: MediaType; base64Data: string } | null;
+    frameText?: FrameText | null;
+  },
+  opts: { costUserId?: string | null } = {},
+): Promise<GeneralCopyResult> {
   const hasText = hasFrameText(frameText);
   const empty: GeneralCopyResult = { summary: "", rewrites: [] };
   if (!image && !hasText) return empty;
@@ -158,6 +162,13 @@ export async function auditCopy({
     temperature: 0,
     messages: [{ role: "user", content }],
     system: COPY_SYSTEM,
+  });
+  // COGS (#406): Improve Copy general audit (Sonnet, plugin-only bonus feature).
+  void recordTokenCost({
+    userId: opts.costUserId,
+    category: "copy",
+    model: "claude-sonnet-4-6",
+    usage: response.usage,
   });
 
   const textBlock = response.content.find((b) => b.type === "text");

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -21,6 +21,7 @@ import {
 import { extractJsonObject } from "./json-extract";
 import { redis } from "./redis";
 import { CURRENT_ENGINE_VERSION } from "./app-version";
+import { recordTokenCost } from "./token-cost";
 import {
   analyzeStyleCompliance,
   hasFrameText,
@@ -256,6 +257,7 @@ async function runModeration(
   client: Anthropic,
   mediaType: MediaType,
   base64Data: string,
+  costUserId?: string | null,
 ): Promise<ScoringError | null> {
   try {
     const modCheck = await client.messages.create({
@@ -275,6 +277,13 @@ async function runModeration(
         },
       ],
       system: MODERATION_PROMPT,
+    });
+    // COGS (#406): moderation is a per-score Haiku overhead call.
+    void recordTokenCost({
+      userId: costUserId,
+      category: "overhead",
+      model: SCORING_MODEL,
+      usage: modCheck.usage,
     });
     const modText = modCheck.content.find((b) => b.type === "text");
     if (modText && modText.type === "text") {
@@ -344,6 +353,8 @@ export async function scoreImage(
      * callers must never set this; scoring is pinned to 0.
      */
     temperature?: number;
+    /** User to attribute Anthropic token cost to (#406 COGS). */
+    costUserId?: string | null;
   } = {},
 ): Promise<ScoreResult | ScoringError> {
   // Cap image size (~5MB base64)
@@ -367,7 +378,7 @@ export async function scoreImage(
   // Moderation gate — only on a cache MISS (a cached score already passed it),
   // and skipped for trusted service-token callers (see skipModeration).
   if (!cached && !opts.skipModeration) {
-    const modErr = await runModeration(client, mediaType, base64Data);
+    const modErr = await runModeration(client, mediaType, base64Data, opts.costUserId);
     if (modErr) return modErr;
   }
 
@@ -378,6 +389,7 @@ export async function scoreImage(
     ? analyzeStyleCompliance(
         { image: { mediaType, base64Data }, frameText: opts.styleFrameText },
         opts.styleRuleset,
+        { costUserId: opts.costUserId },
       )
         .then((outcome) => ({ ok: true as const, ...outcome }))
         .catch((e) => {
@@ -416,6 +428,13 @@ export async function scoreImage(
         },
       ],
       system,
+    });
+    // COGS (#406): the Ladder score itself (Haiku).
+    void recordTokenCost({
+      userId: opts.costUserId,
+      category: "score",
+      model: SCORING_MODEL,
+      usage: response.usage,
     });
 
     const textBlock = response.content.find((b) => b.type === "text");
@@ -507,6 +526,8 @@ export async function* scoreImageStream(
      * anonymous web stream leaves it unset and keeps the gate.
      */
     skipModeration?: boolean;
+    /** User to attribute Anthropic token cost to (#406 COGS). */
+    costUserId?: string | null;
   } = {},
 ): AsyncGenerator<ScoringStreamEvent> {
   if (base64Data.length > 7_000_000) {
@@ -530,6 +551,7 @@ export async function* scoreImageStream(
     ? analyzeStyleCompliance(
         { image: { mediaType, base64Data }, frameText: opts.styleFrameText },
         opts.styleRuleset,
+        { costUserId: opts.costUserId },
       )
         .then((outcome) => ({ ok: true as const, ...outcome }))
         .catch((e) => {
@@ -570,7 +592,7 @@ export async function* scoreImageStream(
    * for trusted service-token callers (see skipModeration) so the plugin's
    * in-canvas score isn't gated behind an extra round-trip. ── */
   if (!opts.skipModeration) {
-    const modErr = await runModeration(client, mediaType, base64Data);
+    const modErr = await runModeration(client, mediaType, base64Data, opts.costUserId);
     if (modErr) {
       yield { kind: "error", value: modErr.error, status: modErr.status };
       return;
@@ -656,6 +678,13 @@ export async function* scoreImageStream(
 
     /* ── Parse final ── */
     const final = await stream.finalMessage();
+    // COGS (#406): the Ladder score itself (Haiku).
+    void recordTokenCost({
+      userId: opts.costUserId,
+      category: "score",
+      model: SCORING_MODEL,
+      usage: final.usage,
+    });
     const textBlock = final.content.find((b) => b.type === "text");
     if (!textBlock || textBlock.type !== "text") {
       yield { kind: "error", value: "No response from scoring engine", status: 500 };

--- a/src/lib/style-guide.ts
+++ b/src/lib/style-guide.ts
@@ -17,6 +17,10 @@ import { createHash } from "crypto";
 import type { MediaType } from "./scoring";
 import { extractJsonObject } from "./json-extract";
 import { redis } from "./redis";
+import { recordTokenCost } from "./token-cost";
+
+/** Model used for all style-guide passes (distill, conflicts, transcribe, compliance). */
+const STYLE_MODEL = "claude-sonnet-4-6";
 
 /**
  * One advisory copy/writing-style finding. Mirrors what the score result and
@@ -208,7 +212,10 @@ Output a tight, plain-text list of rules grouped under short headings (Tone, Ter
  * The PDF is sent natively to Claude (document block) — no PDF parser.
  * Returns the ruleset text, or null if the guide has no usable writing rules.
  */
-export async function distillStyleGuide(pdfBase64: string): Promise<string | null> {
+export async function distillStyleGuide(
+  pdfBase64: string,
+  costUserId?: string | null,
+): Promise<string | null> {
   const client = new Anthropic();
   const response = await client.messages.create({
     model: "claude-sonnet-4-6",
@@ -233,6 +240,12 @@ export async function distillStyleGuide(pdfBase64: string): Promise<string | nul
       },
     ],
     system: DISTILL_SYSTEM,
+  });
+  void recordTokenCost({
+    userId: costUserId,
+    category: "style-guide",
+    model: STYLE_MODEL,
+    usage: response.usage,
   });
 
   const textBlock = response.content.find((b) => b.type === "text");
@@ -265,7 +278,10 @@ If there are no genuine conflicts, return {"conflicts": []}.`;
  * Independent of distillation; best-effort — a failure returns []. Advisory
  * output shown on the team's Settings page so they can fix + re-upload the guide.
  */
-export async function detectStyleConflicts(pdfBase64: string): Promise<StyleConflict[]> {
+export async function detectStyleConflicts(
+  pdfBase64: string,
+  costUserId?: string | null,
+): Promise<StyleConflict[]> {
   // Cache by the PDF's exact bytes + the prompt, so re-uploading the SAME guide
   // always yields the SAME conflicts. Detection is an open-ended "find all
   // contradictions" task that isn't perfectly deterministic even at temperature
@@ -303,6 +319,12 @@ export async function detectStyleConflicts(pdfBase64: string): Promise<StyleConf
       },
     ],
     system: CONFLICT_SYSTEM,
+  });
+  void recordTokenCost({
+    userId: costUserId,
+    category: "style-guide",
+    model: STYLE_MODEL,
+    usage: response.usage,
   });
 
   const textBlock = response.content.find((b) => b.type === "text");
@@ -382,10 +404,13 @@ const TRANSCRIBE_SYSTEM = `You transcribe EVERY piece of visible text in a UI sc
  * still "inferred", not ground truth. Returns null on failure; the caller then
  * falls back to reading the image directly.
  */
-export async function transcribeScreenText(image: {
-  mediaType: MediaType;
-  base64Data: string;
-}): Promise<FrameText | null> {
+export async function transcribeScreenText(
+  image: {
+    mediaType: MediaType;
+    base64Data: string;
+  },
+  costUserId?: string | null,
+): Promise<FrameText | null> {
   const client = new Anthropic();
   const response = await client.messages.create({
     model: "claude-sonnet-4-6",
@@ -404,6 +429,13 @@ export async function transcribeScreenText(image: {
       },
     ],
     system: TRANSCRIBE_SYSTEM,
+  });
+  // COGS (#406): the image-transcription pre-pass is scoring overhead.
+  void recordTokenCost({
+    userId: costUserId,
+    category: "overhead",
+    model: STYLE_MODEL,
+    usage: response.usage,
   });
   const textBlock = response.content.find((b) => b.type === "text");
   if (!textBlock || textBlock.type !== "text") return null;
@@ -435,6 +467,7 @@ export async function analyzeStyleCompliance(
     frameText?: FrameText | null;
   },
   ruleset: string,
+  opts: { costUserId?: string | null } = {},
 ): Promise<StyleComplianceOutcome> {
   const hasText = hasFrameText(frameText);
   // textSource reflects whether we had GROUND-TRUTH text. An image we transcribe
@@ -450,7 +483,9 @@ export async function analyzeStyleCompliance(
   // is unavailable.
   let listing: FrameText | null = hasText ? frameText : null;
   if (!listing && image) {
-    const transcribed = await transcribeScreenText(image).catch(() => null);
+    const transcribed = await transcribeScreenText(image, opts.costUserId).catch(
+      () => null,
+    );
     if (hasFrameText(transcribed)) listing = transcribed;
   }
   const haveListing = hasFrameText(listing);
@@ -484,6 +519,12 @@ export async function analyzeStyleCompliance(
     temperature: 0,
     messages: [{ role: "user", content }],
     system: COMPLIANCE_SYSTEM,
+  });
+  void recordTokenCost({
+    userId: opts.costUserId,
+    category: "style-guide",
+    model: STYLE_MODEL,
+    usage: response.usage,
   });
 
   const textBlock = response.content.find((b) => b.type === "text");
@@ -567,9 +608,10 @@ export async function analyzeStyleComplianceCached(
   },
   ruleset: string,
   orgId: string | null,
+  costUserId?: string | null,
 ): Promise<StyleComplianceOutcome> {
   if (!orgId || !hasFrameText(input.frameText)) {
-    return analyzeStyleCompliance(input, ruleset);
+    return analyzeStyleCompliance(input, ruleset, { costUserId });
   }
   const key = styleCacheKey(orgId, ruleset, input.frameText);
   try {
@@ -578,7 +620,7 @@ export async function analyzeStyleComplianceCached(
   } catch {
     // cache read is best-effort
   }
-  const outcome = await analyzeStyleCompliance(input, ruleset);
+  const outcome = await analyzeStyleCompliance(input, ruleset, { costUserId });
   try {
     // 24h TTL; the key is content-addressed so it's safe to keep — a changed
     // guide or changed screen produces a different key, not a stale hit.

--- a/src/lib/token-cost.ts
+++ b/src/lib/token-cost.ts
@@ -1,0 +1,174 @@
+/**
+ * Token-cost accounting (#406) — internal COGS visibility only, never
+ * client-facing.
+ *
+ * Every Anthropic call in this repo (and the Figma plugin, which shares this
+ * KV) routes its response `usage` through `recordTokenCost`, which prices the
+ * tokens per model and accumulates the cost per user, per month, per category.
+ * The admin Team Detail page (#397) sums current members' costs to show what a
+ * client costs us to compare against what we bill them.
+ *
+ * RULE (documented in /hq/architecture): any new code path that makes an
+ * Anthropic/LLM call MUST call recordTokenCost with a category, or its spend
+ * is invisible to COGS.
+ *
+ * Storage: Redis hash `usage:cost:{userId}:{yyyymm}`, one field per category,
+ * value = accumulated cost in MICRO-USD (integer, via HINCRBY). No TTL — unlike
+ * the 40-day scan counter, cost history is retained for month-by-month review.
+ * Micro-USD (1 USD = 1e6 µ$) keeps the store integer-only; the UI divides.
+ */
+import { redis, currentYearMonth } from "@/lib/redis";
+
+/**
+ * Billable categories — the "what are people actually using" breakdown behind
+ * the Team Detail cost popover. Keep in sync with the /hq/architecture table.
+ */
+export type CostCategory =
+  | "score" // the Ladder score itself (web / plugin / skill) — Haiku
+  | "overhead" // moderation pre-check + image transcription — Haiku
+  | "copy" // Improve Copy (plugin) — Sonnet
+  | "a11y" // Fix Accessibility (plugin) — Sonnet
+  | "style-guide" // team style-guide compliance + ambiguity — Sonnet
+  | "annotation" // annotation calibration — Sonnet
+  | "chat" // plugin "Ask follow-up" chat
+  | "feedback"; // plugin feedback processing
+
+export const COST_CATEGORIES: readonly CostCategory[] = [
+  "score",
+  "overhead",
+  "copy",
+  "a11y",
+  "style-guide",
+  "annotation",
+  "chat",
+  "feedback",
+] as const;
+
+/**
+ * Token usage as returned by the Anthropic SDK / raw API `usage` object. The
+ * SDK types the cache fields as `number | null`, so allow null here too.
+ */
+export type TokenUsage = {
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cache_creation_input_tokens?: number | null;
+  cache_read_input_tokens?: number | null;
+};
+
+/**
+ * Per-model rates in USD per million tokens. Because micro-USD = tokens ×
+ * ($/MTok), storing $/MTok lets us compute cost with a single multiply and no
+ * fractional intermediate. Cache read ≈ 0.1× input; cache write (5-min TTL) =
+ * 1.25× input (Anthropic list prices via the claude-api skill, 2026-07).
+ * Update these when Anthropic pricing changes or a new model is introduced.
+ */
+type ModelRates = {
+  input: number;
+  output: number;
+  cacheWrite: number;
+  cacheRead: number;
+};
+
+const RATES: Record<"haiku" | "sonnet", ModelRates> = {
+  // claude-haiku-4-5: $1 / $5
+  haiku: { input: 1.0, output: 5.0, cacheWrite: 1.25, cacheRead: 0.1 },
+  // claude-sonnet-4-6: $3 / $15
+  sonnet: { input: 3.0, output: 15.0, cacheWrite: 3.75, cacheRead: 0.3 },
+};
+
+/**
+ * Map a model id (dated snapshot or floating alias) to its rate family.
+ * Unknown models fall back to the pricier Sonnet rates and warn — for a COGS
+ * guardrail, over-estimating an unpriced model beats silently dropping it.
+ */
+function ratesFor(model: string): ModelRates {
+  const m = model.toLowerCase();
+  if (m.includes("haiku")) return RATES.haiku;
+  if (m.includes("sonnet")) return RATES.sonnet;
+  console.warn(`[LADDER:COST] unpriced model "${model}" — using Sonnet rates`);
+  return RATES.sonnet;
+}
+
+/** Cost of one call in micro-USD (integer). */
+export function costMicroUsd(model: string, usage: TokenUsage): number {
+  const r = ratesFor(model);
+  const dollars =
+    (usage.input_tokens ?? 0) * r.input +
+    (usage.output_tokens ?? 0) * r.output +
+    (usage.cache_creation_input_tokens ?? 0) * r.cacheWrite +
+    (usage.cache_read_input_tokens ?? 0) * r.cacheRead;
+  // dollars here is already in micro-USD units (tokens × $/MTok == µ$).
+  return Math.round(dollars);
+}
+
+function costKey(userId: string, yyyymm: string): string {
+  return `usage:cost:${userId}:${yyyymm}`;
+}
+
+/**
+ * Record the cost of one Anthropic call. Best-effort and fire-and-forget:
+ * callers should NOT await this on the hot path and it never throws — a cost
+ * write must never break scoring.
+ */
+export async function recordTokenCost(args: {
+  userId: string | null | undefined;
+  category: CostCategory;
+  model: string;
+  usage: TokenUsage | null | undefined;
+  /** Defaults to now; pass the score timestamp to bucket a backdated write. */
+  yyyymm?: string;
+}): Promise<void> {
+  const { userId, category, model, usage } = args;
+  if (!userId || !usage) return;
+  try {
+    const micro = costMicroUsd(model, usage);
+    if (micro <= 0) return;
+    const key = costKey(userId, args.yyyymm ?? currentYearMonth());
+    await redis.hincrby(key, category, micro);
+  } catch (err) {
+    console.error("[LADDER:COST] record failed:", err);
+  }
+}
+
+/** One user's cost for one month: total + per-category, in micro-USD. */
+export async function getMonthlyCost(
+  userId: string,
+  yyyymm: string,
+): Promise<{ total: number; byCategory: Record<string, number> }> {
+  const raw = await redis.hgetall<Record<string, number | string>>(
+    costKey(userId, yyyymm),
+  );
+  const byCategory: Record<string, number> = {};
+  let total = 0;
+  for (const [cat, val] of Object.entries(raw ?? {})) {
+    const n = typeof val === "number" ? val : parseInt(String(val), 10);
+    if (!Number.isFinite(n)) continue;
+    byCategory[cat] = n;
+    total += n;
+  }
+  return { total, byCategory };
+}
+
+/**
+ * Rough per-score cost for ESTIMATING pre-instrumentation months, where all we
+ * retain is the score count (no token data). Covers the Haiku scoring call plus
+ * its moderation/transcription overhead; it CANNOT see the Sonnet bonus-feature
+ * calls (Improve Copy / a11y), so estimated months read low vs actual months —
+ * which is why the UI tags them "Estimated". ~$0.006/score in micro-USD.
+ */
+export const ESTIMATED_MICRO_USD_PER_SCORE = 6000;
+
+export function estimateScoreCostMicroUsd(scoreCount: number): number {
+  return Math.max(0, Math.round(scoreCount)) * ESTIMATED_MICRO_USD_PER_SCORE;
+}
+
+/** Micro-USD → a display string like "$1.23" (or "$0.0043" when small). */
+export function formatMicroUsd(micro: number): string {
+  const usd = micro / 1_000_000;
+  if (usd === 0) return "$0.00";
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  return `$${usd.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`;
+}


### PR DESCRIPTION
Closes #406.

Internal-only per-client Anthropic **COGS** visibility on the admin Team Detail page (#397), so we can compare what a client costs us to run against what we bill them. **Never client-facing.**

## What

- **`src/lib/token-cost.ts`** — single chokepoint `recordTokenCost({userId, category, model, usage})`: prices tokens per model (Haiku $1/$5, Sonnet $3/$15, incl. cache read/write) and accumulates **micro-USD per user / month / category** in a no-TTL Redis hash `usage:cost:{userId}:{yyyymm}`. Categories: `score`, `overhead`, `copy`, `a11y`, `style-guide`, `annotation`, `chat`, `feedback`. Plus a per-score estimate + money formatter.
- **Capture wired into every runladder Anthropic call**: score + moderation, image transcription + style-guide (compliance/distill/conflicts), Improve Copy, annotation, URL modal-check. Threaded via a `costUserId` opt from each route; fire-and-forget, never blocks scoring.
- **Team Detail API**: per-month `costMicroUsd` + `costByCategory` + `costEstimated`.
- **Team Detail UI**: a **Cost** column (4 equal columns, aligned with the Members table), a hover **category-breakdown popover**, and an **`Estimated`** tag on pre-instrumentation months (`scores × ~$0.006`, score category only).
- **`/hq/architecture`**: mechanism + the unbreakable rule that every new LLM call site must register a categorized cost. **`/hq/features`** row added.

## Estimated vs actual

Past months have no token data → shown as an estimate, tagged `Estimated`. From now on, months show real captured cost with the full per-category breakdown. Actual months may read higher than estimated ones at the same score volume (estimates can't see the Sonnet bonus calls) — expected, and the tag explains it.

## Out of scope (coordinated follow-up PR in `ai-design-assistant`)

The plugin's own direct Anthropic calls (`a11y`, `chat`, `feedback`) and sending `userId` to `/api/plugin/analyze/stream` so plugin *score* cost is attributed. Both repos write to the same shared `usage:cost:*` hash. Web + Skill scores and plugin **Improve Copy** are captured by this PR already.

## Verification

- `tsc --noEmit` clean, `eslint` clean, `next build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)