### PR TITLE
chore(#414): CURRENT_PLUGIN_VERSION → 1.14.2

### DIFF
--- a/src/content/hq/features.mdx
+++ b/src/content/hq/features.mdx
@@ -2,7 +2,7 @@
 title: Feature Inventory
 updatedAt: 2026-08-05
 updatedBy: Sara
-lastPr: 440
+lastPr: 443
 ---
 
 ## How to read this page
@@ -70,7 +70,7 @@ Plugin source lives in `ai-design-assistant`. Backend endpoints (`/api/plugin/*`
 | Plugin token verification | Plugin token | Live | `src/app/api/plugin/verify-token/route.ts` |
 | Score persistence from plugin (also runs the team style-compliance pass so plugin scores show Writing Style Guide findings on the dashboard, #364; accepts the plugin-computed `designSystem` advisory payload, capped at 50 findings, #400) | Plugin token | Live | `src/app/api/plugin/persist-score/route.ts` |
 | Plugin metadata endpoint | Public | Live | `src/app/api/plugin/meta/route.ts` |
-| Plugin bundle (v1.14.1, published 2026-08-05) | All | Live | `drawbackwards/ai-design-assistant` `plugin/ui.html` (`PLUGIN_VERSION`, single source); latest-available mirrored in `src/lib/plugin-version.ts` per the two-value model (#414) |
+| Plugin bundle (v1.14.2, published 2026-08-05) | All | Live | `drawbackwards/ai-design-assistant` `plugin/ui.html` (`PLUGIN_VERSION`, single source); latest-available mirrored in `src/lib/plugin-version.ts` per the two-value model (#414) |
 | Free 5-lifetime cap inside plugin | Free | Live | Enforced server-side via shared `plans.ts` |
 | Marketplace listing demo flow | Public | Roadmap | Gates the relaunch (re-review restarted 2026-04-18 per memory) |
 | Batch scoring of a frame stack | Pro+ | Roadmap | Open question per Journeys |

--- a/src/content/hq/journeys.mdx
+++ b/src/content/hq/journeys.mdx
@@ -2,7 +2,7 @@
 title: User Journeys
 updatedAt: 2026-08-05
 updatedBy: Sara
-lastPr: 440
+lastPr: 443
 ---
 
 ## How to read this page
@@ -73,7 +73,7 @@ See [Feature Inventory → Web app](/hq/features#web-app-runladdercom) for shipp
 
 ## Figma plugin: Live (in marketplace re-review per memory)
 
-The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.14.1 (`PLUGIN_VERSION` in `plugin/ui.html`; latest-available mirrored in runladder's `src/lib/plugin-version.ts`, #414).
+The plugin source lives in `drawbackwards/ai-design-assistant`. Plugin backend endpoints live in `runladder` under `/api/plugin/*`. Current bundle version is 1.14.2 (`PLUGIN_VERSION` in `plugin/ui.html`; latest-available mirrored in runladder's `src/lib/plugin-version.ts`, #414).
 
 ### Plugin first-run (Live, with caveats)
 

--- a/src/lib/plugin-version.ts
+++ b/src/lib/plugin-version.ts
@@ -17,7 +17,7 @@
  * get a backwards "downgrade" nag). See /hq/architecture → Versioning for the
  * full plugin release sequence.
  */
-export const CURRENT_PLUGIN_VERSION = "1.14.1";
+export const CURRENT_PLUGIN_VERSION = "1.14.2";
 
 /**
  * True when `latest` is a STRICTLY newer dotted version than `installed`.


### PR DESCRIPTION
Coupling bump for the 1.14.2 marketplace publish (Design System tab refinements, ai-design-assistant#253). MERGE ONLY AFTER the publish is live. /hq bundle-version rows updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)