### PR TITLE
fix(#416): frame-ID screen-match + surface tag on score detail

### DIFF
--- a/src/app/api/plugin/persist-score/route.ts
+++ b/src/app/api/plugin/persist-score/route.ts
@@ -162,6 +162,9 @@ export async function POST(req: NextRequest) {
       score: score.score,
       label: score.label,
       screenName: score.screenName,
+      // Stable Figma node ID → distinguishes same-named frames in the
+      // screen-match key so distinct frames don't produce a false uplift (#416).
+      frameId: score.frameId,
       summary: score.summary,
       next: score.next,
       findings: score.findings,

--- a/src/app/dashboard/scores/[id]/page.tsx
+++ b/src/app/dashboard/scores/[id]/page.tsx
@@ -6,6 +6,7 @@ import { useParams } from "next/navigation";
 import Link from "next/link";
 import { getScoreColor, getLevelColor, getLevel, getNextLevel, getGapToNext, getRungLevel, computePotentialScore } from "@/lib/ladder";
 import { privateScopeLabel, isTeamScope } from "@/lib/score-scope";
+import { surfaceParts } from "@/lib/surface";
 import type { RungName, RungScores } from "@/lib/ladder";
 import { RungBreakdown } from "@/components/RungBreakdown";
 import { ScoreBar } from "@/components/ScoreBar";
@@ -225,7 +226,21 @@ export default function ScoreDetailPage() {
           {/* Right: score panel */}
           <div className="border border-[#333] bg-[#1e1e1e] p-8 flex flex-col">
             <span className="text-[10px] text-muted uppercase tracking-widest mb-2">Screen Score</span>
-            <p className="text-sm text-foreground font-sans mb-6">{data.screenName}</p>
+            {/* Strip the "(Figma)" / "(Skill)" suffix and render the surface as a
+                tag, matching the dashboard history chip (#299) instead of inline text. */}
+            {(() => {
+              const { name, surface } = surfaceParts(data.screenName);
+              return (
+                <div className="flex items-center gap-2 mb-6">
+                  <p className="text-sm text-foreground font-sans">{name}</p>
+                  {surface && (
+                    <span className="text-[8px] text-[#888] uppercase tracking-widest border border-[#3a3a3a] px-1.5 py-0.5 flex-shrink-0">
+                      {surface}
+                    </span>
+                  )}
+                </div>
+              );
+            })()}
 
             <div className="flex-1 flex flex-col items-start justify-center">
               <span className="font-mono font-bold text-[4rem] leading-none tabular-nums text-foreground">

--- a/src/lib/scores.ts
+++ b/src/lib/scores.ts
@@ -49,6 +49,12 @@ export type ScoreEntryInput = {
    */
   styleGuide?: unknown;
   source: string;
+  /**
+   * Stable frame/node ID from the origin surface (Figma), when available. Used
+   * ONLY for the screen-match key so same-named-but-distinct frames don't
+   * collide (#416). Never rendered. Absent for web/Skill.
+   */
+  frameId?: string | null;
   thumbnail?: string;
   isPublic?: boolean;
   timestamp: number;
@@ -88,10 +94,25 @@ const LEADERBOARD_SCANS = "leaderboard:global:scans";
  * "/login" track separately even if their normalized names collide —
  * different journeys, different deltas.
  */
-export function screenKeyFor(source: string, screenName: string | undefined): string {
+export function screenKeyFor(
+  source: string,
+  screenName: string | undefined,
+  frameId?: string | null,
+): string {
   const src = (source || "unknown").toLowerCase().trim();
-  // Strip the "(Figma)" / "(Skill)" surface suffix if a caller already added one,
-  // since the source prefix already encodes that.
+  // When a stable frame/node ID is available (Figma), key on it instead of the
+  // name — designers often leave multiple distinct frames with the SAME name
+  // (e.g. two states of one screen), and a name-only key would treat them as
+  // re-scores of one screen and invent a bogus uplift (#416). The frame ID is
+  // stable across edits, so re-scoring the same (edited) frame still compares
+  // to its own prior score.
+  const fid = (frameId || "").trim();
+  if (fid) {
+    return `${src}::id:${fid.replace(/[^a-zA-Z0-9:_-]+/g, "-").slice(0, 120)}`;
+  }
+  // No frame ID (web URLs, Skill, older plugin builds): fall back to the
+  // normalized name. Strip the "(Figma)" / "(Skill)" surface suffix if a caller
+  // already added one, since the source prefix already encodes that.
   const cleaned = (screenName || "untitled")
     .replace(/\s*\((figma|skill|web|claude|pulse)\)\s*$/i, "")
     .toLowerCase()
@@ -111,7 +132,7 @@ export async function persistScoreEntry(
   userId: string,
   input: ScoreEntryInput,
 ): Promise<StoredScoreEntry> {
-  const screenKey = screenKeyFor(input.source, input.screenName);
+  const screenKey = screenKeyFor(input.source, input.screenName, input.frameId);
 
   // Look up the previous score for the same screen (if any) before writing.
   const prev = await redis.get<{ score: number; ts: number; id: string }>(


### PR DESCRIPTION
**Closes #416 (runladder side).**

Two same-named Figma frames were collapsing into one screen, producing a bogus uplift, because `screenKeyFor` was name-only.

- `scores.ts`: `screenKeyFor(source, name, frameId?)` keys on the stable frame ID when present (Figma); name fallback for web/Skill (unchanged). `frameId` added to `ScoreEntryInput`.
- `persist-score`: threads `score.frameId` in.
- **Score detail:** `(Figma)` inline text → surface **tag chip** (matches dashboard history #299).

Verified `screenKeyFor` with unit cases (same-name/diff-id → different; same-id → same; no-id → name). Plugin side (sending `frameId`) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)