### PR TITLE
feat(#454): window the team-member detail score list

### DIFF
--- a/src/app/dashboard/team/members/[userId]/page.tsx
+++ b/src/app/dashboard/team/members/[userId]/page.tsx
@@ -6,6 +6,7 @@ import { useAuth, RedirectToSignIn } from "@clerk/nextjs";
 import Link from "next/link";
 import { getScoreColor } from "@/lib/ladder";
 import { surfaceParts } from "@/lib/surface";
+import { useInfiniteWindow } from "@/hooks/use-infinite-window";
 import { SHOW_EVALUATIONS_AND_REVIEWS } from "@/lib/feature-flags";
 import {
   ActivityHeatmap,
@@ -280,6 +281,15 @@ export default function TeamMemberDetailPage() {
       cancelled = true;
     };
   }, [isSignedIn, userId]);
+
+  // Window the active tab's list (#454, reuses #448's hook). Derived before the
+  // early returns below so the hook is always called in the same order.
+  const activeScores =
+    (tab === "design" ? data?.design?.scores : data?.evaluation?.scores) ?? [];
+  const { visibleCount, sentinelRef, hasMore } = useInfiniteWindow(
+    activeScores.length,
+    30,
+  );
 
   if (!isLoaded) return null;
   if (!isSignedIn) return <RedirectToSignIn />;
@@ -561,9 +571,11 @@ export default function TeamMemberDetailPage() {
           </div>
         ) : (
           <div className="space-y-1.5">
-            {bucket.scores.map((entry) => (
+            {bucket.scores.slice(0, visibleCount).map((entry) => (
               <ScoreRow key={entry.id} entry={entry} memberUserId={userId ?? ""} />
             ))}
+            {/* Reveal the next page as this scrolls into view (#454). */}
+            {hasMore && <div ref={sentinelRef} aria-hidden className="h-1" />}
           </div>
         )}
       </div>


### PR DESCRIPTION
Closes #454. Follow-up to #448.

Applies the #448 client-side windowing (`useInfiniteWindow`) to the team-member detail page's active tab (design/evaluation), so a Team Lead viewing a heavy designer (e.g. the 128-score account) doesn't mount every row at once. Renders `bucket.scores.slice(0, visibleCount)` with an IntersectionObserver sentinel. No API change — small thumbnails already shipped there in #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)