### PR TITLE
docs(#420): document plugin backend deploy mechanism in /hq

### DIFF
--- a/src/content/hq/architecture.mdx
+++ b/src/content/hq/architecture.mdx
@@ -2,7 +2,7 @@
 title: Architecture
 updatedAt: 2026-07-30
 updatedBy: Sara
-lastPr: 418
+lastPr: 420
 ---
 
 ## Deployment environments
@@ -19,6 +19,8 @@ lastPr: 418
 `runladder.com` and `www.runladder.com` are the public marketing and content domains — same Vercel project, same build, routed as additional domains on the Production environment. Canonical content URLs (OG tags, share links, sitemaps) always reference `runladder.com`. Auth entry point is `app.runladder.com/login`.
 
 Branch protection on `main` requires a passing `build` CI check and disables force-push. Self-merge is allowed.
+
+**ai-design-assistant backend deploy (Figma plugin API).** This repo does NOT auto-deploy from git — Vercel's git-author protection blocks its squash-merge commits (authored as a GitHub noreply email → BLOCKED state, never promoted), so backend changes silently never went live ([#419](https://github.com/drawbackwards/runladder/issues/419)). Production ships via the `deploy-prod` **GitHub Action** using a `VERCEL_TOKEN` (token deploys bypass the git-author gate); native git auto-deploy is turned off in `vercel.json`. So: merge to `main` → the Action deploys prod. Manual `vercel --prod` from the repo also works as a fallback. (The Figma plugin *bundle* itself is a separate marketplace publish — see [Versioning](#versioning).)
 
 ## One scoring framework, three codebases (today)
 


### PR DESCRIPTION
Post-#419 doc: the ai-design-assistant backend deploys via the `deploy-prod` GitHub Action + token (native git deploy blocked). Documented in `/hq` architecture → Deployment so the team knows backend changes ship via the Action, not a git merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)