### PR TITLE
refine: rename COGS popover category to "Accessibility"

### DIFF
--- a/src/app/admin/clients/[orgId]/page.tsx
+++ b/src/app/admin/clients/[orgId]/page.tsx
@@ -47,7 +47,7 @@ const COST_CATEGORY_LABELS: Record<string, string> = {
   score: "Score",
   overhead: "Scoring overhead",
   copy: "Improve Copy",
-  a11y: "Fix Accessibility",
+  a11y: "Accessibility",
   "style-guide": "Style Guide",
   annotation: "Annotation",
   chat: "Chat",


### PR DESCRIPTION
One-line admin label rename in the Team Detail cost popover: `a11y` category now reads "Accessibility" instead of "Fix Accessibility" (pairs with the plugin's "Check Accessibility" button rename). Internal admin only.

/hq: no doc consequence (see commit body).

🤖 Generated with [Claude Code](https://claude.com/claude-code)