### PR TITLE
feat(#401): per-surface usage counters + Team Detail surface popover

### DIFF
--- a/src/app/admin/clients/[orgId]/page.tsx
+++ b/src/app/admin/clients/[orgId]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation";
 import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
 import { Skeleton } from "@/components/Skeleton";
+import { USAGE_SURFACES, USAGE_SURFACE_LABEL, type UsageSurface } from "@/lib/surface";
 
 /**
  * Team Detail (#397) — admin drill-in for one Team workspace. Shows the
@@ -34,6 +35,7 @@ type Member = {
 type MonthUsage = {
   month: string;
   scores: number;
+  scoresBySurface: Record<UsageSurface, number>;
   distinctActiveMembers: number;
   costMicroUsd: number;
   costByCategory: Record<string, number>;
@@ -309,19 +311,43 @@ export default function TeamDetailPage() {
                           )}
                         </td>
                         <td className="p-3 text-left tabular-nums whitespace-nowrap">
-                          <span className={over ? "text-ladder-orange" : "text-muted"}>
-                            {u.scores.toLocaleString()}
-                          </span>
-                          <span className="text-[#444]">
-                            {" "}
-                            / {pool.toLocaleString()}
+                          {/* Combined total is the pool number (unchanged). On
+                              hover, break it down by surface (#401) — same
+                              popover affordance as the Cost cell. */}
+                          <span className="group relative inline-flex items-center cursor-help">
+                            <span className={over ? "text-ladder-orange" : "text-muted"}>
+                              {u.scores.toLocaleString()}
+                            </span>
+                            <span className="text-[#444]">
+                              {" "}
+                              / {pool.toLocaleString()}
+                            </span>
+                            {u.scores > 0 && (
+                              <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-10 min-w-[190px] border border-[#333] bg-[#1a1a1a] p-3 text-left normal-case tracking-normal shadow-lg">
+                                {USAGE_SURFACES.filter((s) => (u.scoresBySurface[s] ?? 0) > 0)
+                                  .sort((a, b) => (u.scoresBySurface[b] ?? 0) - (u.scoresBySurface[a] ?? 0))
+                                  .map((s) => (
+                                    <div
+                                      key={s}
+                                      className="flex items-center justify-between gap-4 py-1"
+                                    >
+                                      <span className="text-muted font-sans">
+                                        {USAGE_SURFACE_LABEL[s]}
+                                      </span>
+                                      <span className="text-foreground tabular-nums">
+                                        {(u.scoresBySurface[s] ?? 0).toLocaleString()}
+                                      </span>
+                                    </div>
+                                  ))}
+                              </div>
+                            )}
                           </span>
                         </td>
                         <td className="p-3 text-left tabular-nums text-muted">
                           {u.distinctActiveMembers.toLocaleString()}
                         </td>
                         <td className="p-3 text-left tabular-nums">
-                          <span className="group relative inline-flex items-center gap-2">
+                          <span className="group relative inline-flex items-center gap-2 cursor-help">
                             <span className="text-foreground">
                               {fmtUsd(u.costMicroUsd)}
                             </span>
@@ -331,7 +357,7 @@ export default function TeamDetailPage() {
                               </span>
                             )}
                             {Object.keys(u.costByCategory).length > 0 && (
-                              <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-10 min-w-[190px] border border-[#333] bg-[#1a1a1a] p-2 text-left normal-case tracking-normal shadow-lg">
+                              <div className="hidden group-hover:block absolute left-0 top-full mt-1 z-10 min-w-[190px] border border-[#333] bg-[#1a1a1a] p-3 text-left normal-case tracking-normal shadow-lg">
                                 {(() => {
                                   // Score first (it's the default action), then
                                   // the rest by cost desc, split by a divider.
@@ -343,9 +369,9 @@ export default function TeamDetailPage() {
                                   return [...score, ...rest].map(([cat, v], i) => (
                                     <div
                                       key={cat}
-                                      className={`flex items-center justify-between gap-4 py-0.5 ${
+                                      className={`flex items-center justify-between gap-4 py-1 ${
                                         score.length > 0 && i === score.length
-                                          ? "mt-1 border-t border-[#333] pt-1.5"
+                                          ? "mt-1 border-t border-[#333] pt-2"
                                           : ""
                                       }`}
                                     >

--- a/src/app/api/admin/clients/[orgId]/route.ts
+++ b/src/app/api/admin/clients/[orgId]/route.ts
@@ -5,6 +5,7 @@ import { isInternalOrg, orgMeta, orgStatus, provisioningUserId } from "@/lib/org
 import { redis, currentYearMonth } from "@/lib/redis";
 import { TEAM_MONTHLY_POOL } from "@/lib/plans";
 import { getMonthlyCost, estimateScoreCostMicroUsd } from "@/lib/token-cost";
+import { surfaceFromSource, USAGE_SURFACES, type UsageSurface } from "@/lib/surface";
 
 /**
  * Org lifecycle management (#190) + Team Detail read (#397).
@@ -26,7 +27,15 @@ function unauthorized() {
 }
 
 /** One persisted score entry from a member's history zset. */
-type RawScore = { score?: number; timestamp?: number };
+type RawScore = { score?: number; timestamp?: number; source?: string };
+
+/** Empty per-surface tally (#401), all canonical surfaces at zero. */
+function emptyBySurface(): Record<UsageSurface, number> {
+  return USAGE_SURFACES.reduce(
+    (acc, s) => ({ ...acc, [s]: 0 }),
+    {} as Record<UsageSurface, number>,
+  );
+}
 
 /** UTC "YYYY-MM" bucket for a score timestamp — same boundary as the counters. */
 function yearMonthOf(ts: number): string {
@@ -47,6 +56,11 @@ type MonthUsage = {
   month: string;
   /** Pooled scoring calls across the workspace that month (all surfaces). */
   scores: number;
+  /**
+   * Surface split of `scores` (#401) — web / figma / skill counts. Reconstructed
+   * from each entry's persisted `source`, so it always sums to `scores`.
+   */
+  scoresBySurface: Record<UsageSurface, number>;
   /** Members with at least one scoring call that month. */
   distinctActiveMembers: number;
   /** Internal COGS: Anthropic token cost this month, in micro-USD (#406). */
@@ -122,7 +136,10 @@ export async function GET(
   );
 
   // Roster (member row) + per-month rollup, in one pass over the histories.
-  const monthTotals = new Map<string, { scores: number; active: Set<string> }>();
+  const monthTotals = new Map<
+    string,
+    { scores: number; active: Set<string>; bySurface: Record<UsageSurface, number> }
+  >();
   const roster: DetailMember[] = members.map((m, i) => {
     const userId = m.publicUserData!.userId!;
     const { entries } = histories[i];
@@ -131,9 +148,11 @@ export async function GET(
     for (const e of entries) {
       if (typeof e.timestamp !== "number") continue;
       const ym = yearMonthOf(e.timestamp);
-      const bucket = monthTotals.get(ym) ?? { scores: 0, active: new Set() };
+      const bucket =
+        monthTotals.get(ym) ?? { scores: 0, active: new Set(), bySurface: emptyBySurface() };
       bucket.scores += 1;
       bucket.active.add(userId);
+      bucket.bySurface[surfaceFromSource(e.source)] += 1;
       monthTotals.set(ym, bucket);
       if (ym === thisMonth) scoresThisMonth += 1;
     }
@@ -152,7 +171,7 @@ export async function GET(
 
   // Always surface the current month (even at zero) so it anchors the top.
   if (!monthTotals.has(thisMonth)) {
-    monthTotals.set(thisMonth, { scores: 0, active: new Set() });
+    monthTotals.set(thisMonth, { scores: 0, active: new Set(), bySurface: emptyBySurface() });
   }
 
   const months = Array.from(monthTotals.keys());
@@ -188,6 +207,7 @@ export async function GET(
         return {
           month,
           scores: b.scores,
+          scoresBySurface: b.bySurface,
           distinctActiveMembers: b.active.size,
           costMicroUsd: actual.total,
           costByCategory: actual.byCategory,
@@ -198,6 +218,7 @@ export async function GET(
       return {
         month,
         scores: b.scores,
+        scoresBySurface: b.bySurface,
         distinctActiveMembers: b.active.size,
         costMicroUsd: estimate,
         costByCategory: estimate > 0 ? { score: estimate } : {},

--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-29
 updatedBy: Sara
-lastPr: 410
+lastPr: 411
 ---
 
 ## Deployment environments
@@ -67,6 +67,8 @@ This diagram shows the future-target architecture (one engine, thin clients). To
 **Billing.** Stripe. Subscriptions live in `runladder`. Pulse and the legacy Ladder engagement (Lumin Digital) bill outside of Stripe via Drawbackwards agency contracts.
 
 **Data.** Upstash Redis in `runladder` for scoring history and tier counters. Pulse uses Prisma + Postgres on Fly.io in `ladder-beta`. Postgres in `runladder` is planned but not scheduled.
+
+**Per-surface usage attribution ([#401](https://github.com/drawbackwards/runladder/issues/401)).** The combined monthly pool meter (`user:{id}:scans:{yyyymm}`, the 25K-cap counter) is unchanged. `persistScoreEntry` additionally increments a sibling hash `user:{id}:scans:{yyyymm}:by-surface` (fields: `web`/`figma`/`skill`, same 40-day TTL) via `surfaceFromSource(source)` — the cheap no-scan rollup primitive. The admin Team Detail surface popover reconstructs the split from each entry's durable `source` (so it has full history and always sums to the month's total); the counter starts clean at first real usage and is not UI-consumed yet.
 
 **Token-cost accounting (COGS, internal only).** Every Anthropic call in this repo routes its response `usage` through the single chokepoint `recordTokenCost(...)` in `src/lib/token-cost.ts`, which prices tokens per model and accumulates cost per **user, per month, per category** in the Redis hash `usage:cost:{userId}:{yyyymm}` (micro-USD, no TTL). Categories: `score`, `overhead` (moderation + transcription), `copy`, `a11y`, `style-guide`, `annotation`, `chat`, `feedback`. The admin Team Detail page ([#397](https://github.com/drawbackwards/runladder/issues/397)) sums current members' costs to show what a client costs us to run, with a per-category popover ([#406](https://github.com/drawbackwards/runladder/issues/406)). Months before this shipped have no token data, so they're shown as an **estimate** (score count × a per-score rate; score category only) and tagged "Estimated" in the UI. This number is **internal COGS only — never client-facing**, and it is intentionally decoupled from the user-facing "scores this month" count (bonus plugin features cost money but are not scores). Pricing rates live in `RATES` in `token-cost.ts`; update them when Anthropic pricing changes.
 

--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -1,8 +1,8 @@
 ---
 title: Feature Inventory
-updatedAt: 2026-07-28
+updatedAt: 2026-07-29
 updatedBy: Sara
-lastPr: 407
+lastPr: 411
 ---
 
 ## How to read this page
@@ -153,6 +153,7 @@ Gated by `ADMIN_EMAILS` env var. Defaults: Ward, Michael, Jordan.
 | Pooled monthly usage column on the admin Clients list | Admin | Live (#297) | `src/app/api/admin/clients/route.ts` (`getTeamMonthlyTotal`), `src/app/admin/(tabbed)/clients/page.tsx` |
 | Team Detail: per-org member roster + usage-by-month (reconstructed from durable score history, `Overage` tag at ≥ pool); clients rows link through | Admin | Live (#397) | `src/app/admin/clients/[orgId]/page.tsx`, `src/app/api/admin/clients/[orgId]/route.ts` (GET) |
 | Team Detail token-cost (COGS) column: per-month Anthropic spend with per-category popover; `Estimated` tag for pre-instrumentation months. Internal only, never client-facing. All LLM calls route through `recordTokenCost` | Admin | Live (#406) | `src/lib/token-cost.ts`, `src/app/admin/clients/[orgId]/`; capture wired in `scoring.ts`, `style-guide.ts`, `copy-audit.ts`, `annotation-analysis.ts`, `screenshot` |
+| Team Detail per-surface usage: `Scores used` cell has a hover popover splitting the monthly total by surface (Web / Figma / Claude Skill), reconstructed from each score's `source`. A sibling `scans:{yyyymm}:by-surface` counter is written at persist time as the no-scan rollup primitive; the combined 25K pool meter is unchanged | Admin | Live (#401) | `src/app/admin/clients/[orgId]/`, `src/lib/surface.ts` (`surfaceFromSource`), `src/lib/scores.ts`, `src/lib/redis.ts` (`surfaceScansKey`) |
 | Internal-org protection (Drawbackwards never suspended/deleted) | Admin | Live (v0.5.5) | `src/lib/orgs.ts` `isInternalOrg` |
 | Admin-only "Admin" entry in Account menu (single row; lands on Clients tab) | Admin | Live | `src/components/UserMenu.tsx`, `src/app/api/admin/status/route.ts` |
 | Unified Admin shell with tabs (Clients / Evaluations / Feedback / Comps / Beta Codes) | Admin | Live (#231) | `src/app/admin/layout.tsx`, `src/components/Tabs.tsx` |

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -47,6 +47,23 @@ export function monthlyScansKey(userId: string, yyyymm: string): string {
   return `user:${userId}:scans:${yyyymm}`;
 }
 
+/**
+ * Per-user, per-month SURFACE breakdown counter (#401). A Redis HASH whose
+ * fields are canonical surfaces ("web" | "figma" | "skill") and whose values
+ * are that surface's scan count for the month. Sibling to `monthlyScansKey`
+ * with the same 40-day TTL; the combined pool meter stays `monthlyScansKey`
+ * and is never touched by this key, so the 25K cap math is unaffected.
+ *
+ * Written at persist time as the cheap no-scan rollup primitive. The admin
+ * Team Detail view does NOT read it yet — it reconstructs full-history surface
+ * splits from the durable score zset (which retains all months). This counter
+ * exists for future no-scan consumers (dashboard, a usage API) and starts
+ * clean at first real usage, so there is no backfill for historical months.
+ */
+export function surfaceScansKey(userId: string, yyyymm: string): string {
+  return `user:${userId}:scans:${yyyymm}:by-surface`;
+}
+
 /** Current "YYYY-MM" string in UTC. Single helper so every caller uses the same boundary. */
 export function currentYearMonth(date: Date = new Date()): string {
   const y = date.getUTCFullYear();

--- a/src/lib/scores.ts
+++ b/src/lib/scores.ts
@@ -2,8 +2,10 @@ import {
   redis,
   lifetimeScansKey,
   monthlyScansKey,
+  surfaceScansKey,
   currentYearMonth,
 } from "@/lib/redis";
+import { surfaceFromSource } from "@/lib/surface";
 import { maybeAlertCapCrossed, ANY_TIER_CAP_THRESHOLD } from "@/lib/usage";
 
 /**
@@ -146,6 +148,13 @@ export async function persistScoreEntry(
   const monthlyKey = monthlyScansKey(userId, yyyymm);
   const newMonthlyCount = await redis.incr(monthlyKey);
 
+  // Per-surface breakdown counter (#401) — a sibling HASH to the pool meter,
+  // NOT a replacement. The combined `monthlyKey` above is still the single
+  // source for the 25K cap; this only records which surface each score came
+  // from so a rollup can answer "web vs Figma vs Skill" without scanning the
+  // raw history. Same 40-day TTL so it lives exactly as long as the meter.
+  const surfaceKey = surfaceScansKey(userId, yyyymm);
+
   const ops: Promise<unknown>[] = [
     redis.zadd(SCORE_HISTORY_KEY(userId), {
       score: entry.timestamp,
@@ -154,6 +163,8 @@ export async function persistScoreEntry(
     redis.incr(lifetimeScansKey(userId)),
     // Forty-day TTL: month length (max 31) + 9-day buffer for late reads.
     redis.expire(monthlyKey, 60 * 60 * 24 * 40),
+    redis.hincrby(surfaceKey, surfaceFromSource(entry.source), 1),
+    redis.expire(surfaceKey, 60 * 60 * 24 * 40),
     redis.set(LASTSCORE_KEY(userId, screenKey), {
       score: entry.score,
       ts: entry.timestamp,

--- a/src/lib/surface.ts
+++ b/src/lib/surface.ts
@@ -22,3 +22,31 @@ export function surfaceParts(label: string): {
     surface: s.charAt(0).toUpperCase() + s.slice(1),
   };
 }
+
+/**
+ * Canonical surfaces for usage attribution (#401). The ticket calls for three:
+ * web, Figma, and the Claude skill. Pulse is a separate SOW/product and is not
+ * pooled here, so it is deliberately not a usage surface.
+ */
+export const USAGE_SURFACES = ["web", "figma", "skill"] as const;
+export type UsageSurface = (typeof USAGE_SURFACES)[number];
+
+/** Human labels for the usage breakdown UI. */
+export const USAGE_SURFACE_LABEL: Record<UsageSurface, string> = {
+  web: "Web",
+  figma: "Figma",
+  skill: "Claude Skill",
+};
+
+/**
+ * Map a persisted score `source` to a canonical usage surface (#401).
+ * `source` is set at persist time: "upload"/"url"/"org" (web-originated),
+ * "figma", "claude-skill". Anything unrecognized falls back to web — the same
+ * default `surfaceParts` uses for an untagged label.
+ */
+export function surfaceFromSource(source: string | null | undefined): UsageSurface {
+  const s = (source || "").toLowerCase().trim();
+  if (s === "figma") return "figma";
+  if (s === "claude-skill" || s === "skill" || s === "claude") return "skill";
+  return "web";
+}


### PR DESCRIPTION
Closes #401.

Every scored entry already stores its origin `source`, but the monthly usage counter was keyed only by user+month — so "how many scores came from Figma vs the Claude skill" required scanning raw history. This adds per-surface visibility **without touching the combined 25K pool meter**.

## What changed
- **Counter (AC #1):** `persistScoreEntry` now also increments a sibling hash `user:{id}:scans:{yyyymm}:by-surface` (fields `web`/`figma`/`skill`, same 40-day TTL) via `surfaceFromSource()`. The combined `:scans:` pool meter is untouched, so the 25K cap math is unaffected (**AC #3**).
- **Rollup (AC #2):** the admin Team Detail API reconstructs the per-month surface split from each entry's durable `source` (full history, always sums to the month total). The "Scores used" cell gains a hover popover — same affordance as the Cost popover — breaking the total into Web / Figma / Claude Skill.
- Both popovers got roomier padding and a `cursor-help` affordance.
- `surface.ts`: `surfaceFromSource` + `USAGE_SURFACES`/labels (Pulse deliberately excluded — separate SOW). `redis.ts`: `surfaceScansKey`.

## Design note
The counter is the no-scan rollup primitive but is **not UI-consumed yet** — the admin view reconstructs from the zset it already scans (so it gets full history). The counter starts clean at first real usage; since current data is all test scans, there is no backfill.

## Verification
`tsc`, `eslint`, and `next build` all clean. Popover verified visually against real multi-surface test scans (Figma 17 / Web 9 / Claude Skill 3 = 29).

## /hq lockstep
- `features.mdx`: new #401 row.
- `architecture.mdx`: per-surface attribution note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)