### PR TITLE
fix: chunk score-history reads past Upstash's 10MB request ceiling (prod dashboard 500)

### DIFF
--- a/src/app/api/admin/clients/[orgId]/route.ts
+++ b/src/app/api/admin/clients/[orgId]/route.ts
@@ -4,7 +4,7 @@ import { getAdminEmail } from "@/lib/admin";
 import { isInternalOrg, orgMeta, orgStatus, provisioningUserId } from "@/lib/orgs";
 import { purgeOrgContent } from "@/lib/data-lifecycle";
 import { isValidIndustry } from "@/lib/industry-registry";
-import { redis, currentYearMonth } from "@/lib/redis";
+import { redis, currentYearMonth, zrangeAllChunked } from "@/lib/redis";
 import { TEAM_MONTHLY_POOL } from "@/lib/plans";
 import { getMonthlyCost, estimateScoreCostMicroUsd } from "@/lib/token-cost";
 import { surfaceFromSource, USAGE_SURFACES, type UsageSurface } from "@/lib/surface";
@@ -128,10 +128,8 @@ export async function GET(
       const userId = m.publicUserData!.userId!;
       let entries: RawScore[] = [];
       try {
-        const raw = await redis.zrange<unknown[]>(
+        const raw = await zrangeAllChunked<unknown>(
           `user:${userId}:scores`,
-          0,
-          -1,
         );
         entries = raw.map((e) =>
           typeof e === "string" ? (JSON.parse(e) as RawScore) : (e as RawScore),

--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { redis, lifetimeScansKey } from "@/lib/redis";
+import { redis, lifetimeScansKey, zrangeAllChunked } from "@/lib/redis";
 import { FREE_LIFETIME_LIMIT, isPaidTier } from "@/lib/plans";
 import { getUserSubscription, grantComp } from "@/lib/tier";
 import { getUserStats } from "@/lib/scores";
@@ -81,7 +81,7 @@ export async function GET() {
   }
 
   const [scores, used, sub, stats] = await Promise.all([
-    redis.zrange(`user:${userId}:scores`, 0, -1, { rev: true }),
+    zrangeAllChunked(`user:${userId}:scores`, { rev: true }),
     redis.get<number>(lifetimeScansKey(userId)),
     getUserSubscription(userId),
     getUserStats(userId),

--- a/src/app/api/dashboard/scores/[id]/route.ts
+++ b/src/app/api/dashboard/scores/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
+import { redis, zrangeAllChunked } from "@/lib/redis";
 
 export async function GET(
   req: Request,
@@ -50,9 +50,7 @@ export async function GET(
     ownerId = memberParam;
   }
 
-  const scores = await redis.zrange(`user:${ownerId}:scores`, 0, -1, {
-    rev: true,
-  });
+  const scores = await zrangeAllChunked(`user:${ownerId}:scores`, { rev: true });
 
   for (const entry of scores as string[]) {
     try {

--- a/src/app/api/dashboard/scores/route.ts
+++ b/src/app/api/dashboard/scores/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
+import { redis, zrangeAllChunked } from "@/lib/redis";
 
 /**
  * Soft-delete a score the signed-in user owns.
@@ -35,7 +35,7 @@ export async function DELETE(req: NextRequest) {
   }
 
   const key = `user:${userId}:scores`;
-  const entries = (await redis.zrange(key, 0, -1)) as Array<string | object>;
+  const entries = (await zrangeAllChunked(key)) as Array<string | object>;
 
   for (const entry of entries) {
     const str = typeof entry === "string" ? entry : JSON.stringify(entry);

--- a/src/app/api/dashboard/team/members/[userId]/route.ts
+++ b/src/app/api/dashboard/team/members/[userId]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
+import { zrangeAllChunked } from "@/lib/redis";
 import { getUserStats } from "@/lib/scores";
 
 /**
@@ -163,7 +163,7 @@ export async function GET(
 
   const [stats, raw] = await Promise.all([
     getUserStats(targetUserId),
-    redis.zrange(`user:${targetUserId}:scores`, 0, -1, { rev: true }),
+    zrangeAllChunked(`user:${targetUserId}:scores`, { rev: true }),
   ]);
 
   const scores: RawScore[] = (raw as Array<string | RawScore>)

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { redis } from "@/lib/redis";
+import { zrangeByScoreAllChunked } from "@/lib/redis";
 import { getUserStats, type UserStats } from "@/lib/scores";
 import { RUNG_NAMES, type RungName } from "@/lib/ladder";
 import { listArchivedMembers } from "@/lib/team-archives";
@@ -74,11 +74,10 @@ async function readRecentScores(
   userId: string,
   sinceTs: number,
 ): Promise<RawScore[]> {
-  const raw = await redis.zrange(
+  const raw = await zrangeByScoreAllChunked(
     `user:${userId}:scores`,
     sinceTs,
     "+inf",
-    { byScore: true },
   );
   return (raw as Array<string | RawScore>)
     .map((entry) => {

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -536,20 +536,34 @@ function DesignSystemCard() {
     <div className={CARD}>
       <p className={LABEL}>Design System</p>
       <div className="mt-3 grid gap-8 md:grid-cols-2">
-        {/* Left — what it does */}
+        {/* Left — what it does + exactly what gets checked */}
         <div>
           <p className="text-sm text-muted font-sans leading-relaxed">
-            When your team scores a frame in the Figma plugin, Ladder diffs it
-            against the design-system libraries enabled in that file and flags
-            drift: instances detached from the library, components rebuilt by
-            hand, colors that don&apos;t come from the library (raw values,
-            local styles, local variables), and text that isn&apos;t using a
-            library text style.
+            When your team scores a frame in the Figma plugin, Ladder checks
+            it against the design-system libraries enabled in that file. What
+            we check:
           </p>
+          <ul className="mt-4 space-y-3">
+            {[
+              ["Color", "Fills and strokes must come from a library token or style. Raw values, local styles, and local variables are flagged."],
+              ["Typography", "Text must use a library text style."],
+              ["Detached instances", "Components that were detached from the library."],
+              ["Rebuilt components", "Local copies of components that should come from the library."],
+            ].map(([name, desc]) => (
+              <li key={name}>
+                <p className="text-sm font-sans font-semibold text-foreground">
+                  {name}
+                </p>
+                <p className="text-sm text-muted font-sans leading-relaxed mt-0.5">
+                  {desc}
+                </p>
+              </li>
+            ))}
+          </ul>
           <p className="text-sm text-muted font-sans leading-relaxed mt-3">
             Findings appear in the plugin&apos;s Design System tab and on the
-            score&apos;s dashboard page. Advisory only — drift never affects
-            the Ladder score.
+            score&apos;s dashboard page. Design system issues never affect the
+            Ladder score.
           </p>
         </div>
         {/* Right — how it's configured (it isn't, yet) */}

--- a/src/components/DesignSystemCompliance.tsx
+++ b/src/components/DesignSystemCompliance.tsx
@@ -103,11 +103,12 @@ export function DesignSystemCompliance({
           </svg>
           <div>
             <p className="text-sm font-bold text-ladder-green">
-              No drift from {libLabel}
+              Matches {libLabel}
             </p>
             <p className="text-xs text-body leading-relaxed mt-1">
               Every layer we checked uses the library&apos;s components,
-              tokens, and styles. Never affects your score.
+              tokens, and styles. Design system issues do not affect your
+              score.
             </p>
           </div>
         </div>

--- a/src/lib/data-lifecycle.ts
+++ b/src/lib/data-lifecycle.ts
@@ -1,6 +1,6 @@
 import { clerkClient } from "@clerk/nextjs/server";
 import { del as blobDel } from "@vercel/blob";
-import { redis } from "@/lib/redis";
+import { redis, zrangeAllChunked } from "@/lib/redis";
 import { listArchivedMembers } from "@/lib/team-archives";
 import { isProvisioningUser, orgMeta } from "@/lib/orgs";
 import {
@@ -62,10 +62,8 @@ async function delKeys(keys: string[]): Promise<number> {
 
 /** Read a user's full score history as parsed entries. */
 async function readScoreHistory(userId: string): Promise<StoredScoreEntry[]> {
-  const raw = await redis.zrange<(StoredScoreEntry | string)[]>(
+  const raw = await zrangeAllChunked<StoredScoreEntry | string>(
     `user:${userId}:scores`,
-    0,
-    -1,
   );
   const entries: StoredScoreEntry[] = [];
   for (const item of raw ?? []) {

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -72,3 +72,52 @@ export function currentYearMonth(date: Date = new Date()): string {
   const m = String(date.getUTCMonth() + 1).padStart(2, "0");
   return `${y}-${m}`;
 }
+
+/**
+ * Read an ENTIRE sorted set in fixed-size slices instead of one ZRANGE 0 -1.
+ *
+ * Upstash rejects any single request whose payload exceeds 10MB. Score-history
+ * entries carry base64 thumbnails, so one active user's full history crossed
+ * that ceiling on 2026-08-05 and every full-history read 500'd (the dashboard
+ * "all my scores are gone" incident). Chunks of 10 keep each response far
+ * below the limit regardless of history length. Slices are fetched
+ * sequentially on purpose — parallel reads could be coalesced back into one
+ * oversized pipeline response by SDK auto-pipelining.
+ *
+ * Element order matches the equivalent single-shot call ({ rev: true } for
+ * newest-first). The real fix is moving thumbnails out of the entries; this
+ * makes every reader safe in the meantime.
+ */
+const ZRANGE_CHUNK = 10;
+
+export async function zrangeAllChunked<T = unknown>(
+  key: string,
+  opts?: { rev?: boolean },
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let start = 0; ; start += ZRANGE_CHUNK) {
+    const slice = (await (opts?.rev
+      ? redis.zrange(key, start, start + ZRANGE_CHUNK - 1, { rev: true })
+      : redis.zrange(key, start, start + ZRANGE_CHUNK - 1))) as T[];
+    out.push(...slice);
+    if (slice.length < ZRANGE_CHUNK) return out;
+  }
+}
+
+/** Chunked variant of ZRANGE ... BYSCORE (ascending), same rationale as above. */
+export async function zrangeByScoreAllChunked<T = unknown>(
+  key: string,
+  min: number | "-inf" | "+inf",
+  max: number | "-inf" | "+inf",
+): Promise<T[]> {
+  const out: T[] = [];
+  for (let offset = 0; ; offset += ZRANGE_CHUNK) {
+    const slice = (await redis.zrange(key, min, max, {
+      byScore: true,
+      offset,
+      count: ZRANGE_CHUNK,
+    })) as T[];
+    out.push(...slice);
+    if (slice.length < ZRANGE_CHUNK) return out;
+  }
+}


### PR DESCRIPTION
**Prod incident, 2026-08-05:** /api/dashboard 500s with `UpstashError: ERR max request size exceeded. Limit: 10485760 bytes, Actual: 12137619`. Every full-history reader does `ZRANGE 0 -1` on `user:{id}:scores`; entries carry base64 thumbnails, and an active user's history crossed 10MB today. Dashboard shows no scores, admin Team Detail shows zeros / missing months (it catches per-member and degrades). **No data was lost** — the reads were rejected, the zsets are intact.

Fix: sequential chunked reads (10 entries/slice) via new `zrangeAllChunked` / `zrangeByScoreAllChunked` helpers, swapped into all seven full-history call sites incl. the data-lifecycle purge path (same bomb, would have broken termination purges for large users).

Not addressed here (follow-up ticket): thumbnails don't belong inside zset entries — history payload shouldn't scale with images. Admin feedback zset reads left as-is (small entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)