### PR TITLE
feat(#451): admin route to run the #442 prod thumbnail backfill

### DIFF
--- a/src/app/api/admin/backfill-thumbnails/route.ts
+++ b/src/app/api/admin/backfill-thumbnails/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { getAdminEmail } from "@/lib/admin";
+import { backfillScoreThumbnails } from "@/lib/thumbnail-backfill";
+
+/**
+ * One-time #442 follow-up (#451): migrate existing inline score thumbnails into
+ * Vercel Blob, in production, where the Sensitive Redis/Blob env exists. Runs
+ * server-side because prod creds can't be pulled to a laptop.
+ *
+ *   GET /api/admin/backfill-thumbnails                 -> DRY RUN (reports scope, writes nothing)
+ *   GET /api/admin/backfill-thumbnails?confirm=migrate -> runs the migration
+ *   &user=<id>                                         -> limit to one user (optional)
+ *
+ * Admin-gated. Idempotent + safe to re-run. Dry run is the default so an
+ * accidental visit (or a link prefetch) never mutates data.
+ */
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+export async function GET(req: Request) {
+  const admin = await getAdminEmail();
+  if (!admin) {
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+  }
+
+  const url = new URL(req.url);
+  const confirm = url.searchParams.get("confirm") === "migrate";
+  const onlyUser = url.searchParams.get("user") || undefined;
+
+  const summary = await backfillScoreThumbnails({ dryRun: !confirm, onlyUser });
+
+  return NextResponse.json({
+    ...summary,
+    admin,
+    ...(confirm
+      ? {}
+      : { note: "Dry run only. Add ?confirm=migrate to the URL to run it for real." }),
+  });
+}

--- a/src/lib/thumbnail-backfill.ts
+++ b/src/lib/thumbnail-backfill.ts
@@ -1,0 +1,138 @@
+import { redis } from "@/lib/redis";
+import { uploadScoreThumbnail } from "@/lib/thumbnail";
+import { SCORE_THUMB_KEY } from "@/lib/scores";
+
+/**
+ * One-time backfill for #442: move inline base64 thumbnails out of the
+ * per-user score-history zset (`user:{id}:scores`) into Vercel Blob, leaving
+ * only a pointer key (`user:{id}:thumb:{scoreId}`) + `hasThumbnail: true`.
+ *
+ * This is the server-side twin of `scripts/backfill-score-thumbnails.mjs`
+ * (used for dev). Prod Redis/Blob creds are marked Sensitive in Vercel and are
+ * NOT returned by `vercel env pull`, so the prod migration can't run from a
+ * laptop — it runs here, inside the prod runtime, via an admin route.
+ *
+ * Behavior: reads each user's history in small chunks (never a single
+ * ZRANGE 0 -1), and is idempotent — an entry with no inline data-URL thumbnail
+ * (already migrated, or never had one) is skipped, so it's safe to re-run.
+ */
+
+const CHUNK = 10; // matches zrangeAllChunked — safely under Upstash's 10MB ceiling
+const DATA_URL_RE = /^data:(image\/[a-z0-9.+-]+);base64,(.+)$/i;
+
+export type BackfillPerUser = {
+  userId: string;
+  total: number;
+  migrated: number;
+  skipped: number;
+};
+
+export type BackfillSummary = {
+  dryRun: boolean;
+  usersScanned: number;
+  migrated: number;
+  skipped: number;
+  perUser: BackfillPerUser[];
+};
+
+async function listHistoryKeys(onlyUser?: string): Promise<string[]> {
+  if (onlyUser) return [`user:${onlyUser}:scores`];
+  const keys: string[] = [];
+  let cursor = "0";
+  do {
+    const [next, batch] = await redis.scan(cursor, {
+      match: "user:*:scores",
+      count: 200,
+    });
+    keys.push(...(batch as string[]));
+    cursor = next;
+  } while (cursor !== "0");
+  return keys;
+}
+
+async function readAllWithScores(
+  key: string,
+): Promise<{ member: unknown; score: number }[]> {
+  const out: { member: unknown; score: number }[] = [];
+  for (let start = 0; ; start += CHUNK) {
+    const slice = (await redis.zrange(key, start, start + CHUNK - 1, {
+      withScores: true,
+    })) as (string | number)[];
+    if (!slice || slice.length === 0) break;
+    for (let i = 0; i < slice.length; i += 2) {
+      out.push({ member: slice[i], score: Number(slice[i + 1]) });
+    }
+    if (slice.length < CHUNK * 2) break;
+  }
+  return out;
+}
+
+export async function backfillScoreThumbnails(
+  opts: { dryRun?: boolean; onlyUser?: string } = {},
+): Promise<BackfillSummary> {
+  const dryRun = !!opts.dryRun;
+  const keys = await listHistoryKeys(opts.onlyUser);
+  const perUser: BackfillPerUser[] = [];
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const historyKey of keys) {
+    const userId = historyKey.slice("user:".length, -":scores".length);
+    const rows = await readAllWithScores(historyKey);
+    let m = 0;
+    let s = 0;
+
+    for (const { member, score } of rows) {
+      let entry: unknown;
+      try {
+        entry = typeof member === "string" ? JSON.parse(member) : member;
+      } catch {
+        s++;
+        continue;
+      }
+      if (!entry || typeof entry !== "object") {
+        s++;
+        continue;
+      }
+      const rec = entry as Record<string, unknown>;
+      const inline = rec.thumbnail;
+      // Idempotent: only entries still carrying an inline data-URL thumbnail.
+      if (typeof inline !== "string" || !DATA_URL_RE.test(inline)) {
+        s++;
+        continue;
+      }
+      const scoreId = typeof rec.id === "string" ? rec.id : null;
+      if (!scoreId) {
+        s++;
+        continue;
+      }
+      if (dryRun) {
+        m++;
+        continue;
+      }
+
+      const blobUrl = await uploadScoreThumbnail(userId, scoreId, inline);
+      if (!blobUrl) {
+        // Upload failed — leave the entry untouched so a re-run retries it.
+        s++;
+        continue;
+      }
+
+      const { thumbnail: _drop, ...rest } = rec;
+      void _drop;
+      const rewritten = JSON.stringify({ ...rest, hasThumbnail: true });
+      await redis.set(SCORE_THUMB_KEY(userId, scoreId), blobUrl);
+      const oldMember =
+        typeof member === "string" ? member : JSON.stringify(member);
+      await redis.zrem(historyKey, oldMember);
+      await redis.zadd(historyKey, { score, member: rewritten });
+      m++;
+    }
+
+    migrated += m;
+    skipped += s;
+    perUser.push({ userId, total: rows.length, migrated: m, skipped: s });
+  }
+
+  return { dryRun, usersScanned: keys.length, migrated, skipped, perUser };
+}

--- a/src/test/auth-gate.test.ts
+++ b/src/test/auth-gate.test.ts
@@ -87,6 +87,7 @@ vi.mock("@/lib/redis", () => ({
  */
 const PROTECTED_ROUTES = [
   // /api/admin/*
+  "src/app/api/admin/backfill-thumbnails/route.ts",
   "src/app/api/admin/clients/[orgId]/route.ts",
   "src/app/api/admin/clients/route.ts",
   "src/app/api/admin/comps/route.ts",
@@ -174,6 +175,8 @@ async function expectAllMethodsRejectAnon(importPath: string): Promise<void> {
 describe("auth gate: /api/admin/*", () => {
   beforeEach(() => vi.clearAllMocks());
 
+  it("backfill-thumbnails", () =>
+    expectAllMethodsRejectAnon("@/app/api/admin/backfill-thumbnails/route"));
   it("clients", () =>
     expectAllMethodsRejectAnon("@/app/api/admin/clients/route"));
   it("clients/[orgId]", () =>


### PR DESCRIPTION
Closes #451. Follow-up to #442.

The existing **prod** score thumbnails were never migrated — prod Redis/Blob creds are Sensitive and can't be pulled to a laptop. This adds a one-time, admin-gated route that runs the migration **inside the prod runtime**:

- `GET /api/admin/backfill-thumbnails` → **dry run** (reports scope, writes nothing)
- `GET /api/admin/backfill-thumbnails?confirm=migrate` → runs it
- `&user=<id>` → limit to one user

Idempotent + safe to re-run. Migration logic lives in `src/lib/thumbnail-backfill.ts` (server-side twin of the dev script). Admin-gated via `getAdminEmail()`; covered by the auth-gate contract test.

## After merge (through the #447 gate)
1. Approve the prod deploy.
2. Hit the route as admin: dry-run first, then `?confirm=migrate`.
3. Verify entries shrank + dashboard healthy; then we can relax the #441 chunked-read helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)