### PR TITLE
fix(#447): prod deploy builds server-side (Sensitive env vars)

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -50,17 +50,13 @@ jobs:
       - name: Install Vercel CLI
         run: npm i -g vercel@latest
 
-      - name: Pull Vercel production environment
-        run: vercel pull --yes --environment=production --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Build (production)
-        run: vercel build --prod --token="$VERCEL_TOKEN"
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy prebuilt to production
-        run: vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN"
+      # Deploy WITHOUT --prebuilt so Vercel builds server-side. This is
+      # deliberate: several prod env vars (Redis/KV) are marked Sensitive, so
+      # `vercel pull` returns them blank and a build running here in CI would
+      # crash at page-data collection on `Redis.fromEnv()`. Building on Vercel
+      # gives the build the real (Sensitive) env, exactly like a native git
+      # deploy. VERCEL_ORG_ID/VERCEL_PROJECT_ID (job env) target the project.
+      - name: Deploy to production
+        run: vercel deploy --prod --yes --token="$VERCEL_TOKEN"
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/src/content/hq/deployment.mdx
+++ b/src/content/hq/deployment.mdx
@@ -44,7 +44,7 @@ Production is deployed by the **`Deploy Production` GitHub Action** (`.github/wo
 - If no one approves, prod stays exactly as it is. That is the whole point.
 - Who can approve: the reviewers configured on the `production` Environment (currently Michael and Ward).
 
-The Action authenticates to Vercel with a `VERCEL_TOKEN` secret (token deploys, not git deploys) plus `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` repo variables, and runs `vercel pull → vercel build --prod → vercel deploy --prebuilt --prod`.
+The Action authenticates to Vercel with a `VERCEL_TOKEN` secret (a **team-scoped** token for the Drawbackwards team — a project-scoped token can't read the settings `vercel` needs) plus `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` repo variables, and runs a single `vercel deploy --prod`. It deploys **without** `--prebuilt` on purpose: several prod env vars (the Redis/KV credentials) are marked **Sensitive**, so a build running in CI can't read them and would crash at page-data collection on `Redis.fromEnv()`. Letting Vercel build server-side gives the build the real environment, exactly like a native git deploy.
 
 ## Ship steps after a production deploy
 


### PR DESCRIPTION
Follow-up to #449. The gated `Deploy Production` workflow failed at build time: the prod Redis/KV vars are **Sensitive**, so `vercel pull` returns them blank and a build running in CI dies at page-data collection on `Redis.fromEnv()` (`/api/admin/clients`).

Fix: deploy with a single `vercel deploy --prod` (no `--prebuilt`, no local `vercel build`) so **Vercel builds server-side** with the real environment, like a native git deploy. Doc updated to explain why.

The approval gate itself is confirmed working (it paused for review). This fixes the deploy step it runs after approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)