### PR TITLE
fix(#406): plugin COGS via runladder endpoint + popover reorder + green compliant box

### DIFF
--- a/src/app/admin/clients/[orgId]/page.tsx
+++ b/src/app/admin/clients/[orgId]/page.tsx
@@ -332,12 +332,22 @@ export default function TeamDetailPage() {
                             )}
                             {Object.keys(u.costByCategory).length > 0 && (
                               <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-10 min-w-[190px] border border-[#333] bg-[#1a1a1a] p-2 text-left normal-case tracking-normal shadow-lg">
-                                {Object.entries(u.costByCategory)
-                                  .sort((a, b) => b[1] - a[1])
-                                  .map(([cat, v]) => (
+                                {(() => {
+                                  // Score first (it's the default action), then
+                                  // the rest by cost desc, split by a divider.
+                                  const entries = Object.entries(u.costByCategory);
+                                  const score = entries.filter(([c]) => c === "score");
+                                  const rest = entries
+                                    .filter(([c]) => c !== "score")
+                                    .sort((a, b) => b[1] - a[1]);
+                                  return [...score, ...rest].map(([cat, v], i) => (
                                     <div
                                       key={cat}
-                                      className="flex items-center justify-between gap-4 py-0.5"
+                                      className={`flex items-center justify-between gap-4 py-0.5 ${
+                                        score.length > 0 && i === score.length
+                                          ? "mt-1 border-t border-[#333] pt-1.5"
+                                          : ""
+                                      }`}
                                     >
                                       <span className="text-muted font-sans">
                                         {COST_CATEGORY_LABELS[cat] ?? cat}
@@ -346,7 +356,8 @@ export default function TeamDetailPage() {
                                         {fmtUsd(v)}
                                       </span>
                                     </div>
-                                  ))}
+                                  ));
+                                })()}
                               </div>
                             )}
                           </span>

--- a/src/app/api/plugin/record-cost/route.ts
+++ b/src/app/api/plugin/record-cost/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  recordTokenCost,
+  COST_CATEGORIES,
+  type CostCategory,
+} from "@/lib/token-cost";
+
+/**
+ * POST /api/plugin/record-cost — plugin-side COGS ingest (#406).
+ *
+ * The Figma plugin runs some Anthropic calls directly (Fix Accessibility, chat,
+ * feedback) and lives on a SEPARATE Upstash instance from runladder, so it
+ * can't write cost to runladder's KV directly. It POSTs here instead; we record
+ * into runladder's canonical `usage:cost:*` hash so the admin Team Detail COGS
+ * view sees plugin spend too. Service-token auth, mirroring /api/plugin/analyze.
+ *
+ * Body: { userId, category, model, usage: {input_tokens, output_tokens, ...} }
+ */
+export async function POST(req: NextRequest) {
+  const serviceToken = req.headers.get("x-ladder-service-token") ?? "";
+  const expected = process.env.LADDER_SERVICE_TOKEN;
+  if (!expected) {
+    return NextResponse.json({ error: "Service not configured." }, { status: 503 });
+  }
+  if (!serviceToken || serviceToken !== expected) {
+    return NextResponse.json({ error: "Invalid service token" }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => ({}));
+  const userId = typeof body.userId === "string" ? body.userId : null;
+  const category = body.category as CostCategory;
+  const model = typeof body.model === "string" ? body.model : "";
+  const usage = body.usage;
+
+  if (!userId || !COST_CATEGORIES.includes(category) || !model) {
+    return NextResponse.json(
+      { error: "Body must include userId, a known category, and model." },
+      { status: 400 },
+    );
+  }
+
+  await recordTokenCost({ userId, category, model, usage });
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/StyleGuideFindings.tsx
+++ b/src/components/StyleGuideFindings.tsx
@@ -73,13 +73,29 @@ export function StyleGuideFindings({
       )}
 
       {status === "compliant" && (
-        <div className={CARD}>
-          <p className="text-sm font-bold text-ladder-green">
-            Complies with the {teamLabel}
-          </p>
-          <p className="text-xs text-body leading-relaxed mt-2">
-            No copy issues found.
-          </p>
+        <div className="flex items-start gap-3 border border-ladder-green/40 bg-ladder-green/5 p-6">
+          <svg
+            viewBox="0 0 20 20"
+            className="w-5 h-5 shrink-0 mt-0.5 text-ladder-green"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            aria-hidden="true"
+          >
+            <path
+              d="M4.5 10.5l3.5 3.5L15.5 6.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+          <div>
+            <p className="text-sm font-bold text-ladder-green">
+              Complies with the {teamLabel}
+            </p>
+            <p className="text-xs text-body leading-relaxed mt-1">
+              Never affects your score.
+            </p>
+          </div>
         </div>
       )}
 

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-28
 updatedBy: Sara
-lastPr: 407
+lastPr: 409
 ---
 
 ## Deployment environments
@@ -70,7 +70,7 @@ This diagram shows the future-target architecture (one engine, thin clients). To
 
 **Token-cost accounting (COGS, internal only).** Every Anthropic call in this repo routes its response `usage` through the single chokepoint `recordTokenCost(...)` in `src/lib/token-cost.ts`, which prices tokens per model and accumulates cost per **user, per month, per category** in the Redis hash `usage:cost:{userId}:{yyyymm}` (micro-USD, no TTL). Categories: `score`, `overhead` (moderation + transcription), `copy`, `a11y`, `style-guide`, `annotation`, `chat`, `feedback`. The admin Team Detail page ([#397](https://github.com/drawbackwards/runladder/issues/397)) sums current members' costs to show what a client costs us to run, with a per-category popover ([#406](https://github.com/drawbackwards/runladder/issues/406)). Months before this shipped have no token data, so they're shown as an **estimate** (score count × a per-score rate; score category only) and tagged "Estimated" in the UI. This number is **internal COGS only — never client-facing**, and it is intentionally decoupled from the user-facing "scores this month" count (bonus plugin features cost money but are not scores). Pricing rates live in `RATES` in `token-cost.ts`; update them when Anthropic pricing changes.
 
-> **RULE (unbreakable):** any new code path that makes an Anthropic/LLM call MUST call `recordTokenCost` with an appropriate category, or its spend is invisible to COGS. When you add a new category, add it to `CostCategory`, the category list above, and the popover labels in the Team Detail page. The Figma plugin's own direct Anthropic calls (a11y, chat, feedback in `ai-design-assistant/api/*`) write to the same shared `usage:cost:*` hash — keep both repos in sync.
+> **RULE (unbreakable):** any new code path that makes an Anthropic/LLM call MUST call `recordTokenCost` with an appropriate category, or its spend is invisible to COGS. When you add a new category, add it to `CostCategory`, the category list above, and the popover labels in the Team Detail page. **The Figma plugin runs on a SEPARATE Upstash instance**, so its own direct Anthropic calls (a11y, chat, feedback in `ai-design-assistant/api/*`) can't write to runladder's KV directly — they forward usage to `POST /api/plugin/record-cost` (service-token), which records into runladder's `usage:cost:*`. Rule: the plugin writes shared data ONLY through runladder endpoints, never its own KV.
 
 ## Versioning
 


### PR DESCRIPTION
Follow-up fixes to #406 found during testing.

- **KV split fix (the big one):** the Figma plugin runs on a **separate Upstash instance** from runladder, so plugin-recorded costs (a11y/chat/feedback) were written to the plugin's own KV and never appeared in the admin COGS view. New `POST /api/plugin/record-cost` (service-token) writes to runladder's canonical `usage:cost:*`; the plugin's `_token-cost.js` now forwards to it (plugin PR alongside).
- **Popover reorder:** Score first (default action), divider, then the rest by cost desc.
- **Green compliant box (web):** the style-guide compliant state is now a green box with a left checkmark. Plugin gets the same in a follow-up `ui.html` PR.

Verified: tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)