### PR TITLE
release(#415): CURRENT_PLUGIN_VERSION 1.13.0 + Figma release-note convention

### DIFF
--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-30
 updatedBy: Sara
-lastPr: 414
+lastPr: 415
 ---
 
 ## Deployment environments
@@ -100,7 +100,9 @@ These constants are what runtime code reads. **`package.json`'s `version` field 
 **Plugin release sequence — steps 2 and 3 MUST be coordinated, or the update banner misfires:**
 
 1. In the plugin PR: bump `PLUGIN_VERSION` in `plugin/ui.html` and add a changelog entry. (Merging this alone is safe — it changes nothing live until published *and* the server value is bumped.)
-2. Publish the new build to the Figma marketplace.
+2. Publish the new build to the Figma marketplace. **The release note MUST lead with our semver, in this exact format:** `vX.Y.Z — <one-line summary>` (e.g. `v1.13.0 — Redesigned result screen, ask-a-question follow-up chat, Check Accessibility.`). Figma assigns its own sequential "Version N" publish counter that we can't set or read at runtime, so the semver in the note is the ONLY thing that maps a marketplace entry to our version + changelog. Always use this format; never publish a blank or ad-hoc note.
 3. Set runladder's `CURRENT_PLUGIN_VERSION` to the same value and deploy runladder — **at the same time as step 2**.
+
+**Anchor:** Figma marketplace "Version 15" (published 2026-07-30) is our `v1.13.0` — the first publish where the marketplace note and our semver are reconciled. Earlier Figma versions (1–14) predate this convention and have no reliable semver mapping.
 
 If the server value is bumped before the marketplace has the build, installed users get nagged toward a build they can't download. If the marketplace is ahead of the server, new installs get a backwards "downgrade" nag. So 2 and 3 travel together.

--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -17,4 +17,4 @@
  * get a backwards "downgrade" nag). See /hq/architecture → Versioning for the
  * full plugin release sequence.
  */
-export const CURRENT_PLUGIN_VERSION = "1.11.11";
+export const CURRENT_PLUGIN_VERSION = "1.13.0";


### PR DESCRIPTION
Coordinated with the marketplace publish of the 1.13.0 plugin build.

- `plugin-version.ts`: `CURRENT_PLUGIN_VERSION` 1.11.11 → **1.13.0** so the update banner recognizes 1.13.0 installs as current (and nags older builds correctly).
- `/hq` architecture: marketplace release notes MUST lead with `vX.Y.Z — summary` (Figma's sequential 'Version N' can't map to our semver otherwise), plus the **Figma v15 = v1.13.0** anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)